### PR TITLE
Fix Django CSRF; update Django example

### DIFF
--- a/examples/django/.gitignore
+++ b/examples/django/.gitignore
@@ -1,0 +1,1 @@
+db.sqlite3

--- a/examples/django/Makefile
+++ b/examples/django/Makefile
@@ -9,6 +9,3 @@ dev: check-venv
 
 install: check-venv
 	@pip install .
-
-prod: check-venv
-	./scripts/start.sh

--- a/examples/django/inngest_django/asgi.py
+++ b/examples/django/inngest_django/asgi.py
@@ -1,16 +1,7 @@
-"""
-ASGI config for inngest_django project.
-
-It exposes the ASGI callable as a module-level variable named ``application``.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/5.0/howto/deployment/asgi/
-"""
-
 import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'inngest_django.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "inngest_django.settings")
 
 application = get_asgi_application()

--- a/examples/django/inngest_django/asgi.py
+++ b/examples/django/inngest_django/asgi.py
@@ -1,0 +1,16 @@
+"""
+ASGI config for inngest_django project.
+
+It exposes the ASGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/5.0/howto/deployment/asgi/
+"""
+
+import os
+
+from django.core.asgi import get_asgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'inngest_django.settings')
+
+application = get_asgi_application()

--- a/examples/django/inngest_django/inngest_client.py
+++ b/examples/django/inngest_django/inngest_client.py
@@ -1,0 +1,5 @@
+import inngest
+
+inngest_client = inngest.Inngest(
+    app_id="django_example",
+)

--- a/examples/django/inngest_django/settings.py
+++ b/examples/django/inngest_django/settings.py
@@ -1,0 +1,113 @@
+from pathlib import Path
+
+# Build paths inside the project like this: BASE_DIR / 'subdir'.
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = (
+    "django-insecure-=9hnl210(_zi@p57)3bzh6@1)0!19_hd1!=yiozndj*()sff+k"  # noqa: S105
+)
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+ALLOWED_HOSTS = []
+
+
+# Application definition
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+ROOT_URLCONF = "inngest_django.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = "inngest_django.wsgi.application"
+
+
+# Database
+# https://docs.djangoproject.com/en/5.0/ref/settings/#databases
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}
+
+
+# Password validation
+# https://docs.djangoproject.com/en/5.0/ref/settings/#auth-password-validators
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
+    },
+]
+
+
+# Internationalization
+# https://docs.djangoproject.com/en/5.0/topics/i18n/
+
+LANGUAGE_CODE = "en-us"
+
+TIME_ZONE = "UTC"
+
+USE_I18N = True
+
+USE_TZ = True
+
+
+# Static files (CSS, JavaScript, Images)
+# https://docs.djangoproject.com/en/5.0/howto/static-files/
+
+STATIC_URL = "static/"
+
+# Default primary key field type
+# https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
+
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/examples/django/inngest_django/urls.py
+++ b/examples/django/inngest_django/urls.py
@@ -1,0 +1,15 @@
+from django.contrib import admin
+from django.urls import path
+
+import inngest.django
+from examples import functions
+
+from .inngest_client import inngest_client
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    inngest.django.serve(
+        inngest_client,
+        functions.functions_sync,
+    ),
+]

--- a/examples/django/inngest_django/wsgi.py
+++ b/examples/django/inngest_django/wsgi.py
@@ -1,16 +1,7 @@
-"""
-WSGI config for inngest_django project.
-
-It exposes the WSGI callable as a module-level variable named ``application``.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/5.0/howto/deployment/wsgi/
-"""
-
 import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'inngest_django.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "inngest_django.settings")
 
 application = get_wsgi_application()

--- a/examples/django/inngest_django/wsgi.py
+++ b/examples/django/inngest_django/wsgi.py
@@ -1,0 +1,16 @@
+"""
+WSGI config for inngest_django project.
+
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/5.0/howto/deployment/wsgi/
+"""
+
+import os
+
+from django.core.wsgi import get_wsgi_application
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'inngest_django.settings')
+
+application = get_wsgi_application()

--- a/examples/django/manage.py
+++ b/examples/django/manage.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+import os
+import sys
+
+
+def main():
+    """Run administrative tasks."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "inngest_django.settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/django/scripts/start.sh
+++ b/examples/django/scripts/start.sh
@@ -8,4 +8,4 @@ if [ -n "${ENV_VARS}" ]; then
     export $(echo ${ENV_VARS} | xargs)
 fi
 
-python ./app.py runserver
+python manage.py runserver

--- a/inngest/django.py
+++ b/inngest/django.py
@@ -8,6 +8,7 @@ import json
 import django
 import django.http
 import django.urls
+import django.views.decorators.csrf
 
 from ._internal import (
     client_lib,
@@ -152,7 +153,10 @@ def _create_handler_sync(
             status=http.HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
-    return django.urls.path("api/inngest", inngest_api)
+    return django.urls.path(
+        "api/inngest",
+        django.views.decorators.csrf.csrf_exempt(inngest_api),
+    )
 
 
 def _create_handler_async(
@@ -234,7 +238,10 @@ def _create_handler_async(
             status=http.HTTPStatus.METHOD_NOT_ALLOWED,
         )
 
-    return django.urls.path("api/inngest", inngest_api)
+    return django.urls.path(
+        "api/inngest",
+        django.views.decorators.csrf.csrf_exempt(inngest_api),
+    )
 
 
 def _to_response(


### PR DESCRIPTION
- Fix `403`s during registration due to CSRF on the `/api/inngest` Django view.
- Update Django example to be more Django-ful.