### PR TITLE
Use HTTP connection pools

### DIFF
--- a/inngest/_internal/comm.py
+++ b/inngest/_internal/comm.py
@@ -227,7 +227,7 @@ class CommHandler:
         if sync_id is not None:
             params[const.QueryParamKey.SYNC_ID.value] = sync_id
 
-        return httpx.Client().build_request(
+        return self._client._http_client.build_request(
             "POST",
             registration_url,
             headers=headers,
@@ -538,18 +538,19 @@ class CommHandler:
         if isinstance(req, Exception):
             return CommResponse.from_error(self._client.logger, req)
 
-        async with httpx.AsyncClient() as client:
-            res = await net.fetch_with_auth_fallback(
-                client,
-                req,
-                signing_key=self._signing_key,
-                signing_key_fallback=self._signing_key_fallback,
-            )
+        res = await net.fetch_with_auth_fallback(
+            self._client.logger,
+            self._client._http_client,
+            self._client._http_client_sync,
+            req,
+            signing_key=self._signing_key,
+            signing_key_fallback=self._signing_key_fallback,
+        )
 
-            return self._parse_registration_response(
-                res,
-                server_kind,
-            )
+        return self._parse_registration_response(
+            res,
+            server_kind,
+        )
 
     def register_sync(
         self,
@@ -572,18 +573,17 @@ class CommHandler:
         if isinstance(req, Exception):
             return CommResponse.from_error(self._client.logger, req)
 
-        with httpx.Client() as client:
-            res = net.fetch_with_auth_fallback_sync(
-                client,
-                req,
-                signing_key=self._signing_key,
-                signing_key_fallback=self._signing_key_fallback,
-            )
+        res = net.fetch_with_auth_fallback_sync(
+            self._client._http_client_sync,
+            req,
+            signing_key=self._signing_key,
+            signing_key_fallback=self._signing_key_fallback,
+        )
 
-            return self._parse_registration_response(
-                res,
-                server_kind,
-            )
+        return self._parse_registration_response(
+            res,
+            server_kind,
+        )
 
     async def _respond(
         self,

--- a/inngest/_internal/comm.py
+++ b/inngest/_internal/comm.py
@@ -227,7 +227,7 @@ class CommHandler:
         if sync_id is not None:
             params[const.QueryParamKey.SYNC_ID.value] = sync_id
 
-        return self._client._http_client.build_request(
+        return self._client._http_client_sync.build_request(
             "POST",
             registration_url,
             headers=headers,

--- a/inngest/_internal/net.py
+++ b/inngest/_internal/net.py
@@ -138,17 +138,18 @@ async def fetch_with_auth_fallback(
             const.HeaderKey.AUTHORIZATION.value
         ] = f"Bearer {transforms.hash_signing_key(signing_key)}"
 
-    res = await client.send(request)
-    if (
-        res.status_code
-        in (http.HTTPStatus.FORBIDDEN, http.HTTPStatus.UNAUTHORIZED)
-        and signing_key_fallback is not None
-    ):
-        # Try again with the signing key fallback
-        request.headers[
-            const.HeaderKey.AUTHORIZATION.value
-        ] = f"Bearer {transforms.hash_signing_key(signing_key_fallback)}"
+    async with client:
         res = await client.send(request)
+        if (
+            res.status_code
+            in (http.HTTPStatus.FORBIDDEN, http.HTTPStatus.UNAUTHORIZED)
+            and signing_key_fallback is not None
+        ):
+            # Try again with the signing key fallback
+            request.headers[
+                const.HeaderKey.AUTHORIZATION.value
+            ] = f"Bearer {transforms.hash_signing_key(signing_key_fallback)}"
+            res = await client.send(request)
 
     return res
 

--- a/inngest/_internal/net_test.py
+++ b/inngest/_internal/net_test.py
@@ -192,6 +192,7 @@ class Test_RequestSignature(unittest.TestCase):
 class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         super().setUp()
+        self._logger = unittest.mock.Mock()
         self._req = httpx.Request("GET", "http://localhost")
 
     def _create_async_transport(
@@ -241,7 +242,11 @@ class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
             return httpx.Response(200, content=b"", request=request)
 
         res = await net.fetch_with_auth_fallback(
-            httpx.AsyncClient(transport=self._create_async_transport(handler)),
+            self._logger,
+            net.ThreadAwareAsyncHTTPClient(
+                transport=self._create_async_transport(handler)
+            ).initialize(),
+            httpx.Client(transport=self._create_transport(handler)),
             self._req,
             signing_key=_signing_key,
             signing_key_fallback=_signing_key_fallback,
@@ -283,7 +288,11 @@ class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
             return httpx.Response(200, content=b"", request=request)
 
         res = await net.fetch_with_auth_fallback(
-            httpx.AsyncClient(transport=self._create_async_transport(handler)),
+            self._logger,
+            net.ThreadAwareAsyncHTTPClient(
+                transport=self._create_async_transport(handler)
+            ).initialize(),
+            httpx.Client(transport=self._create_transport(handler)),
             self._req,
             signing_key=_signing_key,
             signing_key_fallback=_signing_key_fallback,
@@ -325,7 +334,11 @@ class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
             return httpx.Response(200, content=b"", request=request)
 
         res = await net.fetch_with_auth_fallback(
-            httpx.AsyncClient(transport=self._create_async_transport(handler)),
+            self._logger,
+            net.ThreadAwareAsyncHTTPClient(
+                transport=self._create_async_transport(handler)
+            ).initialize(),
+            httpx.Client(transport=self._create_transport(handler)),
             self._req,
             signing_key="signkey-prod-aaaaaa",
             signing_key_fallback="signkey-prod-bbbbbb",
@@ -362,7 +375,11 @@ class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
             return httpx.Response(200, content=b"", request=request)
 
         res = await net.fetch_with_auth_fallback(
-            httpx.AsyncClient(transport=self._create_async_transport(handler)),
+            self._logger,
+            net.ThreadAwareAsyncHTTPClient(
+                transport=self._create_async_transport(handler)
+            ).initialize(),
+            httpx.Client(transport=self._create_transport(handler)),
             self._req,
             signing_key=None,
             signing_key_fallback=None,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,4 @@
+import asyncio
 import dataclasses
 import json
 import typing
@@ -62,6 +63,26 @@ class TestClient(unittest.TestCase):
             f"inngest-py:v{const.VERSION}"
         ]
         assert event_key in state.path
+
+    async def test_many_parallel_sends(self) -> None:
+        """
+        Ensure the client can run many sends in parallel
+        """
+
+        class_name = self.__class__.__name__
+        method_name = self._testMethodName
+        client = inngest.Inngest(
+            app_id=f"{class_name}-{method_name}",
+            is_production=False,
+        )
+
+        sends = []
+        for _ in range(1000):
+            sends.append(
+                client.send(inngest.Event(name=f"{class_name}-{method_name}"))
+            )
+
+        await asyncio.gather(*sends)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replace ad-hoc HTTP client creation with shared HTTP clients stored on the Inngest client.

To prevent regressions, this PR adds a test that calls `Inngest.send` 1000 times in parallel.

Fixes #78