### PR TITLE
Add after_send_events middleware hook

### DIFF
--- a/inngest/__init__.py
+++ b/inngest/__init__.py
@@ -1,7 +1,7 @@
 """Public entrypoint for the Inngest SDK."""
 
 
-from ._internal.client_lib import Inngest
+from ._internal.client_lib import Inngest, SendEventsResult
 from ._internal.errors import NonRetriableError, RetryAfterError, StepError
 from ._internal.event_lib import Event
 from ._internal.function import Context, Function
@@ -38,6 +38,7 @@ __all__ = [
     "NonRetriableError",
     "RateLimit",
     "RetryAfterError",
+    "SendEventsResult",
     "Step",
     "StepError",
     "StepMemos",

--- a/inngest/_internal/client_lib/__init__.py
+++ b/inngest/_internal/client_lib/__init__.py
@@ -1,0 +1,4 @@
+from .client import Inngest
+from .models import SendEventsResult
+
+__all__ = ["Inngest", "SendEventsResult"]

--- a/inngest/_internal/client_lib/client.py
+++ b/inngest/_internal/client_lib/client.py
@@ -514,4 +514,3 @@ def _get_mode(
         f"Cloud mode enabled. Set {const.EnvKey.DEV.value} to enable development mode"
     )
     return const.ServerKind.CLOUD
-    return const.ServerKind.CLOUD

--- a/inngest/_internal/client_lib/client_test.py
+++ b/inngest/_internal/client_lib/client_test.py
@@ -3,7 +3,7 @@ import unittest
 
 import pytest
 
-from . import client_lib, const, errors, event_lib
+from inngest._internal import client_lib, const, errors, event_lib
 
 
 class Test(unittest.TestCase):

--- a/inngest/_internal/client_lib/models.py
+++ b/inngest/_internal/client_lib/models.py
@@ -1,0 +1,8 @@
+import typing
+
+from inngest._internal import types
+
+
+class SendEventsResult(types.BaseModel):
+    error: typing.Optional[str] = None
+    ids: list[str]

--- a/inngest/_internal/errors.py
+++ b/inngest/_internal/errors.py
@@ -171,6 +171,19 @@ class RetryAfterError(Error):
         self.quiet: bool = quiet
 
 
+class SendEventsError(Error):
+    def __init__(self, message: str, ids: list[str]) -> None:
+        """
+        Args:
+        ----
+            message: Error message
+            ids: List of event IDs that successfully sent
+        """
+
+        super().__init__(message)
+        self.ids = ids
+
+
 class StepError(Error):
     """
     Wraps a userland error. This is necessary because the Executor sends

--- a/inngest/_internal/middleware_lib/middleware.py
+++ b/inngest/_internal/middleware_lib/middleware.py
@@ -28,6 +28,15 @@ class Middleware:
         """
         return None
 
+    async def after_send_events(
+        self,
+        result: client_lib.SendEventsResult,
+    ) -> None:
+        """
+        After sending events.
+        """
+        return None
+
     async def before_execution(self) -> None:
         """
         Before executing new code. Called multiple times per run when using
@@ -88,6 +97,15 @@ class MiddlewareSync:
         """
         After executing new code. Called multiple times per run when using
         steps.
+        """
+        return None
+
+    def after_send_events(
+        self,
+        result: client_lib.SendEventsResult,
+    ) -> None:
+        """
+        After sending events.
         """
         return None
 

--- a/tests/test_client/test_client_middleware.py
+++ b/tests/test_client/test_client_middleware.py
@@ -42,6 +42,7 @@ class TestClientMiddleware(unittest.IsolatedAsyncioTestCase):
         # Assert that the middleware hooks were called in the correct order
         assert state.hook_list == [
             "before_send_events",
+            "after_send_events",
             # Entry 1
             "transform_input",
             "before_execution",
@@ -52,6 +53,7 @@ class TestClientMiddleware(unittest.IsolatedAsyncioTestCase):
             "transform_input",
             "before_execution",
             "before_send_events",
+            "after_send_events",
             "after_execution",
             "transform_output",
             "before_response",
@@ -101,6 +103,12 @@ class TestClientMiddleware(unittest.IsolatedAsyncioTestCase):
         class Middleware(inngest.Middleware):
             async def after_execution(self) -> None:
                 state.hook_list.append("after_execution")
+
+            async def after_send_events(
+                self,
+                result: inngest.SendEventsResult,
+            ) -> None:
+                state.hook_list.append("after_send_events")
 
             async def before_response(self) -> None:
                 state.hook_list.append("before_response")
@@ -189,6 +197,12 @@ class TestClientMiddleware(unittest.IsolatedAsyncioTestCase):
         class Middleware(inngest.MiddlewareSync):
             def after_execution(self) -> None:
                 state.hook_list.append("after_execution")
+
+            def after_send_events(
+                self,
+                result: inngest.SendEventsResult,
+            ) -> None:
+                state.hook_list.append("after_send_events")
 
             def before_response(self) -> None:
                 state.hook_list.append("before_response")

--- a/tests/test_function/cases/function_middleware.py
+++ b/tests/test_function/cases/function_middleware.py
@@ -42,6 +42,12 @@ def create(
         def after_execution(self) -> None:
             state.messages.append("hook:after_execution")
 
+        def after_send_events(
+            self,
+            result: inngest.SendEventsResult,
+        ) -> None:
+            state.messages.append("hook:after_send_events")
+
         def before_response(self) -> None:
             state.messages.append("hook:before_response")
 
@@ -49,7 +55,7 @@ def create(
             state.messages.append("hook:before_execution")
 
         def before_send_events(self, events: list[inngest.Event]) -> None:
-            state.messages.append("before_send_events")
+            state.messages.append("hook:before_send_events")
 
         def transform_input(
             self,
@@ -78,6 +84,12 @@ def create(
         async def after_execution(self) -> None:
             state.messages.append("hook:after_execution")
 
+        async def after_send_events(
+            self,
+            result: inngest.SendEventsResult,
+        ) -> None:
+            state.messages.append("hook:after_send_events")
+
         async def before_response(self) -> None:
             state.messages.append("hook:before_response")
 
@@ -88,7 +100,7 @@ def create(
             self,
             events: list[inngest.Event],
         ) -> None:
-            state.messages.append("before_send_events")
+            state.messages.append("hook:before_send_events")
 
         async def transform_input(
             self,
@@ -186,7 +198,8 @@ def create(
             "fn_logic: before step_1",
             "hook:before_execution",
             "fn_logic: after step_1",
-            "before_send_events",
+            "hook:before_send_events",
+            "hook:after_send_events",
             "hook:after_execution",
             "hook:transform_output",
             "hook:before_response",


### PR DESCRIPTION
- Add `after_send_events` middleware hook
- Raise new `SendEventsError` when the Event API responds with an error (could be a partial error)