### PR TITLE
Move most function args into a ctx object

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,10 @@ import requests
     trigger=inngest.TriggerEvent(event="app/person.find"),
 )
 def fetch_person(
-    *,
-    event: inngest.Event,
+    ctx: inngest.Context,
     step: inngest.StepSync,
-    **_kwargs: object,
 ) -> dict:
-    person_id = event.data["person_id"]
+    person_id = ctx.event.data["person_id"]
     res = requests.get(f"https://swapi.dev/api/people/{person_id}")
     return res.json()
 
@@ -108,16 +106,14 @@ The following example registers a function that will:
     trigger=inngest.TriggerEvent(event="app/ships.find"),
 )
 def fetch_ships(
-    *,
-    event: inngest.Event,
+    ctx: inngest.Context,
     step: inngest.StepSync,
-    **_kwargs: object,
 ) -> dict:
     """
     Find all the ships a person has.
     """
 
-    person_id = event.data["person_id"]
+    person_id = ctx.event.data["person_id"]
 
     def _fetch_person() -> dict:
         res = requests.get(f"https://swapi.dev/api/people/{person_id}")
@@ -151,12 +147,10 @@ def fetch_ships(
     trigger=inngest.TriggerEvent(event="app/person.find"),
 )
 async def fetch_person(
-    *,
-    event: inngest.Event,
+    ctx: inngest.Context,
     step: inngest.Step,
-    **_kwargs: object,
 ) -> dict:
-    person_id = event.data["person_id"]
+    person_id = ctx.event.data["person_id"]
     async with httpx.AsyncClient() as client:
         res = await client.get(f"https://swapi.dev/api/people/{person_id}")
         return res.json()

--- a/examples/functions/batch.py
+++ b/examples/functions/batch.py
@@ -12,12 +12,10 @@ import inngest
     trigger=inngest.TriggerEvent(event="app/batch"),
 )
 def fn_sync(
-    *,
-    events: list[inngest.Event],
+    ctx: inngest.Context,
     step: inngest.StepSync,
-    **_kwargs: object,
 ) -> None:
     def _print_events() -> None:
-        print(len(events))
+        print(len(ctx.events))
 
     step.run("print_events", _print_events)

--- a/examples/functions/cancel.py
+++ b/examples/functions/cancel.py
@@ -8,5 +8,8 @@ import inngest
     fn_id="cancel",
     trigger=inngest.TriggerEvent(event="app/cancel"),
 )
-def fn_sync(*, run_id: str, **_kwargs: object) -> None:
+def fn_sync(
+    ctx: inngest.Context,
+    step: inngest.StepSync,
+) -> None:
     time.sleep(5)

--- a/examples/functions/cron.py
+++ b/examples/functions/cron.py
@@ -13,7 +13,10 @@ else:
     fn_id="cron",
     trigger=trigger,
 )
-async def fn(**_kwargs: object) -> None:
+async def fn(
+    ctx: inngest.Context,
+    step: inngest.Step,
+) -> None:
     pass
 
 
@@ -21,5 +24,8 @@ async def fn(**_kwargs: object) -> None:
     fn_id="cron_sync",
     trigger=trigger,
 )
-def fn_sync(**_kwargs: object) -> None:
+def fn_sync(
+    ctx: inngest.Context,
+    step: inngest.StepSync,
+) -> None:
     pass

--- a/examples/functions/debounce.py
+++ b/examples/functions/debounce.py
@@ -8,5 +8,8 @@ import inngest
     fn_id="debounce",
     trigger=inngest.TriggerEvent(event="app/debounce"),
 )
-def fn_sync(*, run_id: str, **_kwargs: object) -> None:
-    print(run_id)
+def fn_sync(
+    ctx: inngest.Context,
+    step: inngest.StepSync,
+) -> None:
+    print(ctx.run_id)

--- a/examples/functions/duplicate_step_name.py
+++ b/examples/functions/duplicate_step_name.py
@@ -5,7 +5,10 @@ import inngest
     fn_id="duplicate_step_name_sync",
     trigger=inngest.TriggerEvent(event="app/duplicate_step_name_sync"),
 )
-def fn_sync(*, step: inngest.StepSync, **_kwargs: object) -> str:
+def fn_sync(
+    ctx: inngest.Context,
+    step: inngest.StepSync,
+) -> str:
     for _ in range(3):
         step.run("foo", lambda: None)
 

--- a/examples/functions/error_step.py
+++ b/examples/functions/error_step.py
@@ -10,7 +10,10 @@ class MyError(Exception):
     retries=0,
     trigger=inngest.TriggerEvent(event="app/error_step"),
 )
-def fn_sync(*, step: inngest.StepSync, **_kwargs: object) -> None:
+def fn_sync(
+    ctx: inngest.Context,
+    step: inngest.StepSync,
+) -> None:
     step.run("first_step", lambda: None)
 
     def _second_step() -> None:

--- a/examples/functions/no_steps.py
+++ b/examples/functions/no_steps.py
@@ -5,5 +5,8 @@ import inngest
     fn_id="no_steps",
     trigger=inngest.TriggerEvent(event="app/no_steps"),
 )
-def fn_sync(**_kwargs: object) -> int:
+def fn_sync(
+    ctx: inngest.Context,
+    step: inngest.StepSync,
+) -> int:
     return 1

--- a/examples/functions/on_failure.py
+++ b/examples/functions/on_failure.py
@@ -2,7 +2,8 @@ import inngest
 
 
 def _on_failure(
-    **_kwargs: object,
+    ctx: inngest.Context,
+    step: inngest.StepSync,
 ) -> None:
     print("on_failure called")
 
@@ -13,5 +14,8 @@ def _on_failure(
     retries=0,
     trigger=inngest.TriggerEvent(event="app/on_failure"),
 )
-def fn_sync(*, run_id: str, **_kwargs: object) -> None:
+def fn_sync(
+    ctx: inngest.Context,
+    step: inngest.StepSync,
+) -> None:
     raise Exception("intentional error")

--- a/examples/functions/parallel_steps.py
+++ b/examples/functions/parallel_steps.py
@@ -8,7 +8,10 @@ import inngest
     fn_id="parallel_steps",
     trigger=inngest.TriggerEvent(event="app/parallel_steps"),
 )
-async def fn(*, step: inngest.Step, **_kwargs: object) -> tuple[int, ...]:
+async def fn(
+    ctx: inngest.Context,
+    step: inngest.Step,
+) -> tuple[int, ...]:
     async def _step_1a() -> int:
         await asyncio.sleep(2)
         return 1
@@ -29,7 +32,10 @@ async def fn(*, step: inngest.Step, **_kwargs: object) -> tuple[int, ...]:
     fn_id="parallel_steps",
     trigger=inngest.TriggerEvent(event="app/parallel_steps"),
 )
-def fn_sync(*, step: inngest.StepSync, **_kwargs: object) -> tuple[int, ...]:
+def fn_sync(
+    ctx: inngest.Context,
+    step: inngest.StepSync,
+) -> tuple[int, ...]:
     def _step_1a() -> int:
         time.sleep(2)
         return 1

--- a/examples/functions/print_event.py
+++ b/examples/functions/print_event.py
@@ -6,17 +6,18 @@ import inngest
     trigger=inngest.TriggerEvent(event="app/print_event"),
 )
 async def fn(
-    *, event: inngest.Event, step: inngest.Step, **_kwargs: object
+    ctx: inngest.Context,
+    step: inngest.Step,
 ) -> None:
     async def _print_data() -> dict[str, object]:
-        print(event.data)
-        return event.data
+        print(ctx.event.data)
+        return ctx.event.data
 
     await step.run("print_data", _print_data)
 
     async def _print_user() -> dict[str, object]:
-        print(event.user)
-        return event.user
+        print(ctx.event.user)
+        return ctx.event.user
 
     await step.run("print_user", _print_user)
 
@@ -26,16 +27,17 @@ async def fn(
     trigger=inngest.TriggerEvent(event="app/print_event_sync"),
 )
 def fn_sync(
-    *, event: inngest.Event, step: inngest.StepSync, **_kwargs: object
+    ctx: inngest.Context,
+    step: inngest.StepSync,
 ) -> None:
     def _print_data() -> dict[str, object]:
-        print(event.data)
-        return event.data
+        print(ctx.event.data)
+        return ctx.event.data
 
     step.run("print_data", _print_data)
 
     def _print_user() -> dict[str, object]:
-        print(event.user)
-        return event.user
+        print(ctx.event.user)
+        return ctx.event.user
 
     step.run("print_user", _print_user)

--- a/examples/functions/send_event.py
+++ b/examples/functions/send_event.py
@@ -5,7 +5,10 @@ import inngest
     fn_id="send_event",
     trigger=inngest.TriggerEvent(event="app/send_event"),
 )
-def fn_sync(*, step: inngest.StepSync, **_kwargs: object) -> None:
+def fn_sync(
+    ctx: inngest.Context,
+    step: inngest.StepSync,
+) -> None:
     step.run("first", lambda: None)
     step.send_event("send", inngest.Event(name="foo"))
     step.run("second", lambda: None)

--- a/examples/functions/two_steps_and_sleep.py
+++ b/examples/functions/two_steps_and_sleep.py
@@ -7,7 +7,10 @@ import inngest
     fn_id="two_steps_and_sleep",
     trigger=inngest.TriggerEvent(event="app/two_steps_and_sleep"),
 )
-async def fn(*, step: inngest.Step, **_kwargs: object) -> str:
+async def fn(
+    ctx: inngest.Context,
+    step: inngest.Step,
+) -> str:
     user_id = await step.run("get_user_id", lambda: 1)
     await step.run("print_user_id", lambda: f"user ID is {user_id}")
 
@@ -23,7 +26,10 @@ async def fn(*, step: inngest.Step, **_kwargs: object) -> str:
     fn_id="two_steps_and_sleep_sync",
     trigger=inngest.TriggerEvent(event="app/two_steps_and_sleep_sync"),
 )
-def fn_sync(*, step: inngest.StepSync, **_kwargs: object) -> str:
+def fn_sync(
+    ctx: inngest.Context,
+    step: inngest.StepSync,
+) -> str:
     user_id = step.run("get_user_id", lambda: 1)
     step.run("print_user_id", lambda: f"user ID is {user_id}")
 

--- a/examples/functions/wait_for_event.py
+++ b/examples/functions/wait_for_event.py
@@ -7,7 +7,10 @@ import inngest
     fn_id="wait_for_event",
     trigger=inngest.TriggerEvent(event="app/wait_for_event"),
 )
-def fn_sync(*, step: inngest.StepSync, **_kwargs: object) -> None:
+def fn_sync(
+    ctx: inngest.Context,
+    step: inngest.StepSync,
+) -> None:
     res = step.wait_for_event(
         "wait",
         event="app/wait_for_event.fulfill",

--- a/inngest/__init__.py
+++ b/inngest/__init__.py
@@ -4,7 +4,7 @@
 from ._internal.client_lib import Inngest
 from ._internal.errors import NonRetriableError
 from ._internal.event_lib import Event
-from ._internal.function import Function, create_function
+from ._internal.function import Context, Function, create_function
 from ._internal.function_config import (
     Batch,
     Cancel,
@@ -20,6 +20,7 @@ from ._internal.types import Logger, Serializable
 __all__ = [
     "Batch",
     "Cancel",
+    "Context",
     "Debounce",
     "Event",
     "Function",

--- a/inngest/_internal/comm_test.py
+++ b/inngest/_internal/comm_test.py
@@ -42,7 +42,10 @@ class Test_get_function_configs(unittest.TestCase):
             ),
             trigger=inngest.TriggerEvent(event="app/fn"),
         )
-        def fn(**_kwargs: object) -> int:
+        def fn(
+            ctx: inngest.Context,
+            step: inngest.StepSync,
+        ) -> int:
             return 1
 
         handler = comm.CommHandler(

--- a/inngest/_internal/function.py
+++ b/inngest/_internal/function.py
@@ -21,6 +21,15 @@ from inngest._internal import (
 
 
 @dataclasses.dataclass
+class Context:
+    attempt: int
+    event: event_lib.Event
+    events: list[event_lib.Event]
+    logger: types.Logger
+    run_id: str
+
+
+@dataclasses.dataclass
 class _Config:
     # The user-defined function
     main: function_config.FunctionConfig
@@ -33,12 +42,7 @@ class _Config:
 class _FunctionHandlerAsync(typing.Protocol):
     def __call__(
         self,
-        *,
-        attempt: int,
-        event: event_lib.Event,
-        events: list[event_lib.Event],
-        logger: types.Logger,
-        run_id: str,
+        ctx: Context,
         step: step_lib.Step,
     ) -> typing.Awaitable[types.Serializable]:
         ...
@@ -48,12 +52,7 @@ class _FunctionHandlerAsync(typing.Protocol):
 class _FunctionHandlerSync(typing.Protocol):
     def __call__(
         self,
-        *,
-        attempt: int,
-        event: event_lib.Event,
-        events: list[event_lib.Event],
-        logger: types.Logger,
-        run_id: str,
+        ctx: Context,
         step: step_lib.StepSync,
     ) -> types.Serializable:
         ...
@@ -253,11 +252,13 @@ class Function:
             # # handler is sync.
             if _is_function_handler_async(handler):
                 output = await handler(
-                    attempt=call.ctx.attempt,
-                    event=call.event,
-                    events=call.events,
-                    logger=call_input.logger,
-                    run_id=call.ctx.run_id,
+                    ctx=Context(
+                        attempt=call.ctx.attempt,
+                        event=call.event,
+                        events=call.events,
+                        logger=call_input.logger,
+                        run_id=call.ctx.run_id,
+                    ),
                     step=step_lib.Step(
                         client,
                         memos,
@@ -268,11 +269,13 @@ class Function:
                 )
             elif _is_function_handler_sync(handler):
                 output = handler(
-                    attempt=call.ctx.attempt,
-                    event=call.event,
-                    events=call.events,
-                    logger=call_input.logger,
-                    run_id=call.ctx.run_id,
+                    ctx=Context(
+                        attempt=call.ctx.attempt,
+                        event=call.event,
+                        events=call.events,
+                        logger=call_input.logger,
+                        run_id=call.ctx.run_id,
+                    ),
                     step=step_lib.StepSync(
                         client,
                         memos,
@@ -361,11 +364,13 @@ class Function:
 
             if _is_function_handler_sync(handler):
                 output: object = handler(
-                    attempt=call.ctx.attempt,
-                    event=call.event,
-                    events=call.events,
-                    logger=call_input.logger,
-                    run_id=call.ctx.run_id,
+                    ctx=Context(
+                        attempt=call.ctx.attempt,
+                        event=call.event,
+                        events=call.events,
+                        logger=call_input.logger,
+                        run_id=call.ctx.run_id,
+                    ),
                     step=step_lib.StepSync(
                         client,
                         memos,

--- a/tests/cases/cancel.py
+++ b/tests/cases/cancel.py
@@ -33,9 +33,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     def fn_sync(
-        *, run_id: str, step: inngest.StepSync, **_kwargs: object
+        ctx: inngest.Context,
+        step: inngest.StepSync,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         # Wait a little bit to allow the cancel event to be sent.
         time.sleep(3)
@@ -57,9 +58,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     async def fn_async(
-        *, run_id: str, step: inngest.Step, **_kwargs: object
+        ctx: inngest.Context,
+        step: inngest.Step,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         # Wait a little bit to allow the cancel event to be sent.
         await asyncio.sleep(3)

--- a/tests/cases/client_middleware.py
+++ b/tests/cases/client_middleware.py
@@ -91,13 +91,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     def fn_sync(
-        *,
-        logger: inngest.Logger,
+        ctx: inngest.Context,
         step: inngest.StepSync,
-        run_id: str,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         def _step_1() -> str:
             return "original output"
@@ -115,13 +112,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     async def fn_async(
-        *,
-        logger: inngest.Logger,
+        ctx: inngest.Context,
         step: inngest.Step,
-        run_id: str,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         async def _step_1() -> str:
             return "original output"

--- a/tests/cases/client_send.py
+++ b/tests/cases/client_send.py
@@ -21,16 +21,22 @@ def create(
         retries=0,
         trigger=inngest.TriggerEvent(event=event_name),
     )
-    def fn_sync(*, run_id: str, **_kwargs: object) -> None:
-        state.run_id = run_id
+    def fn_sync(
+        ctx: inngest.Context,
+        step: inngest.StepSync,
+    ) -> None:
+        state.run_id = ctx.run_id
 
     @inngest.create_function(
         fn_id=test_name,
         retries=0,
         trigger=inngest.TriggerEvent(event=event_name),
     )
-    async def fn_async(*, run_id: str, **_kwargs: object) -> None:
-        state.run_id = run_id
+    async def fn_async(
+        ctx: inngest.Context,
+        step: inngest.Step,
+    ) -> None:
+        state.run_id = ctx.run_id
 
     def run_test(self: base.TestClass) -> None:
         asyncio.run(self.client.send(inngest.Event(name=event_name)))

--- a/tests/cases/debounce.py
+++ b/tests/cases/debounce.py
@@ -29,10 +29,11 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     def fn_sync(
-        *, run_id: str, step: inngest.StepSync, **_kwargs: object
+        ctx: inngest.Context,
+        step: inngest.StepSync,
     ) -> None:
         state.run_count += 1
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
     @inngest.create_function(
         debounce=inngest.Debounce(
@@ -43,10 +44,11 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     async def fn_async(
-        *, run_id: str, step: inngest.Step, **_kwargs: object
+        ctx: inngest.Context,
+        step: inngest.Step,
     ) -> None:
         state.run_count += 1
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
     def run_test(self: base.TestClass) -> None:
         self.client.send_sync(

--- a/tests/cases/event_payload.py
+++ b/tests/cases/event_payload.py
@@ -24,10 +24,11 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     def fn_sync(
-        *, event: inngest.Event, run_id: str, **_kwargs: object
+        ctx: inngest.Context,
+        step: inngest.StepSync,
     ) -> None:
-        state.event = event
-        state.run_id = run_id
+        state.event = ctx.event
+        state.run_id = ctx.run_id
 
     @inngest.create_function(
         fn_id=test_name,
@@ -35,10 +36,11 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     async def fn_async(
-        *, event: inngest.Event, run_id: str, **_kwargs: object
+        ctx: inngest.Context,
+        step: inngest.Step,
     ) -> None:
-        state.event = event
-        state.run_id = run_id
+        state.event = ctx.event
+        state.run_id = ctx.run_id
 
     def run_test(self: base.TestClass) -> None:
         self.client.send_sync(

--- a/tests/cases/function_args.py
+++ b/tests/cases/function_args.py
@@ -27,18 +27,13 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     def fn_sync(
-        *,
-        attempt: int,
-        event: inngest.Event,
-        events: list[inngest.Event],
-        logger: inngest.Logger,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.StepSync,
     ) -> None:
-        state.attempt = attempt
-        state.event = event
-        state.events = events
-        state.run_id = run_id
+        state.attempt = ctx.attempt
+        state.event = ctx.event
+        state.events = ctx.events
+        state.run_id = ctx.run_id
         state.step = step
 
     @inngest.create_function(
@@ -47,18 +42,13 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     async def fn_async(
-        *,
-        attempt: int,
-        event: inngest.Event,
-        events: list[inngest.Event],
-        logger: inngest.Logger,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.Step,
     ) -> None:
-        state.attempt = attempt
-        state.event = event
-        state.events = events
-        state.run_id = run_id
+        state.attempt = ctx.attempt
+        state.event = ctx.event
+        state.events = ctx.events
+        state.run_id = ctx.run_id
         state.step = step
 
     def run_test(self: base.TestClass) -> None:

--- a/tests/cases/function_middleware.py
+++ b/tests/cases/function_middleware.py
@@ -85,13 +85,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     def fn_sync(
-        *,
-        logger: inngest.Logger,
+        ctx: inngest.Context,
         step: inngest.StepSync,
-        run_id: str,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         def _step_1() -> str:
             return "original output"
@@ -110,13 +107,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     async def fn_async(
-        *,
-        logger: inngest.Logger,
+        ctx: inngest.Context,
         step: inngest.Step,
-        run_id: str,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         async def _step_1() -> str:
             return "original output"

--- a/tests/cases/inconsistent_step_order.py
+++ b/tests/cases/inconsistent_step_order.py
@@ -34,12 +34,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     def fn_sync(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.StepSync,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
         state.request_counter += 1
 
         def step_1() -> int:
@@ -67,12 +65,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     async def fn_async(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.Step,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
         state.request_counter += 1
 
         async def step_1() -> int:

--- a/tests/cases/logger.py
+++ b/tests/cases/logger.py
@@ -37,27 +37,24 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     def fn_sync(
-        *,
-        logger: inngest.Logger,
+        ctx: inngest.Context,
         step: inngest.StepSync,
-        run_id: str,
-        **_kwargs: object,
     ) -> None:
-        logger.info("function start")
-        state.run_id = run_id
+        ctx.logger.info("function start")
+        state.run_id = ctx.run_id
 
         def _first_step() -> None:
-            logger.info("first_step")
+            ctx.logger.info("first_step")
 
         step.run("first_step", _first_step)
 
-        logger.info("between steps")
+        ctx.logger.info("between steps")
 
         def _second_step() -> None:
-            logger.info("second_step")
+            ctx.logger.info("second_step")
 
         step.run("second_step", _second_step)
-        logger.info("function end")
+        ctx.logger.info("function end")
 
     @inngest.create_function(
         fn_id=test_name,
@@ -65,27 +62,24 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     async def fn_async(
-        *,
-        logger: inngest.Logger,
+        ctx: inngest.Context,
         step: inngest.Step,
-        run_id: str,
-        **_kwargs: object,
     ) -> None:
-        logger.info("function start")
-        state.run_id = run_id
+        ctx.logger.info("function start")
+        state.run_id = ctx.run_id
 
         def _first_step() -> None:
-            logger.info("first_step")
+            ctx.logger.info("first_step")
 
         await step.run("first_step", _first_step)
 
-        logger.info("between steps")
+        ctx.logger.info("between steps")
 
         def _second_step() -> None:
-            logger.info("second_step")
+            ctx.logger.info("second_step")
 
         await step.run("second_step", _second_step)
-        logger.info("function end")
+        ctx.logger.info("function end")
 
     def run_test(self: base.TestClass) -> None:
         self.client.set_logger(_logger)

--- a/tests/cases/no_steps.py
+++ b/tests/cases/no_steps.py
@@ -21,8 +21,11 @@ def create(
         retries=0,
         trigger=inngest.TriggerEvent(event=event_name),
     )
-    def fn_sync(*, run_id: str, **_kwargs: object) -> dict[str, object]:
-        state.run_id = run_id
+    def fn_sync(
+        ctx: inngest.Context,
+        step: inngest.StepSync,
+    ) -> dict[str, object]:
+        state.run_id = ctx.run_id
         return {"foo": {"bar": 1}}
 
     @inngest.create_function(
@@ -30,8 +33,11 @@ def create(
         retries=0,
         trigger=inngest.TriggerEvent(event=event_name),
     )
-    async def fn_async(*, run_id: str, **_kwargs: object) -> dict[str, object]:
-        state.run_id = run_id
+    async def fn_async(
+        ctx: inngest.Context,
+        step: inngest.Step,
+    ) -> dict[str, object]:
+        state.run_id = ctx.run_id
         return {"foo": {"bar": 1}}
 
     def run_test(self: base.TestClass) -> None:

--- a/tests/cases/on_failure.py
+++ b/tests/cases/on_failure.py
@@ -38,33 +38,23 @@ def create(
     state = _State()
 
     def on_failure_sync(
-        *,
-        attempt: int,
-        event: inngest.Event,
-        events: list[inngest.Event],
-        logger: inngest.Logger,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.StepSync,
     ) -> None:
-        state.attempt = attempt
-        state.event = event
-        state.events = events
-        state.on_failure_run_id = run_id
+        state.attempt = ctx.attempt
+        state.event = ctx.event
+        state.events = ctx.events
+        state.on_failure_run_id = ctx.run_id
         state.step = step
 
     async def on_failure_async(
-        *,
-        attempt: int,
-        event: inngest.Event,
-        events: list[inngest.Event],
-        logger: inngest.Logger,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.Step,
     ) -> None:
-        state.attempt = attempt
-        state.event = event
-        state.events = events
-        state.on_failure_run_id = run_id
+        state.attempt = ctx.attempt
+        state.event = ctx.event
+        state.events = ctx.events
+        state.on_failure_run_id = ctx.run_id
         state.step = step
 
     @inngest.create_function(
@@ -74,12 +64,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     def fn_sync(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.StepSync,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
         raise MyError("intentional failure")
 
     @inngest.create_function(
@@ -89,12 +77,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     async def fn_async(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.Step,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
         raise MyError("intentional failure")
 
     def run_test(self: base.TestClass) -> None:

--- a/tests/cases/parallel_steps.py
+++ b/tests/cases/parallel_steps.py
@@ -29,12 +29,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     def fn_sync(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.StepSync,
-        **_kwargs: object,
     ) -> tuple[inngest.Serializable, ...]:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
         state.request_counter += 1
 
         def _step_1a() -> int:
@@ -61,12 +59,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     async def fn_async(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.Step,
-        **_kwargs: object,
     ) -> tuple[int | list[str] | None, ...]:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
         state.request_counter += 1
 
         def _step_1a() -> int:

--- a/tests/cases/sleep.py
+++ b/tests/cases/sleep.py
@@ -30,12 +30,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     def fn_sync(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.StepSync,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         if state.before_sleep is None:
             state.before_sleep = datetime.datetime.now()
@@ -51,12 +49,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     async def fn_async(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.Step,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         if state.before_sleep is None:
             state.before_sleep = datetime.datetime.now()

--- a/tests/cases/sleep_until.py
+++ b/tests/cases/sleep_until.py
@@ -30,12 +30,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     def fn_sync(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.StepSync,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         if state.before_sleep is None:
             state.before_sleep = datetime.datetime.now()
@@ -53,12 +51,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     async def fn_async(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.Step,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         if state.before_sleep is None:
             state.before_sleep = datetime.datetime.now()

--- a/tests/cases/two_steps.py
+++ b/tests/cases/two_steps.py
@@ -27,12 +27,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     def fn_sync(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.StepSync,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         def step_1() -> list[dict[str, object]]:
             state.step_1_counter += 1
@@ -51,12 +49,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     async def fn_async(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.Step,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         async def step_1() -> list[dict[str, object]]:
             state.step_1_counter += 1

--- a/tests/cases/unserializable_step_output.py
+++ b/tests/cases/unserializable_step_output.py
@@ -26,12 +26,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     def fn_sync(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.StepSync,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         class Foo:
             pass
@@ -54,12 +52,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     async def fn_async(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.Step,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         class Foo:
             pass

--- a/tests/cases/wait_for_event_fulfill.py
+++ b/tests/cases/wait_for_event_fulfill.py
@@ -27,12 +27,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     def fn_sync(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.StepSync,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         state.result = step.wait_for_event(
             "wait",
@@ -46,12 +44,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     async def fn_async(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.Step,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         state.result = await step.wait_for_event(
             "wait",

--- a/tests/cases/wait_for_event_timeout.py
+++ b/tests/cases/wait_for_event_timeout.py
@@ -26,12 +26,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     def fn_sync(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.StepSync,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         state.result = step.wait_for_event(
             "wait",
@@ -45,12 +43,10 @@ def create(
         trigger=inngest.TriggerEvent(event=event_name),
     )
     async def fn_async(
-        *,
-        run_id: str,
+        ctx: inngest.Context,
         step: inngest.Step,
-        **_kwargs: object,
     ) -> None:
-        state.run_id = run_id
+        state.run_id = ctx.run_id
 
         state.result = await step.wait_for_event(
             "wait",

--- a/tests/test_fast_api.py
+++ b/tests/test_fast_api.py
@@ -97,7 +97,10 @@ class TestRegistration(unittest.TestCase):
             retries=0,
             trigger=inngest.TriggerEvent(event="app/foo"),
         )
-        async def fn(**_kwargs: object) -> None:
+        async def fn(
+            ctx: inngest.Context,
+            step: inngest.Step,
+        ) -> None:
             pass
 
         app = fastapi.FastAPI()

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -83,7 +83,10 @@ class TestRegistration(unittest.TestCase):
             retries=0,
             trigger=inngest.TriggerEvent(event="app/foo"),
         )
-        def fn(**_kwargs: object) -> None:
+        def fn(
+            ctx: inngest.Context,
+            step: inngest.StepSync,
+        ) -> None:
             pass
 
         app = flask.Flask(__name__)

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -95,7 +95,10 @@ class TestTornadoRegistration(tornado.testing.AsyncHTTPTestCase):
             retries=0,
             trigger=inngest.TriggerEvent(event="app/foo"),
         )
-        def fn(**_kwargs: object) -> None:
+        def fn(
+            ctx: inngest.Context,
+            step: inngest.StepSync,
+        ) -> None:
             pass
 
         inngest.tornado.serve(


### PR DESCRIPTION
Move all functions args except `step` into a `ctx` object. This is a breaking change but will minimize breaking changes in the future.

Before:
```py
@inngest.create_function(
    fn_id="my-function",
    trigger=inngest.TriggerEvent(event="my-event"),
)
def fn(
    *,
    attempt: int,
    event: inngest.Event,
    events: list[inngest.Event],
    logger: inngest.Logger,
    run_id: str,
    step: inngest.StepSync,
) -> None:
    #  ...
```

After:
```py
@inngest.create_function(
    fn_id="my-function",
    trigger=inngest.TriggerEvent(event="my-event"),
)
def fn(
    ctx: inngest.Context,
    step: inngest.StepSync,
) -> None:
    #  ...
```