### PR TITLE
Add signing key rotation support

### DIFF
--- a/inngest/_internal/client_lib.py
+++ b/inngest/_internal/client_lib.py
@@ -57,8 +57,8 @@ class Inngest:
         return self._signing_key
 
     @property
-    def signing_key_rotated(self) -> typing.Optional[str]:
-        return self._signing_key_rotated
+    def signing_key_fallback(self) -> typing.Optional[str]:
+        return self._signing_key_fallback
 
     def __init__(
         self,
@@ -116,8 +116,8 @@ class Inngest:
                 f"Signing key must be set when Cloud mode is enabled. If you don't want to use Cloud mode, set the {const.EnvKey.DEV.value} env var."
             )
 
-        self._signing_key_rotated = signing_key or os.getenv(
-            const.EnvKey.SIGNING_KEY_ROTATED.value
+        self._signing_key_fallback = signing_key or os.getenv(
+            const.EnvKey.SIGNING_KEY_FALLBACK.value
         )
 
         self._env = env or env_lib.get_environment_name()

--- a/inngest/_internal/client_lib.py
+++ b/inngest/_internal/client_lib.py
@@ -56,6 +56,10 @@ class Inngest:
     def signing_key(self) -> typing.Optional[str]:
         return self._signing_key
 
+    @property
+    def signing_key_rotated(self) -> typing.Optional[str]:
+        return self._signing_key_rotated
+
     def __init__(
         self,
         *,
@@ -111,6 +115,10 @@ class Inngest:
             raise errors.SigningKeyMissingError(
                 f"Signing key must be set when Cloud mode is enabled. If you don't want to use Cloud mode, set the {const.EnvKey.DEV.value} env var."
             )
+
+        self._signing_key_rotated = signing_key or os.getenv(
+            const.EnvKey.SIGNING_KEY_ROTATED.value
+        )
 
         self._env = env or env_lib.get_environment_name()
         if (

--- a/inngest/_internal/comm.py
+++ b/inngest/_internal/comm.py
@@ -147,7 +147,7 @@ class CommHandler:
     _framework: const.Framework
     _mode: const.ServerKind
     _signing_key: typing.Optional[str]
-    _signing_key_rotated: typing.Optional[str]
+    _signing_key_fallback: typing.Optional[str]
 
     def __init__(
         self,
@@ -187,7 +187,7 @@ class CommHandler:
                     raise errors.SigningKeyMissingError()
         self._signing_key = signing_key
 
-        self._signing_key_rotated = client.signing_key_rotated
+        self._signing_key_fallback = client.signing_key_fallback
 
     def _build_registration_request(
         self,
@@ -257,7 +257,7 @@ class CommHandler:
         # Validate the request signature.
         err = req_sig.validate(
             signing_key=self._signing_key,
-            signing_key_rotated=self._signing_key_rotated,
+            signing_key_fallback=self._signing_key_fallback,
         )
         if isinstance(err, Exception):
             return await self._respond(middleware, err)
@@ -326,7 +326,7 @@ class CommHandler:
         # Validate the request signature.
         err = req_sig.validate(
             signing_key=self._signing_key,
-            signing_key_rotated=self._signing_key_rotated,
+            signing_key_fallback=self._signing_key_fallback,
         )
         if isinstance(err, Exception):
             return self._respond_sync(middleware, err)

--- a/inngest/_internal/comm.py
+++ b/inngest/_internal/comm.py
@@ -194,7 +194,6 @@ class CommHandler:
         *,
         app_url: str,
         server_kind: typing.Optional[const.ServerKind],
-        signing_key: typing.Optional[str],
         sync_id: typing.Optional[str],
     ) -> types.MaybeError[httpx.Request]:
         registration_url = urllib.parse.urljoin(
@@ -222,7 +221,6 @@ class CommHandler:
             env=self._client.env,
             framework=self._framework,
             server_kind=server_kind,
-            signing_key=signing_key,
         )
 
         params = {}
@@ -444,7 +442,6 @@ class CommHandler:
                 env=self._client.env,
                 framework=self._framework,
                 server_kind=server_kind,
-                signing_key=None,
             ),
             status_code=200,
         )
@@ -475,7 +472,6 @@ class CommHandler:
                     env=self._client.env,
                     framework=self._framework,
                     server_kind=server_kind,
-                    signing_key=None,
                 ),
                 status_code=http.HTTPStatus.OK,
             )
@@ -503,32 +499,21 @@ class CommHandler:
         if comm_res is not None:
             return comm_res
 
-        async with httpx.AsyncClient() as client:
-            req = self._build_registration_request(
-                app_url=app_url,
-                server_kind=server_kind,
-                signing_key=self._signing_key,
-                sync_id=sync_id,
-            )
-            if isinstance(req, Exception):
-                return CommResponse.from_error(self._client.logger, req)
-            res = await client.send(req)
+        req = self._build_registration_request(
+            app_url=app_url,
+            server_kind=server_kind,
+            sync_id=sync_id,
+        )
+        if isinstance(req, Exception):
+            return CommResponse.from_error(self._client.logger, req)
 
-            if (
-                res.status_code
-                in (http.HTTPStatus.FORBIDDEN, http.HTTPStatus.UNAUTHORIZED)
-                and self._signing_key_fallback is not None
-            ):
-                # Retry with the fallback signing key
-                req = self._build_registration_request(
-                    app_url=app_url,
-                    server_kind=server_kind,
-                    signing_key=self._signing_key_fallback,
-                    sync_id=sync_id,
-                )
-                if isinstance(req, Exception):
-                    return CommResponse.from_error(self._client.logger, req)
-                res = await client.send(req)
+        async with httpx.AsyncClient() as client:
+            res = await net.fetch_with_auth_fallback(
+                client,
+                req,
+                signing_key=self._signing_key,
+                signing_key_fallback=self._signing_key_fallback,
+            )
 
             return self._parse_registration_response(
                 res,
@@ -548,32 +533,21 @@ class CommHandler:
         if comm_res is not None:
             return comm_res
 
-        with httpx.Client() as client:
-            req = self._build_registration_request(
-                app_url=app_url,
-                server_kind=server_kind,
-                signing_key=self._signing_key,
-                sync_id=sync_id,
-            )
-            if isinstance(req, Exception):
-                return CommResponse.from_error(self._client.logger, req)
-            res = client.send(req)
+        req = self._build_registration_request(
+            app_url=app_url,
+            server_kind=server_kind,
+            sync_id=sync_id,
+        )
+        if isinstance(req, Exception):
+            return CommResponse.from_error(self._client.logger, req)
 
-            if (
-                res.status_code
-                in (http.HTTPStatus.FORBIDDEN, http.HTTPStatus.UNAUTHORIZED)
-                and self._signing_key_fallback is not None
-            ):
-                # Retry with the fallback signing key
-                req = self._build_registration_request(
-                    app_url=app_url,
-                    server_kind=server_kind,
-                    signing_key=self._signing_key_fallback,
-                    sync_id=sync_id,
-                )
-                if isinstance(req, Exception):
-                    return CommResponse.from_error(self._client.logger, req)
-                res = client.send(req)
+        with httpx.Client() as client:
+            res = net.fetch_with_auth_fallback_sync(
+                client,
+                req,
+                signing_key=self._signing_key,
+                signing_key_fallback=self._signing_key_fallback,
+            )
 
             return self._parse_registration_response(
                 res,

--- a/inngest/_internal/const.py
+++ b/inngest/_internal/const.py
@@ -27,7 +27,7 @@ class EnvKey(enum.Enum):
     SERVE_ORIGIN = "INNGEST_SERVE_ORIGIN"
     SERVE_PATH = "INNGEST_SERVE_PATH"
     SIGNING_KEY = "INNGEST_SIGNING_KEY"
-    SIGNING_KEY_ROTATED = "INNGEST_SIGNING_KEY_ROTATED"
+    SIGNING_KEY_FALLBACK = "INNGEST_SIGNING_KEY_FALLBACK"
 
     # Vercel deployment's git branch
     # https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables#system-environment-variables

--- a/inngest/_internal/const.py
+++ b/inngest/_internal/const.py
@@ -27,6 +27,7 @@ class EnvKey(enum.Enum):
     SERVE_ORIGIN = "INNGEST_SERVE_ORIGIN"
     SERVE_PATH = "INNGEST_SERVE_PATH"
     SIGNING_KEY = "INNGEST_SIGNING_KEY"
+    SIGNING_KEY_ROTATED = "INNGEST_SIGNING_KEY_ROTATED"
 
     # Vercel deployment's git branch
     # https://vercel.com/docs/concepts/projects/environment-variables/system-environment-variables#system-environment-variables

--- a/inngest/_internal/net.py
+++ b/inngest/_internal/net.py
@@ -164,23 +164,23 @@ class RequestSignature:
         self,
         *,
         signing_key: typing.Optional[str],
-        signing_key_rotated: typing.Optional[str],
+        signing_key_fallback: typing.Optional[str],
     ) -> types.MaybeError[None]:
         """
-        Validate the request signature. Falls back to the rotated signing key if
+        Validate the request signature. Falls back to the fallback signing key if
         signature validation fails with the primary signing key.
 
         Args:
         ----
             signing_key: The primary signing key.
-            signing_key_rotated: The rotated signing key.
+            signing_key_fallback: The fallback signing key.
         """
 
         err = self._validate(signing_key)
-        if err is not None and signing_key_rotated is not None:
-            # If the signature validation failed but there's a "rotated" signing
-            # key, then assume that the signing key was rotated. Attempt to
-            # validate the signature with the rotated key
-            err = self._validate(signing_key_rotated)
+        if err is not None and signing_key_fallback is not None:
+            # If the signature validation failed but there's a "fallback"
+            # signing key, then assume that the signing key was fallback.
+            # Attempt to validate the signature with the fallback key
+            err = self._validate(signing_key_fallback)
 
         return err

--- a/inngest/_internal/net.py
+++ b/inngest/_internal/net.py
@@ -1,6 +1,5 @@
 import hashlib
 import hmac
-import http
 import os
 import typing
 import urllib.parse

--- a/inngest/_internal/net.py
+++ b/inngest/_internal/net.py
@@ -1,5 +1,6 @@
 import hashlib
 import hmac
+import http
 import os
 import typing
 import urllib.parse

--- a/inngest/_internal/net.py
+++ b/inngest/_internal/net.py
@@ -179,8 +179,8 @@ class RequestSignature:
         err = self._validate(signing_key)
         if err is not None and signing_key_fallback is not None:
             # If the signature validation failed but there's a "fallback"
-            # signing key, then assume that the signing key was fallback.
-            # Attempt to validate the signature with the fallback key
+            # signing key, attempt to validate the signature with the fallback
+            # key
             err = self._validate(signing_key_fallback)
 
         return err

--- a/inngest/_internal/net_test.py
+++ b/inngest/_internal/net_test.py
@@ -107,7 +107,7 @@ class Test_RequestSignature(unittest.TestCase):
         assert not isinstance(
             req_sig.validate(
                 signing_key=signing_key,
-                signing_key_rotated=None,
+                signing_key_fallback=None,
             ),
             Exception,
         )
@@ -132,21 +132,21 @@ class Test_RequestSignature(unittest.TestCase):
 
         validation = req_sig.validate(
             signing_key=signing_key,
-            signing_key_rotated=None,
+            signing_key_fallback=None,
         )
         assert isinstance(validation, errors.SigVerificationFailedError)
 
     def test_rotation(self) -> None:
         """
-        Validation succeeds if the primary signing key fails but the rotated
+        Validation succeeds if the primary signing key fails but the fallback
         signing key succeeds
         """
 
         body = json.dumps({"msg": "hi"}).encode("utf-8")
         signing_key = "super-secret"
-        signing_key_rotated = "super-secret-rotated"
+        signing_key_fallback = "super-secret-fallback"
         unix_ms = round(time.time() * 1000)
-        sig = _sign(body, signing_key_rotated, unix_ms)
+        sig = _sign(body, signing_key_fallback, unix_ms)
         headers = {
             const.HeaderKey.SIGNATURE.value: f"s={sig}&t={unix_ms}",
         }
@@ -157,7 +157,7 @@ class Test_RequestSignature(unittest.TestCase):
         assert not isinstance(
             req_sig.validate(
                 signing_key=signing_key,
-                signing_key_rotated=signing_key_rotated,
+                signing_key_fallback=signing_key_fallback,
             ),
             Exception,
         )
@@ -169,7 +169,7 @@ class Test_RequestSignature(unittest.TestCase):
 
         body = json.dumps({"msg": "hi"}).encode("utf-8")
         signing_key = "super-secret"
-        signing_key_rotated = "super-secret-rotated"
+        signing_key_fallback = "super-secret-fallback"
         unix_ms = round(time.time() * 1000)
         sig = _sign(body, "something-else", unix_ms)
         headers = {
@@ -182,7 +182,7 @@ class Test_RequestSignature(unittest.TestCase):
         assert isinstance(
             req_sig.validate(
                 signing_key=signing_key,
-                signing_key_rotated=signing_key_rotated,
+                signing_key_fallback=signing_key_fallback,
             ),
             Exception,
         )

--- a/inngest/django.py
+++ b/inngest/django.py
@@ -263,7 +263,6 @@ def _to_response(
                 env=client.env,
                 framework=FRAMEWORK,
                 server_kind=server_kind,
-                signing_key=None,
             ),
         },
         status=comm_res.status_code,

--- a/inngest/django.py
+++ b/inngest/django.py
@@ -51,7 +51,6 @@ def serve(
         client=client,
         framework=FRAMEWORK,
         functions=functions,
-        signing_key=client.signing_key,
     )
 
     if async_mode:

--- a/inngest/fast_api.py
+++ b/inngest/fast_api.py
@@ -44,7 +44,6 @@ def serve(
         client=client,
         framework=FRAMEWORK,
         functions=functions,
-        signing_key=client.signing_key,
     )
 
     @app.get("/api/inngest")

--- a/inngest/fast_api.py
+++ b/inngest/fast_api.py
@@ -146,7 +146,6 @@ def _to_response(
                 env=client.env,
                 framework=FRAMEWORK,
                 server_kind=server_kind,
-                signing_key=None,
             ),
         },
         status_code=comm_res.status_code,

--- a/inngest/flask.py
+++ b/inngest/flask.py
@@ -249,7 +249,6 @@ def _to_response(
                 env=client.env,
                 framework=FRAMEWORK,
                 server_kind=server_kind,
-                signing_key=None,
             ),
         },
         response=body.encode("utf-8"),

--- a/inngest/flask.py
+++ b/inngest/flask.py
@@ -45,7 +45,6 @@ def serve(
         client=client,
         framework=FRAMEWORK,
         functions=functions,
-        signing_key=client.signing_key,
     )
 
     async_mode = any(

--- a/inngest/tornado.py
+++ b/inngest/tornado.py
@@ -157,7 +157,6 @@ def serve(
                 env=client.env,
                 framework=FRAMEWORK,
                 server_kind=server_kind,
-                signing_key=None,
             ).items():
                 self.add_header(k, v)
 

--- a/inngest/tornado.py
+++ b/inngest/tornado.py
@@ -44,7 +44,6 @@ def serve(
         client=client,
         framework=FRAMEWORK,
         functions=functions,
-        signing_key=client.signing_key,
     )
 
     class InngestHandler(tornado.web.RequestHandler):


### PR DESCRIPTION
## Description
- Add `INNGEST_SIGNING_KEY_FALLBACK` env var
- Retry request with fallback signing key if:
  - Signature validation fails
  - Fetching batch or step data from API fails with 401 or 403 status code
  - Synchronization fails with with 401 or 403 status code

## Context
This implements part of the fallback signing key behavior in the SDK spec ([here](https://github.com/inngest/inngest/blob/main/docs/SDK_SPEC.md#31-critical-variables)). The introspection endpoint is implemented by #77