### PR TITLE
Fix NonRetriableError raised in step.run

### DIFF
--- a/inngest/_internal/step_lib/step_async.py
+++ b/inngest/_internal/step_lib/step_async.py
@@ -259,6 +259,9 @@ class Step(base.StepBase):
                     op=execution.Opcode.STEP_RUN,
                 )
             )
+        except errors.NonRetriableError as err:
+            # NonRetriableErrors should bubble up to the function level
+            raise err
         except Exception as err:
             transforms.remove_first_traceback_frame(err)
 

--- a/inngest/_internal/step_lib/step_sync.py
+++ b/inngest/_internal/step_lib/step_sync.py
@@ -242,6 +242,9 @@ class StepSync(base.StepBase):
                     op=execution.Opcode.STEP_RUN,
                 )
             )
+        except errors.NonRetriableError as err:
+            # NonRetriableErrors should bubble up to the function level
+            raise err
         except Exception as err:
             transforms.remove_first_traceback_frame(err)
 

--- a/tests/cases/non_retriable_error.py
+++ b/tests/cases/non_retriable_error.py
@@ -25,7 +25,7 @@ def create(
 
     @client.create_function(
         fn_id=fn_id,
-        retries=0,
+        retries=1,
         trigger=inngest.TriggerEvent(event=event_name),
     )
     def fn_sync(
@@ -42,7 +42,7 @@ def create(
 
     @client.create_function(
         fn_id=fn_id,
-        retries=0,
+        retries=1,
         trigger=inngest.TriggerEvent(event=event_name),
     )
     async def fn_async(
@@ -71,6 +71,7 @@ def create(
             output = json.loads(run.output)
 
             assert output == {
+                "code": "non_retriable_error",
                 "is_retriable": False,
                 "message": "foo",
                 "name": "NonRetriableError",


### PR DESCRIPTION
Fix `NonRetriableError` not working when raised in `step.run`