### PR TITLE
More async/sync unification; fix function output

### DIFF
--- a/inngest/_internal/comm.py
+++ b/inngest/_internal/comm.py
@@ -18,6 +18,7 @@ from inngest._internal import (
     registration,
     result,
     transforms,
+    types,
 )
 
 
@@ -226,7 +227,9 @@ class CommHandler:
 
     def _create_response(
         self,
-        call_res: list[execution.CallResponse] | str | execution.CallError,
+        call_res: list[execution.CallResponse]
+        | types.Serializable
+        | execution.CallError,
     ) -> CommResponse:
         comm_res = CommResponse(
             headers={
@@ -235,7 +238,7 @@ class CommHandler:
             }
         )
 
-        if isinstance(call_res, list):
+        if execution.is_call_responses(call_res):
             out: list[dict[str, object]] = []
             for item in call_res:
                 match item.to_dict():

--- a/inngest/_internal/execution.py
+++ b/inngest/_internal/execution.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import enum
+import typing
 
 from . import errors, event_lib, transforms, types
 
@@ -47,6 +48,14 @@ class CallResponse(types.BaseModel):
     name: str
     op: Opcode
     opts: dict[str, object] | None = None
+
+
+def is_call_responses(
+    value: object,
+) -> typing.TypeGuard[list[CallResponse]]:
+    if not isinstance(value, list):
+        return False
+    return all(isinstance(item, CallResponse) for item in value)
 
 
 class Opcode(enum.Enum):

--- a/inngest/_internal/step_lib/step_async.py
+++ b/inngest/_internal/step_lib/step_async.py
@@ -1,11 +1,9 @@
 import datetime
 import inspect
-import json
 import typing
 
 from inngest._internal import (
     client_lib,
-    errors,
     event_lib,
     execution,
     result,
@@ -69,10 +67,12 @@ class Step(base.StepBase):
         else:
             output = handler()
 
-        try:
-            json.dumps(output)
-        except TypeError as err:
-            raise errors.UnserializableOutput(str(err)) from None
+        # Check whether output is serializable
+        match transforms.dump_json(output):
+            case result.Ok(_):
+                pass
+            case result.Err(err):
+                raise err
 
         raise base.Interrupt(
             hashed_id=hashed_id,

--- a/inngest/_internal/step_lib/step_async.py
+++ b/inngest/_internal/step_lib/step_async.py
@@ -1,4 +1,5 @@
 import datetime
+import inspect
 import json
 import typing
 
@@ -26,13 +27,35 @@ class Step(base.StepBase):
         self._memos = memos
         self._step_id_counter = step_id_counter
 
+    @typing.overload
     async def run(
         self,
         step_id: str,
-        handler: typing.Callable[[], typing.Awaitable[types.T]],
-    ) -> types.T:
+        handler: typing.Callable[[], typing.Awaitable[types.SerializableT]],
+    ) -> types.SerializableT:
+        ...
+
+    @typing.overload
+    async def run(
+        self,
+        step_id: str,
+        handler: typing.Callable[[], types.SerializableT],
+    ) -> types.SerializableT:
+        ...
+
+    async def run(
+        self,
+        step_id: str,
+        handler: typing.Callable[[], typing.Awaitable[types.SerializableT]]
+        | typing.Callable[[], types.SerializableT],
+    ) -> types.SerializableT:
         """
         Run logic that should be retried on error and memoized after success.
+
+        Args:
+            step_id: Unique step ID within the function. If the same step ID is
+                encountered multiple times then it'll get an index suffix.
+            handler: The logic to run. Can be async or sync.
         """
 
         hashed_id = self._get_hashed_id(step_id)
@@ -41,7 +64,10 @@ class Step(base.StepBase):
         if memo is not types.EmptySentinel:
             return memo  # type: ignore
 
-        output = await handler()
+        if inspect.iscoroutinefunction(handler):
+            output = await handler()
+        else:
+            output = handler()
 
         try:
             json.dumps(output)

--- a/inngest/_internal/step_lib/step_sync.py
+++ b/inngest/_internal/step_lib/step_sync.py
@@ -33,6 +33,11 @@ class StepSync(base.StepBase):
     ) -> types.T:
         """
         Run logic that should be retried on error and memoized after success.
+
+        Args:
+            step_id: Unique step ID within the function. If the same step ID is
+                encountered multiple times then it'll get an index suffix.
+            handler: The logic to run.
         """
 
         hashed_id = self._get_hashed_id(step_id)

--- a/inngest/_internal/step_lib/step_sync.py
+++ b/inngest/_internal/step_lib/step_sync.py
@@ -1,10 +1,8 @@
 import datetime
-import json
 import typing
 
 from inngest._internal import (
     client_lib,
-    errors,
     event_lib,
     execution,
     result,
@@ -48,10 +46,12 @@ class StepSync(base.StepBase):
 
         output = handler()
 
-        try:
-            json.dumps(output)
-        except TypeError as err:
-            raise errors.UnserializableOutput(str(err)) from None
+        # Check whether output is serializable
+        match transforms.dump_json(output):
+            case result.Ok(_):
+                pass
+            case result.Err(err):
+                raise err
 
         raise base.Interrupt(
             hashed_id=hashed_id,

--- a/inngest/_internal/transforms.py
+++ b/inngest/_internal/transforms.py
@@ -1,5 +1,6 @@
 import datetime
 import hashlib
+import json
 import re
 import traceback
 
@@ -20,6 +21,13 @@ def hash_signing_key(key: str) -> str:
 
 def hash_step_id(step_id: str) -> str:
     return hashlib.sha1(step_id.encode("utf-8")).hexdigest()
+
+
+def dump_json(obj: object) -> result.Result[str, errors.UnserializableOutput]:
+    try:
+        return result.Ok(json.dumps(obj))
+    except Exception as err:
+        return result.Err(errors.UnserializableOutput(str(err)))
 
 
 def remove_signing_key_prefix(key: str) -> str:

--- a/inngest/_internal/types.py
+++ b/inngest/_internal/types.py
@@ -10,9 +10,17 @@ T = typing.TypeVar("T")
 
 EmptySentinel = object()
 
-JSONSerializableOutput = (
-    bool | float | int | str | dict | list | tuple[object, ...] | None
+Serializable = (
+    bool
+    | float
+    | int
+    | str
+    | dict[typing.Any, typing.Any]
+    | list[typing.Any]
+    | tuple[typing.Any, ...]
+    | None
 )
+SerializableT = typing.TypeVar("SerializableT", bound=Serializable)
 
 
 class BaseModel(pydantic.BaseModel):

--- a/inngest/tornado.py
+++ b/inngest/tornado.py
@@ -14,7 +14,7 @@ from inngest._internal import (
 )
 
 
-def serve_sync(
+def serve(
     app: tornado.web.Application,
     client: client_lib.Inngest,
     functions: list[function.Function],

--- a/tests/cases/unserializable_step_output.py
+++ b/tests/cases/unserializable_step_output.py
@@ -65,7 +65,7 @@ def create(
             return Foo()
 
         try:
-            await step.run("step_1", step_1)
+            await step.run("step_1", step_1)  # type: ignore
         except BaseException as err:
             state.error = err
             raise

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -29,7 +29,7 @@ class TestFlask(unittest.TestCase):
 
         app = flask.Flask(__name__)
         app.logger.disabled = True
-        inngest.flask.serve_sync(
+        inngest.flask.serve(
             app,
             _client,
             [
@@ -98,7 +98,7 @@ class TestRegistration(unittest.TestCase):
             pass
 
         app = flask.Flask(__name__)
-        inngest.flask.serve_sync(
+        inngest.flask.serve(
             app,
             client,
             [fn],


### PR DESCRIPTION
- Fix function output showing as stringified JSON
- Make `flask.serve` work for both async and sync
- Make `step.run` accepts both async and sync handlers
