### PR TITLE
Fix `if_exp` is ignored

### DIFF
--- a/inngest/_internal/const.py
+++ b/inngest/_internal/const.py
@@ -6,7 +6,7 @@ DEFAULT_EVENT_ORIGIN: typing.Final = "https://inn.gs/"
 DEV_SERVER_ORIGIN: typing.Final = "http://127.0.0.1:8288/"
 LANGUAGE: typing.Final = "py"
 ROOT_STEP_ID: typing.Final = "step"
-VERSION: typing.Final = "0.3.4a1"
+VERSION: typing.Final = "0.3.4a2"
 
 
 class EnvKey(enum.Enum):

--- a/inngest/_internal/function_config.py
+++ b/inngest/_internal/function_config.py
@@ -35,7 +35,7 @@ class Batch(_BaseConfig):
 
 class Cancel(_BaseConfig):
     event: str
-    if_exp: str | None = None
+    if_exp: str | None = pydantic.Field(default=None, serialization_alias="if")
     timeout: int | datetime.timedelta | None = None
 
     @pydantic.field_serializer("timeout")

--- a/inngest/_internal/function_config_test.py
+++ b/inngest/_internal/function_config_test.py
@@ -63,7 +63,7 @@ def test_serialization() -> None:
         "cancel": [
             {
                 "event": "foo",
-                "if_exp": "foo",
+                "if": "foo",
                 "timeout": "1m",
             }
         ],

--- a/inngest/_internal/step_lib/base.py
+++ b/inngest/_internal/step_lib/base.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import dataclasses
 import threading
 
+import pydantic
+
 from inngest._internal import (
     client_lib,
     errors,
@@ -215,5 +217,5 @@ class InvokeOptsPayload(types.BaseModel):
 
 
 class WaitForEventOpts(types.BaseModel):
-    if_exp: str | None
+    if_exp: str | None = pydantic.Field(..., serialization_alias="if")
     timeout: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.3.4a1"
+version = "0.3.4a2"
 description = "Python SDK for Inngest"
 readme = "README.md"
 classifiers = [

--- a/tests/cases/__init__.py
+++ b/tests/cases/__init__.py
@@ -17,6 +17,7 @@ from . import (
     invoke_by_object,
     invoke_failure,
     logger,
+    no_cancel_if_exp_not_match,
     no_steps,
     non_retriable_error,
     on_failure,
@@ -27,7 +28,8 @@ from . import (
     unexpected_step_during_targeting,
     unserializable_step_output,
     wait_for_event_fulfill,
-    wait_for_event_timeout,
+    wait_for_event_timeout_if_exp_not_match,
+    wait_for_event_timeout_name_not_match,
 )
 
 _modules = (
@@ -46,6 +48,7 @@ _modules = (
     invoke_by_object,
     invoke_failure,
     logger,
+    no_cancel_if_exp_not_match,
     no_steps,
     non_retriable_error,
     on_failure,
@@ -56,7 +59,8 @@ _modules = (
     unexpected_step_during_targeting,
     unserializable_step_output,
     wait_for_event_fulfill,
-    wait_for_event_timeout,
+    wait_for_event_timeout_if_exp_not_match,
+    wait_for_event_timeout_name_not_match,
 )
 
 

--- a/tests/cases/no_cancel_if_exp_not_match.py
+++ b/tests/cases/no_cancel_if_exp_not_match.py
@@ -1,3 +1,7 @@
+"""
+Don't cancel the run if the function's cancel expression isn't matched
+"""
+
 import asyncio
 import time
 
@@ -6,7 +10,7 @@ import tests.helper
 
 from . import base
 
-_TEST_NAME = "cancel"
+_TEST_NAME = "no_cancel_if_exp_not_match"
 
 
 class _State(base.BaseState):
@@ -77,11 +81,11 @@ def create(
         self.client.send_sync(inngest.Event(name=event_name, data={"id": 123}))
         run_id = state.wait_for_run_id()
         self.client.send_sync(
-            inngest.Event(name=f"{event_name}.cancel", data={"id": 123})
+            inngest.Event(name=f"{event_name}.cancel", data={"id": 456})
         )
         tests.helper.client.wait_for_run_status(
             run_id,
-            tests.helper.RunStatus.CANCELLED,
+            tests.helper.RunStatus.COMPLETED,
         )
 
         def assert_is_done() -> None:

--- a/tests/cases/wait_for_event_fulfill.py
+++ b/tests/cases/wait_for_event_fulfill.py
@@ -37,7 +37,7 @@ def create(
         state.result = step.wait_for_event(
             "wait",
             event=f"{event_name}.fulfill",
-            if_exp="event.data.id == 123",
+            if_exp="event.data.id == async.data.id",
             timeout=datetime.timedelta(minutes=1),
         )
 
@@ -55,12 +55,17 @@ def create(
         state.result = await step.wait_for_event(
             "wait",
             event=f"{event_name}.fulfill",
-            if_exp="event.data.id == 123",
+            if_exp="event.data.id == async.data.id",
             timeout=datetime.timedelta(minutes=1),
         )
 
     def run_test(self: base.TestClass) -> None:
-        self.client.send_sync(inngest.Event(name=event_name))
+        self.client.send_sync(
+            inngest.Event(
+                data={"id": 123},
+                name=event_name,
+            )
+        )
         run_id = state.wait_for_run_id()
 
         # Sleep long enough for the wait_for_event to register.

--- a/tests/cases/wait_for_event_timeout_if_exp_not_match.py
+++ b/tests/cases/wait_for_event_timeout_if_exp_not_match.py
@@ -41,7 +41,7 @@ def create(
         state.result = step.wait_for_event(
             "wait",
             event=f"{event_name}.fulfill",
-            if_exp="event.data.id == 123",
+            if_exp="event.data.id == async.data.id",
             timeout=datetime.timedelta(seconds=1),
         )
 
@@ -59,12 +59,17 @@ def create(
         state.result = await step.wait_for_event(
             "wait",
             event=f"{event_name}.fulfill",
-            if_exp="event.data.id == 123",
+            if_exp="event.data.id == async.data.id",
             timeout=datetime.timedelta(seconds=1),
         )
 
     def run_test(self: base.TestClass) -> None:
-        self.client.send_sync(inngest.Event(name=event_name))
+        self.client.send_sync(
+            inngest.Event(
+                data={"id": 123},
+                name=event_name,
+            )
+        )
         run_id = state.wait_for_run_id()
 
         # Sleep long enough for the wait_for_event to register.
@@ -72,7 +77,7 @@ def create(
 
         self.client.send_sync(
             inngest.Event(
-                data={"id": 123},
+                data={"id": 456},
                 name=f"{event_name}.fulfill",
             )
         )


### PR DESCRIPTION
# Description
The `if_exp` field was being ignored because we didn't serialize it to `if`, which the Inngest server expects.

The fixes are in these 2 files:
- `inngest/_internal/function_config.py`
- `inngest/_internal/step_lib/base.py`

The rest of the changes are for tests against regressions

# Context
We had to name the field `if_exp` instead of `if` because Python doesn't let you use statement keywords (`if`, `for`, etc.) as class fields names

# Testing
Added automated tests that would've caught this