### PR TITLE
Auto-detect Django async mode

### DIFF
--- a/inngest/_internal/async_lib.py
+++ b/inngest/_internal/async_lib.py
@@ -1,0 +1,11 @@
+import asyncio
+import typing
+
+
+def get_event_loop() -> typing.Optional[asyncio.AbstractEventLoop]:
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        return None
+
+    return loop

--- a/inngest/_internal/client_lib.py
+++ b/inngest/_internal/client_lib.py
@@ -291,7 +291,6 @@ class Inngest:
         )
 
         return await net.fetch_with_auth_fallback(
-            self.logger,
             self._http_client,
             self._http_client_sync,
             req,
@@ -414,7 +413,6 @@ class Inngest:
             raise req
 
         res = await net.fetch_with_thready_safety(
-            self.logger,
             self._http_client,
             self._http_client_sync,
             req,

--- a/inngest/_internal/comm.py
+++ b/inngest/_internal/comm.py
@@ -542,7 +542,6 @@ class CommHandler:
             return CommResponse.from_error(self._client.logger, req)
 
         res = await net.fetch_with_auth_fallback(
-            self._client.logger,
             self._client._http_client,
             self._client._http_client_sync,
             req,

--- a/inngest/_internal/net_test.py
+++ b/inngest/_internal/net_test.py
@@ -192,7 +192,6 @@ class Test_RequestSignature(unittest.TestCase):
 class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self._logger = unittest.mock.Mock()
         self._req = httpx.Request("GET", "http://localhost")
 
     def _create_async_transport(
@@ -242,7 +241,6 @@ class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
             return httpx.Response(200, content=b"", request=request)
 
         res = await net.fetch_with_auth_fallback(
-            self._logger,
             net.ThreadAwareAsyncHTTPClient(
                 transport=self._create_async_transport(handler)
             ).initialize(),
@@ -288,7 +286,6 @@ class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
             return httpx.Response(200, content=b"", request=request)
 
         res = await net.fetch_with_auth_fallback(
-            self._logger,
             net.ThreadAwareAsyncHTTPClient(
                 transport=self._create_async_transport(handler)
             ).initialize(),
@@ -334,7 +331,6 @@ class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
             return httpx.Response(200, content=b"", request=request)
 
         res = await net.fetch_with_auth_fallback(
-            self._logger,
             net.ThreadAwareAsyncHTTPClient(
                 transport=self._create_async_transport(handler)
             ).initialize(),
@@ -375,7 +371,6 @@ class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
             return httpx.Response(200, content=b"", request=request)
 
         res = await net.fetch_with_auth_fallback(
-            self._logger,
             net.ThreadAwareAsyncHTTPClient(
                 transport=self._create_async_transport(handler)
             ).initialize(),

--- a/inngest/_internal/transforms.py
+++ b/inngest/_internal/transforms.py
@@ -109,6 +109,17 @@ def to_iso_utc(value: datetime.datetime) -> str:
     )
 
 
+def _to_int(value: typing.Any) -> types.MaybeError[int]:
+    try:
+        return int(value)
+    except Exception as err:
+        return ValueError(f"invalid integer: {err}")
+
+
+def get_major_version(version: str) -> types.MaybeError[int]:
+    return _to_int(version.split(".")[0])
+
+
 def get_server_kind(
     headers: dict[str, str],
 ) -> typing.Union[const.ServerKind, None, Exception]:

--- a/inngest/django.py
+++ b/inngest/django.py
@@ -178,6 +178,7 @@ def _create_handler_async(
         client.logger.error(major_version)
     else:
         if major_version < 5:
+            # Django 5 introduced async support for csrf_exempt
             raise Exception(
                 "Django version 5 or higher is required for async mode"
             )

--- a/inngest/django.py
+++ b/inngest/django.py
@@ -29,7 +29,7 @@ def serve(
     client: client_lib.Inngest,
     functions: list[function.Function],
     *,
-    async_mode: bool = False,
+    async_mode: typing.Optional[bool] = None,
     serve_origin: typing.Optional[str] = None,
     serve_path: typing.Optional[str] = None,
 ) -> django.urls.URLPattern:
@@ -41,7 +41,7 @@ def serve(
         client: Inngest client.
         functions: List of functions to serve.
 
-        async_mode: Whether to serve functions asynchronously.
+        async_mode: [DEPRECATED] Whether to serve functions asynchronously.
         serve_origin: Origin to serve Inngest from.
         serve_path: Path to serve Inngest from.
     """
@@ -52,6 +52,13 @@ def serve(
         framework=FRAMEWORK,
         functions=functions,
     )
+
+    # TODO: Remove async_mode kwarg in v0.4.0
+    if async_mode is not None:
+        async_mode = any(
+            function.is_handler_async or function.is_on_failure_handler_async
+            for function in functions
+        )
 
     if async_mode:
         return _create_handler_async(
@@ -166,6 +173,15 @@ def _create_handler_async(
     serve_origin: typing.Optional[str],
     serve_path: typing.Optional[str],
 ) -> django.urls.URLPattern:
+    major_version = transforms.get_major_version(django.get_version())
+    if isinstance(major_version, Exception):
+        client.logger.error(major_version)
+    else:
+        if major_version < 5:
+            raise Exception(
+                "Django version 5 or higher is required for async mode"
+            )
+
     async def inngest_api(
         request: django.http.HttpRequest,
     ) -> django.http.HttpResponse:

--- a/inngest/django.py
+++ b/inngest/django.py
@@ -54,7 +54,7 @@ def serve(
     )
 
     # TODO: Remove async_mode kwarg in v0.4.0
-    if async_mode is not None:
+    if async_mode is None:
         async_mode = any(
             function.is_handler_async or function.is_on_failure_handler_async
             for function in functions


### PR DESCRIPTION
- Auto-detect Django async mode.
- Raise error if major version is below 5. Django didn't add async support to `csrf_exempt` until version 5.
- Remove annoying warning in `fetch_with_thready_safety`.