### PR TITLE
Fix successful sync not responding with 200

### DIFF
--- a/inngest/_internal/comm.py
+++ b/inngest/_internal/comm.py
@@ -378,7 +378,7 @@ class CommHandler:
             return CommResponse(
                 body=server_res_body,
                 headers=net.create_headers(self._framework, server_kind),
-                status_code=server_res.status_code,
+                status_code=http.HTTPStatus.OK,
             )
 
         msg = server_res_body.get("error")

--- a/inngest/_internal/const.py
+++ b/inngest/_internal/const.py
@@ -6,7 +6,7 @@ DEFAULT_EVENT_ORIGIN: typing.Final = "https://inn.gs/"
 DEV_SERVER_ORIGIN: typing.Final = "http://127.0.0.1:8288/"
 LANGUAGE: typing.Final = "py"
 ROOT_STEP_ID: typing.Final = "step"
-VERSION: typing.Final = "0.3.0"
+VERSION: typing.Final = "0.3.1"
 
 
 class EnvKey(enum.Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python SDK for Inngest"
 readme = "README.md"
 classifiers = [


### PR DESCRIPTION
Parroting the Inngest server's sync response status code breaks the Inngest Cloud UI. Instead, respond with `200` when successful