### PR TITLE
Fix not fetching event batch from API

### DIFF
--- a/inngest/_internal/execution.py
+++ b/inngest/_internal/execution.py
@@ -12,8 +12,9 @@ from . import const, errors, event_lib, transforms, types
 class Call(types.BaseModel):
     ctx: CallContext
     event: event_lib.Event
-    events: list[event_lib.Event]
+    events: typing.Optional[list[event_lib.Event]] = None
     steps: dict[str, object]
+    use_api: bool
 
 
 class CallContext(types.BaseModel):

--- a/tests/cases/__init__.py
+++ b/tests/cases/__init__.py
@@ -2,6 +2,7 @@ import inngest
 
 from . import (
     base,
+    batch_that_needs_api,
     cancel,
     change_step_error,
     client_middleware,
@@ -34,6 +35,7 @@ from . import (
 )
 
 _modules = (
+    batch_that_needs_api,
     cancel,
     change_step_error,
     client_middleware,

--- a/tests/cases/batch_that_needs_api.py
+++ b/tests/cases/batch_that_needs_api.py
@@ -1,0 +1,94 @@
+"""
+Send a batch so large that it can't be included in the request sent from the
+Executor to the SDK. The SDK will need to fetch the batch from the API
+"""
+
+import datetime
+import typing
+
+import inngest
+import tests.helper
+
+from . import base
+
+_TEST_NAME = "batch_that_needs_api"
+
+
+class _State(base.BaseState):
+    events: typing.Optional[list[inngest.Event]] = None
+
+
+def create(
+    client: inngest.Inngest,
+    framework: str,
+    is_sync: bool,
+) -> base.Case:
+    test_name = base.create_test_name(_TEST_NAME, is_sync)
+    event_name = base.create_event_name(framework, test_name)
+    fn_id = base.create_fn_id(test_name)
+    state = _State()
+
+    @client.create_function(
+        batch_events=inngest.Batch(
+            max_size=50,
+            timeout=datetime.timedelta(seconds=10),
+        ),
+        fn_id=fn_id,
+        retries=0,
+        trigger=inngest.TriggerEvent(event=event_name),
+    )
+    def fn_sync(
+        ctx: inngest.Context,
+        step: inngest.StepSync,
+    ) -> None:
+        state.run_id = ctx.run_id
+        state.events = ctx.events
+
+    @client.create_function(
+        batch_events=inngest.Batch(
+            max_size=50,
+            timeout=datetime.timedelta(seconds=10),
+        ),
+        fn_id=fn_id,
+        retries=0,
+        trigger=inngest.TriggerEvent(event=event_name),
+    )
+    async def fn_async(
+        ctx: inngest.Context,
+        step: inngest.Step,
+    ) -> None:
+        state.run_id = ctx.run_id
+        state.events = ctx.events
+
+    def run_test(self: base.TestClass) -> None:
+        # Send a large (in terms of bytes, not event count) enough batch to
+        # ensure that the SDK needs to fetch the batch from the API
+        events = []
+        for _ in range(50):
+            events.append(
+                inngest.Event(
+                    data={"msg": "a" * 1024 * 1024},
+                    name=event_name,
+                )
+            )
+        self.client.send_sync(events)
+
+        run_id = state.wait_for_run_id()
+        tests.helper.client.wait_for_run_status(
+            run_id,
+            tests.helper.RunStatus.COMPLETED,
+        )
+
+        assert state.events is not None
+        assert len(state.events) == 50
+
+    if is_sync:
+        fn = fn_sync
+    else:
+        fn = fn_async
+
+    return base.Case(
+        fn=fn,
+        run_test=run_test,
+        name=test_name,
+    )


### PR DESCRIPTION
## Description
Fix the SDK not fetching the event batch from the API when the Executor tells it to

## Context
The Executor tells the SDK to fetch the event batch from the API when the event batch is too large to fit in the request to the SDK.

We need to make a similar change for fetching step data from the API, but that's out of scope for this PR