### PR TITLE
Add modes

### DIFF
--- a/examples/django/inngest_django/inngest_client.py
+++ b/examples/django/inngest_django/inngest_client.py
@@ -1,3 +1,9 @@
+import logging
+
 import inngest
 
-inngest_client = inngest.Inngest(app_id="django_example")
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler())
+logger.setLevel(logging.DEBUG)
+
+inngest_client = inngest.Inngest(app_id="django_example", logger=logger)

--- a/examples/fast_api/app.py
+++ b/examples/fast_api/app.py
@@ -1,5 +1,4 @@
 import fastapi
-import uvicorn
 from src.inngest import inngest_client
 
 import inngest.fast_api
@@ -13,6 +12,3 @@ inngest.fast_api.serve(
     inngest_client,
     functions.create_async_functions(inngest_client),
 )
-
-if __name__ == "__main__":
-    uvicorn.run("app:app", host="127.0.0.1", port=8000, reload=True)

--- a/examples/fast_api/scripts/start.sh
+++ b/examples/fast_api/scripts/start.sh
@@ -8,4 +8,4 @@ if [ -n "${ENV_VARS}" ]; then
     export $(echo ${ENV_VARS} | xargs)
 fi
 
-python ./app.py
+uvicorn app:app --reload

--- a/examples/fast_api/src/inngest/client.py
+++ b/examples/fast_api/src/inngest/client.py
@@ -1,3 +1,9 @@
+import logging
+
 import inngest
 
-inngest_client = inngest.Inngest(app_id="fast_api_example")
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler())
+logger.setLevel(logging.DEBUG)
+
+inngest_client = inngest.Inngest(app_id="fast_api_example", logger=logger)

--- a/examples/flask/app.py
+++ b/examples/flask/app.py
@@ -5,9 +5,6 @@ import inngest.flask
 from examples import functions
 
 app = flask.Flask(__name__)
-inngest_client.set_logger(
-    app.logger,
-)
 
 
 inngest.flask.serve(

--- a/examples/flask/src/inngest/client.py
+++ b/examples/flask/src/inngest/client.py
@@ -1,3 +1,9 @@
+import logging
+
 import inngest
 
-inngest_client = inngest.Inngest(app_id="flask_example")
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler())
+logger.setLevel(logging.DEBUG)
+
+inngest_client = inngest.Inngest(app_id="flask_example", logger=logger)

--- a/examples/tornado/src/inngest/client.py
+++ b/examples/tornado/src/inngest/client.py
@@ -1,3 +1,9 @@
+import logging
+
 import inngest
 
-inngest_client = inngest.Inngest(app_id="tornado_example")
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.StreamHandler())
+logger.setLevel(logging.DEBUG)
+
+inngest_client = inngest.Inngest(app_id="tornado_example", logger=logger)

--- a/inngest/_internal/const.py
+++ b/inngest/_internal/const.py
@@ -22,7 +22,6 @@ class EnvKey(enum.Enum):
 class ErrorCode(enum.Enum):
     ASYNC_UNSUPPORTED = "async_unsupported"
     BODY_INVALID = "body_invalid"
-    DISALLOWED_REGISTRATION_INITIATOR = "disallowed_registration_initiator"
     EVENT_KEY_UNSPECIFIED = "event_key_unspecified"
     FUNCTION_CONFIG_INVALID = "function_config_invalid"
     FUNCTION_NOT_FOUND = "function_not_found"
@@ -31,6 +30,7 @@ class ErrorCode(enum.Enum):
     OUTPUT_UNSERIALIZABLE = "output_unserializable"
     QUERY_PARAM_MISSING = "query_param_missing"
     REGISTRATION_FAILED = "registration_failed"
+    SERVER_KIND_MISMATCH = "server_kind_mismatch"
     SIGNING_KEY_UNSPECIFIED = "signing_key_unspecified"
     SIG_VERIFICATION_FAILED = "sig_verification_failed"
     STEP_ERRORED = "step_errored"

--- a/inngest/_internal/env.py
+++ b/inngest/_internal/env.py
@@ -3,9 +3,12 @@ import os
 from . import const
 
 
-def is_truthy(env_var: const.EnvKey, *, default: bool = False) -> bool:
+def is_true(env_var: const.EnvKey) -> bool:
     val = os.getenv(env_var.value)
     if val is None:
-        return default
+        return False
 
-    return val.lower() in ("true", "1")
+    if val.lower() in ("true", "1"):
+        return True
+
+    return False

--- a/inngest/_internal/errors.py
+++ b/inngest/_internal/errors.py
@@ -32,10 +32,6 @@ class Error(Exception):
         return transforms.get_traceback(self)
 
 
-class DisallowedRegistrationError(Error):
-    code = const.ErrorCode.DISALLOWED_REGISTRATION_INITIATOR
-
-
 class URLInvalidError(Error):
     code = const.ErrorCode.URL_INVALID
 

--- a/inngest/_internal/net.py
+++ b/inngest/_internal/net.py
@@ -110,10 +110,10 @@ class RequestSignature:
         self,
         body: bytes,
         headers: dict[str, str],
-        is_production: bool,
+        mode: const.ServerKind,
     ) -> None:
         self._body = body
-        self._is_production = is_production
+        self._mode = mode
 
         sig_header = headers.get(const.HeaderKey.SIGNATURE.value)
         if sig_header is not None:
@@ -124,7 +124,7 @@ class RequestSignature:
                 self._signature = parsed["s"][0]
 
     def validate(self, signing_key: str | None) -> types.MaybeError[None]:
-        if not self._is_production:
+        if self._mode == const.ServerKind.DEV_SERVER:
             return None
 
         if signing_key is None:

--- a/inngest/_internal/net_test.py
+++ b/inngest/_internal/net_test.py
@@ -100,7 +100,7 @@ def test_success() -> None:
         const.HeaderKey.SIGNATURE.value: f"s={sig}&t={unix_ms}",
     }
 
-    req_sig = net.RequestSignature(body, headers, is_production=True)
+    req_sig = net.RequestSignature(body, headers, mode=const.ServerKind.CLOUD)
     assert not isinstance(req_sig.validate(signing_key), Exception)
 
 
@@ -114,7 +114,7 @@ def test_body_tamper() -> None:
     }
 
     body = json.dumps({"msg": "you've been hacked"}).encode("utf-8")
-    req_sig = net.RequestSignature(body, headers, is_production=True)
+    req_sig = net.RequestSignature(body, headers, mode=const.ServerKind.CLOUD)
 
     validation = req_sig.validate(signing_key)
     assert isinstance(validation, errors.SigVerificationFailedError)

--- a/inngest/django.py
+++ b/inngest/django.py
@@ -123,7 +123,7 @@ def _create_handler_sync(
                     req_sig=net.RequestSignature(
                         body=request.body,
                         headers=headers,
-                        is_production=client.is_production,
+                        mode=client._mode,
                     ),
                     target_hashed_id=step_id,
                 ),
@@ -211,7 +211,7 @@ def _create_handler_async(
                     req_sig=net.RequestSignature(
                         body=request.body,
                         headers=headers,
-                        is_production=client.is_production,
+                        mode=client._mode,
                     ),
                     target_hashed_id=step_id,
                 ),

--- a/inngest/fast_api.py
+++ b/inngest/fast_api.py
@@ -94,7 +94,7 @@ def serve(
                 req_sig=net.RequestSignature(
                     body=body,
                     headers=headers,
-                    is_production=client.is_production,
+                    mode=client._mode,
                 ),
                 target_hashed_id=stepId,
             ),

--- a/inngest/flask.py
+++ b/inngest/flask.py
@@ -125,7 +125,7 @@ def _create_handler_async(
                     req_sig=net.RequestSignature(
                         body=flask.request.data,
                         headers=headers,
-                        is_production=client.is_production,
+                        mode=client._mode,
                     ),
                     target_hashed_id=step_id,
                 ),
@@ -205,7 +205,7 @@ def _create_handler_sync(
                     req_sig=net.RequestSignature(
                         body=flask.request.data,
                         headers=headers,
-                        is_production=client.is_production,
+                        mode=client._mode,
                     ),
                     target_hashed_id=step_id,
                 ),

--- a/inngest/tornado.py
+++ b/inngest/tornado.py
@@ -104,7 +104,7 @@ def serve(
                 req_sig=net.RequestSignature(
                     body=self.request.body,
                     headers=headers,
-                    is_production=client.is_production,
+                    mode=client._mode,
                 ),
                 target_hashed_id=step_id,
             )

--- a/tests/test_fast_api.py
+++ b/tests/test_fast_api.py
@@ -136,8 +136,7 @@ class TestRegistration(unittest.TestCase):
         body: object = res.json()
         assert (
             isinstance(body, dict)
-            and body["code"]
-            == const.ErrorCode.DISALLOWED_REGISTRATION_INITIATOR.value
+            and body["code"] == const.ErrorCode.SERVER_KIND_MISMATCH.value
         )
 
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -121,10 +121,7 @@ class TestRegistration(unittest.TestCase):
         assert res.status_code == 400
         body: object = res.json
         assert isinstance(body, dict)
-        assert (
-            body["code"]
-            == const.ErrorCode.DISALLOWED_REGISTRATION_INITIATOR.value
-        )
+        assert body["code"] == const.ErrorCode.SERVER_KIND_MISMATCH.value
 
 
 if __name__ == "__main__":

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -116,8 +116,7 @@ class TestTornadoRegistration(tornado.testing.AsyncHTTPTestCase):
         body: object = json.loads(res.body)
         assert (
             isinstance(body, dict)
-            and body["code"]
-            == const.ErrorCode.DISALLOWED_REGISTRATION_INITIATOR.value
+            and body["code"] == const.ErrorCode.SERVER_KIND_MISMATCH.value
         )
 
 


### PR DESCRIPTION
Add the concept of "modes" (Cloud and Dev Server), which also exist in the TypeScript SDK. One big difference is that the Python SDK doesn't need explicit/implicit modes, since it doesn't have legacy mode inference logic to support.

This PR should not contain any breaking changes. Except for an error code change 😄 

Also improved logging in the example apps, which makes it easier to see the new log messages