### PR TITLE
Fix signing key required for client-only

### DIFF
--- a/inngest/_internal/client_lib.py
+++ b/inngest/_internal/client_lib.py
@@ -107,10 +107,6 @@ class Inngest:
         self._signing_key = signing_key or os.getenv(
             const.EnvKey.SIGNING_KEY.value
         )
-        if self._signing_key is None and self._mode == const.ServerKind.CLOUD:
-            raise errors.SigningKeyMissingError(
-                f"Signing key must be set when Cloud mode is enabled. If you don't want to use Cloud mode, set the {const.EnvKey.DEV.value} env var."
-            )
 
         self._env = env or env_lib.get_environment_name()
         if (

--- a/inngest/_internal/client_lib_test.py
+++ b/inngest/_internal/client_lib_test.py
@@ -91,13 +91,15 @@ class Test(unittest.TestCase):
         )
         assert client.signing_key == "foo1"
 
-    def test_signing_key_missing(self) -> None:
+    def test_cloud_mode_without_signing_key(self) -> None:
         """
-        Error is raised when the signing key is not set in production.
+        When in Cloud mode but no signing key, no error is raised. This behavior
+        is necessary because some users may only use the Inngest client for
+        sending events. The signing key should only be required when serving
+        Inngest functions in Cloud mode
         """
 
-        with pytest.raises(errors.SigningKeyMissingError):
-            client_lib.Inngest(app_id="test")
+        client_lib.Inngest(app_id="test")
 
     def test_api_base_url_env_var(self) -> None:
         os.environ[const.EnvKey.API_BASE_URL.value] = "example.com"


### PR DESCRIPTION
## Description
No longer require a signing key when instantiating the Inngest client. Instead, the signing key is only required when serving Inngest functions in Cloud mode.

## Motivation
Some users may want to only use the Inngest client for sending events. For that use case, only the event key should be required