### PR TITLE
Fix not sending sync ID query param

### DIFF
--- a/inngest/_internal/comm.py
+++ b/inngest/_internal/comm.py
@@ -173,8 +173,10 @@ class CommHandler:
 
     def _build_registration_request(
         self,
+        *,
         app_url: str,
         server_kind: const.ServerKind | None,
+        sync_id: str | None,
     ) -> types.MaybeError[httpx.Request]:
         registration_url = urllib.parse.urljoin(
             self._api_origin,
@@ -208,6 +210,9 @@ class CommHandler:
             registration_url,
             headers=headers,
             json=transforms.prep_body(body),
+            params={
+                const.QueryParamKey.SYNC_ID.value: sync_id,
+            },
             timeout=30,
         )
 
@@ -396,6 +401,7 @@ class CommHandler:
         *,
         app_url: str,
         server_kind: const.ServerKind | None,
+        sync_id: str | None = None,
     ) -> CommResponse:
         """Handle a registration call."""
         err = self._validate_registration(server_kind)
@@ -403,7 +409,11 @@ class CommHandler:
             return CommResponse.from_error(self._client.logger, err)
 
         async with httpx.AsyncClient() as client:
-            req = self._build_registration_request(app_url, server_kind)
+            req = self._build_registration_request(
+                app_url=app_url,
+                server_kind=server_kind,
+                sync_id=sync_id,
+            )
             if isinstance(req, Exception):
                 return CommResponse.from_error(self._client.logger, req)
 
@@ -417,6 +427,7 @@ class CommHandler:
         *,
         app_url: str,
         server_kind: const.ServerKind | None,
+        sync_id: str | None,
     ) -> CommResponse:
         """Handle a registration call."""
         err = self._validate_registration(server_kind)
@@ -424,7 +435,11 @@ class CommHandler:
             return CommResponse.from_error(self._client.logger, err)
 
         with httpx.Client() as client:
-            req = self._build_registration_request(app_url, server_kind)
+            req = self._build_registration_request(
+                app_url=app_url,
+                server_kind=server_kind,
+                sync_id=sync_id,
+            )
             if isinstance(req, Exception):
                 return CommResponse.from_error(self._client.logger, req)
 

--- a/inngest/_internal/const.py
+++ b/inngest/_internal/const.py
@@ -58,6 +58,7 @@ class HeaderKey(enum.Enum):
 class QueryParamKey(enum.Enum):
     FUNCTION_ID = "fnId"
     STEP_ID = "stepId"
+    SYNC_ID = "deployId"
 
 
 class InternalEvents(enum.Enum):

--- a/inngest/django.py
+++ b/inngest/django.py
@@ -131,6 +131,8 @@ def _create_handler_sync(
             )
 
         if request.method == "PUT":
+            sync_id = request.GET.get(const.QueryParamKey.SYNC_ID.value)
+
             return _to_response(
                 client.logger,
                 handler.register_sync(
@@ -140,6 +142,7 @@ def _create_handler_sync(
                         serve_path=serve_path,
                     ),
                     server_kind=server_kind,
+                    sync_id=sync_id,
                 ),
                 server_kind,
             )
@@ -216,6 +219,8 @@ def _create_handler_async(
             )
 
         if request.method == "PUT":
+            sync_id = request.GET.get(const.QueryParamKey.SYNC_ID.value)
+
             return _to_response(
                 client.logger,
                 await handler.register(
@@ -225,6 +230,7 @@ def _create_handler_async(
                         serve_path=serve_path,
                     ),
                     server_kind=server_kind,
+                    sync_id=sync_id,
                 ),
                 server_kind,
             )

--- a/inngest/fast_api.py
+++ b/inngest/fast_api.py
@@ -102,13 +102,17 @@ def serve(
         )
 
     @app.put("/api/inngest")
-    async def put_inngest_api(request: fastapi.Request) -> fastapi.Response:
+    async def put_inngest_api(
+        request: fastapi.Request,
+    ) -> fastapi.Response:
         headers = net.normalize_headers(dict(request.headers.items()))
 
         server_kind = transforms.get_server_kind(headers)
         if isinstance(server_kind, Exception):
             client.logger.error(server_kind)
             server_kind = None
+
+        sync_id = request.query_params.get(const.QueryParamKey.SYNC_ID.value)
 
         return _to_response(
             client.logger,
@@ -119,6 +123,7 @@ def serve(
                     serve_path=serve_path,
                 ),
                 server_kind=server_kind,
+                sync_id=sync_id,
             ),
             server_kind,
         )

--- a/inngest/flask.py
+++ b/inngest/flask.py
@@ -213,6 +213,8 @@ def _create_handler_sync(
             )
 
         if flask.request.method == "PUT":
+            sync_id = flask.request.args.get(const.QueryParamKey.SYNC_ID.value)
+
             return _to_response(
                 client.logger,
                 handler.register_sync(
@@ -222,6 +224,7 @@ def _create_handler_sync(
                         serve_path=serve_path,
                     ),
                     server_kind=server_kind,
+                    sync_id=sync_id,
                 ),
                 server_kind,
             )

--- a/inngest/tornado.py
+++ b/inngest/tornado.py
@@ -119,6 +119,13 @@ def serve(
                 client.logger.error(server_kind)
                 server_kind = None
 
+            sync_id: str | None = None
+            raw_sync_id = self.request.query_arguments.get(
+                const.QueryParamKey.SYNC_ID.value
+            )
+            if raw_sync_id is not None:
+                sync_id = raw_sync_id[0].decode("utf-8")
+
             comm_res = handler.register_sync(
                 app_url=net.create_serve_url(
                     request_url=self.request.full_url(),
@@ -126,6 +133,7 @@ def serve(
                     serve_path=serve_path,
                 ),
                 server_kind=server_kind,
+                sync_id=sync_id,
             )
 
             self._write_comm_response(comm_res, server_kind)


### PR DESCRIPTION
During the sync process, the SDK may receive a sync ID in the incoming sync request. When the sync ID is present, the SDK must send it as a query param to Inngest's sync endpoint