### PR TITLE
Separate execution layer

### DIFF
--- a/inngest/__init__.py
+++ b/inngest/__init__.py
@@ -4,7 +4,8 @@
 from ._internal.client_lib import Inngest, SendEventsResult
 from ._internal.errors import NonRetriableError, RetryAfterError, StepError
 from ._internal.event_lib import Event
-from ._internal.function import Context, Function
+from ._internal.execution import Context
+from ._internal.function import Function
 from ._internal.function_config import (
     Batch,
     Cancel,

--- a/inngest/_internal/client_lib/client.py
+++ b/inngest/_internal/client_lib/client.py
@@ -13,6 +13,7 @@ from inngest._internal import (
     env_lib,
     errors,
     event_lib,
+    execution,
     function,
     function_config,
     middleware_lib,
@@ -205,7 +206,7 @@ class Inngest:
         ] = None,
         name: typing.Optional[str] = None,
         on_failure: typing.Union[
-            function.FunctionHandlerAsync, function.FunctionHandlerSync, None
+            execution.FunctionHandlerAsync, execution.FunctionHandlerSync, None
         ] = None,
         priority: typing.Optional[function_config.Priority] = None,
         rate_limit: typing.Optional[function_config.RateLimit] = None,
@@ -223,7 +224,7 @@ class Inngest:
     ) -> typing.Callable[
         [
             typing.Union[
-                function.FunctionHandlerAsync, function.FunctionHandlerSync
+                execution.FunctionHandlerAsync, execution.FunctionHandlerSync
             ]
         ],
         function.Function,
@@ -252,11 +253,10 @@ class Inngest:
 
         def decorator(
             func: typing.Union[
-                function.FunctionHandlerAsync, function.FunctionHandlerSync
+                execution.FunctionHandlerAsync, execution.FunctionHandlerSync
             ],
         ) -> function.Function:
             triggers = trigger if isinstance(trigger, list) else [trigger]
-
             return function.Function(
                 function.FunctionOpts(
                     batch_events=batch_events,

--- a/inngest/_internal/comm.py
+++ b/inngest/_internal/comm.py
@@ -349,8 +349,9 @@ class CommHandler:
             return await self._respond(Exception("events not in request"))
 
         call_res = await fn.call(
+            call.ctx,
             self._client,
-            function.Context(
+            execution.Context(
                 attempt=call.ctx.attempt,
                 event=call.event,
                 events=events,
@@ -423,7 +424,7 @@ class CommHandler:
 
         call_res = fn.call_sync(
             self._client,
-            function.Context(
+            execution.Context(
                 attempt=call.ctx.attempt,
                 event=call.event,
                 events=events,

--- a/inngest/_internal/execution/__init__.py
+++ b/inngest/_internal/execution/__init__.py
@@ -1,0 +1,25 @@
+from .consts import UNSPECIFIED_STEP_ID
+from .models import (
+    Call,
+    CallContext,
+    CallResult,
+    Context,
+    FunctionHandlerAsync,
+    FunctionHandlerSync,
+    Output,
+    ReportedStep,
+    UserError,
+)
+
+__all__ = [
+    "Call",
+    "CallContext",
+    "CallResult",
+    "Context",
+    "FunctionHandlerAsync",
+    "FunctionHandlerSync",
+    "Output",
+    "ReportedStep",
+    "UNSPECIFIED_STEP_ID",
+    "UserError",
+]

--- a/inngest/_internal/execution/consts.py
+++ b/inngest/_internal/execution/consts.py
@@ -1,0 +1,2 @@
+# If the Executor sends this step ID then it isn't targeting a specific step.
+UNSPECIFIED_STEP_ID = "step"

--- a/inngest/_internal/execution/models.py
+++ b/inngest/_internal/execution/models.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import typing
+
+import pydantic
+
+from inngest._internal import errors, event_lib, transforms, types
+
+if typing.TYPE_CHECKING:
+    from inngest._internal import step_lib
+
+
+class Call(types.BaseModel):
+    ctx: CallContext
+    event: event_lib.Event
+    events: typing.Optional[list[event_lib.Event]] = None
+    steps: dict[str, object]
+    use_api: bool
+
+
+class CallContext(types.BaseModel):
+    attempt: int
+    run_id: str
+    stack: CallStack
+
+
+class CallStack(types.BaseModel):
+    stack: list[str]
+
+
+@dataclasses.dataclass
+class CallResult:
+    error: typing.Optional[Exception] = None
+
+    # Multiple results from a single call (only used for steps). This will only
+    # be longer than 1 for parallel steps. Otherwise, it will be 1 long for
+    # sequential steps
+    multi: typing.Optional[list[CallResult]] = None
+
+    # Need a sentinel value to differentiate between None and unset
+    output: object = types.empty_sentinel
+
+    # Step metadata (e.g. user-specified ID)
+    step: typing.Optional[step_lib.StepInfo] = None
+
+    @property
+    def is_empty(self) -> bool:
+        return all(
+            [
+                self.error is None,
+                self.multi is None,
+                self.output is types.empty_sentinel,
+                self.step is None,
+            ]
+        )
+
+    @classmethod
+    def from_responses(
+        cls,
+        responses: list[step_lib.StepResponse],
+    ) -> CallResult:
+        multi = []
+
+        for response in responses:
+            error = None
+            if isinstance(response.original_error, Exception):
+                error = response.original_error
+
+            multi.append(
+                cls(
+                    error=error,
+                    output=response.output,
+                    step=response.step,
+                )
+            )
+
+        return cls(multi=multi)
+
+
+@dataclasses.dataclass
+class Context:
+    attempt: int
+    event: event_lib.Event
+    events: list[event_lib.Event]
+    logger: types.Logger
+    run_id: str
+
+
+@typing.runtime_checkable
+class FunctionHandlerAsync(typing.Protocol):
+    def __call__(
+        self,
+        ctx: Context,
+        step: step_lib.Step,
+    ) -> typing.Awaitable[types.JSON]:
+        ...
+
+
+@typing.runtime_checkable
+class FunctionHandlerSync(typing.Protocol):
+    def __call__(
+        self,
+        ctx: Context,
+        step: step_lib.StepSync,
+    ) -> types.JSON:
+        ...
+
+
+class Output(types.BaseModel):
+    # Fail validation if any extra fields exist, because this will prevent
+    # accidentally assuming user data is nested data
+    model_config = pydantic.ConfigDict(extra="forbid")
+
+    data: object = None
+    error: typing.Optional[MemoizedError] = None
+
+
+class MemoizedError(types.BaseModel):
+    message: str
+    name: str
+    stack: typing.Optional[str] = None
+
+    @classmethod
+    def from_error(cls, err: Exception) -> MemoizedError:
+        return cls(
+            message=str(err),
+            name=type(err).__name__,
+            stack=transforms.get_traceback(err),
+        )
+
+
+class ReportedStep:
+    def __init__(
+        self,
+        step_signal: asyncio.Future[ReportedStep],
+        step_info: step_lib.StepInfo,
+    ) -> None:
+        self.error: typing.Optional[errors.StepError] = None
+        self.info = step_info
+        self.output: object = types.empty_sentinel
+        self.skip = False
+        self._release_signal = step_signal
+        self._done_signal = asyncio.Future[None]()
+
+    async def __aenter__(self) -> ReportedStep:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        self._done_signal.set_result(None)
+
+    async def release(self) -> None:
+        if self._release_signal.done():
+            return
+
+        self._release_signal.set_result(self)
+        await self._release_signal
+
+    async def release_and_skip(self) -> None:
+        self.skip = True
+        await self.release()
+
+    def on_done(
+        self,
+        callback: typing.Callable[[], typing.Coroutine[None, None, None]],
+    ) -> None:
+        self._done_signal.add_done_callback(
+            lambda _: asyncio.create_task(callback())
+        )
+
+    async def wait(self) -> None:
+        await self._done_signal
+
+
+class UserError(Exception):
+    """
+    Wrap an error that occurred in user code.
+    """
+
+    def __init__(self, err: Exception) -> None:
+        self.err = err

--- a/inngest/_internal/middleware_lib/log.py
+++ b/inngest/_internal/middleware_lib/log.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from inngest._internal import client_lib, function, step_lib, types
+from inngest._internal import client_lib, execution, function, step_lib, types
 
 from .middleware import MiddlewareSync
 
@@ -43,7 +43,7 @@ class LoggerMiddleware(MiddlewareSync):
 
     def transform_input(
         self,
-        ctx: function.Context,
+        ctx: execution.Context,
         function: function.Function,
         steps: step_lib.StepMemos,
     ) -> None:

--- a/inngest/_internal/middleware_lib/manager.py
+++ b/inngest/_internal/middleware_lib/manager.py
@@ -218,7 +218,7 @@ class MiddlewareManager:
 
     async def transform_input(
         self,
-        ctx: function.Context,
+        ctx: execution.Context,
         function: function.Function,
         steps: step_lib.StepMemos,
     ) -> types.MaybeError[None]:
@@ -242,7 +242,7 @@ class MiddlewareManager:
 
     def transform_input_sync(
         self,
-        ctx: function.Context,
+        ctx: execution.Context,
         function: function.Function,
         steps: step_lib.StepMemos,
     ) -> types.MaybeError[None]:

--- a/inngest/_internal/middleware_lib/middleware.py
+++ b/inngest/_internal/middleware_lib/middleware.py
@@ -75,7 +75,7 @@ class Middleware:
 
     async def transform_input(
         self,
-        ctx: function.Context,
+        ctx: execution.Context,
         function: function.Function,
         steps: step_lib.StepMemos,
     ) -> None:
@@ -162,7 +162,7 @@ class MiddlewareSync:
 
     def transform_input(
         self,
-        ctx: function.Context,
+        ctx: execution.Context,
         function: function.Function,
         steps: step_lib.StepMemos,
     ) -> None:
@@ -202,5 +202,5 @@ class TransformOutputResult:
 @dataclasses.dataclass
 class TransformOutputStepInfo:
     id: str
-    op: execution.Opcode
+    op: step_lib.Opcode
     opts: typing.Optional[dict[str, object]]

--- a/inngest/_internal/orchestrator/__init__.py
+++ b/inngest/_internal/orchestrator/__init__.py
@@ -1,0 +1,9 @@
+from .base import BaseOrchestrator, BaseOrchestratorSync
+from .v0 import OrchestratorV0, OrchestratorV0Sync
+
+__all__ = [
+    "BaseOrchestrator",
+    "BaseOrchestratorSync",
+    "OrchestratorV0",
+    "OrchestratorV0Sync",
+]

--- a/inngest/_internal/orchestrator/base.py
+++ b/inngest/_internal/orchestrator/base.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import typing
+
+if typing.TYPE_CHECKING:
+    from inngest._internal import client_lib, execution, function, step_lib
+
+
+class BaseOrchestrator(typing.Protocol):
+    version: str
+
+    async def report_step(
+        self,
+        step_info: step_lib.StepInfo,
+        inside_parallel: bool,
+    ) -> execution.ReportedStep:
+        ...
+
+    async def run(
+        self,
+        client: client_lib.Inngest,
+        ctx: execution.Context,
+        handler: typing.Union[
+            execution.FunctionHandlerAsync, execution.FunctionHandlerSync
+        ],
+        fn: function.Function,
+    ) -> execution.CallResult:
+        ...
+
+
+class BaseOrchestratorSync(typing.Protocol):
+    version: str
+
+    def run(
+        self,
+        client: client_lib.Inngest,
+        ctx: execution.Context,
+        handler: typing.Union[
+            execution.FunctionHandlerAsync, execution.FunctionHandlerSync
+        ],
+        fn: function.Function,
+    ) -> execution.CallResult:
+        ...

--- a/inngest/_internal/orchestrator/utils.py
+++ b/inngest/_internal/orchestrator/utils.py
@@ -1,0 +1,18 @@
+import inspect
+import typing
+
+import typing_extensions
+
+from ..execution.models import FunctionHandlerAsync, FunctionHandlerSync
+
+
+def is_function_handler_async(
+    value: typing.Union[FunctionHandlerAsync, FunctionHandlerSync],
+) -> typing_extensions.TypeGuard[FunctionHandlerAsync]:
+    return inspect.iscoroutinefunction(value)
+
+
+def is_function_handler_sync(
+    value: typing.Union[FunctionHandlerAsync, FunctionHandlerSync],
+) -> typing_extensions.TypeGuard[FunctionHandlerSync]:
+    return not inspect.iscoroutinefunction(value)

--- a/inngest/_internal/orchestrator/v0.py
+++ b/inngest/_internal/orchestrator/v0.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import asyncio
+import typing
+
+from inngest._internal import errors, execution, step_lib, transforms, types
+
+from .utils import is_function_handler_async, is_function_handler_sync
+
+if typing.TYPE_CHECKING:
+    from inngest._internal import client_lib, function, middleware_lib
+
+
+class OrchestratorV0:
+    version = "0"
+
+    def __init__(
+        self,
+        memos: step_lib.StepMemos,
+        middleware: middleware_lib.MiddlewareManager,
+        target_hashed_id: typing.Optional[str],
+    ) -> None:
+        self._memos = memos
+        self._middleware = middleware
+        self._target_hashed_id = target_hashed_id
+
+    def _handle_skip(
+        self,
+        step_info: step_lib.StepInfo,
+    ) -> None:
+        """
+        Handle a skip interrupt. Step targeting is enabled and this step is not
+        the target then skip the step.
+        """
+
+        is_targeting_enabled = self._target_hashed_id is not None
+        is_targeted = self._target_hashed_id == step_info.id
+        if is_targeting_enabled and not is_targeted:
+            # Skip this step because a different step is targeted.
+            raise step_lib.SkipInterrupt(step_info.display_name)
+
+    async def report_step(
+        self,
+        step_info: step_lib.StepInfo,
+        inside_parallel: bool,
+    ) -> execution.ReportedStep:
+        step_signal = asyncio.Future[execution.ReportedStep]()
+
+        step = execution.ReportedStep(step_signal, step_info)
+        await step.release()
+
+        memo = self._memos.pop(step.info.id)
+
+        # If there are no more memos then all future code is new.
+        if self._memos.size == 0:
+            await self._middleware.before_execution()
+
+        if not isinstance(memo, types.EmptySentinel):
+            if memo.error is not None:
+                step.error = errors.StepError(
+                    message=memo.error.message,
+                    name=memo.error.name,
+                    stack=memo.error.stack,
+                )
+            elif not isinstance(memo.data, types.EmptySentinel):
+                step.output = memo.data
+
+            return step
+
+        self._handle_skip(step_info)
+
+        is_targeting_enabled = self._target_hashed_id is not None
+        if inside_parallel and not is_targeting_enabled:
+            if step_info.op == step_lib.Opcode.STEP_RUN:
+                step_info.op = step_lib.Opcode.PLANNED
+
+            # Plan this step because we're in parallel mode.
+            raise step_lib.ResponseInterrupt(
+                step_lib.StepResponse(step=step_info)
+            )
+
+        if step_info.op == step_lib.Opcode.STEP_RUN:
+            return step
+
+        raise step_lib.ResponseInterrupt(step_lib.StepResponse(step=step_info))
+
+    async def run(
+        self,
+        client: client_lib.Inngest,
+        ctx: execution.Context,
+        handler: typing.Union[
+            execution.FunctionHandlerAsync, execution.FunctionHandlerSync
+        ],
+        fn: function.Function,
+    ) -> execution.CallResult:
+        # Give middleware the opportunity to change some of params passed to the
+        # user's handler.
+        middleware_err = await self._middleware.transform_input(
+            ctx,
+            fn,
+            self._memos,
+        )
+        if isinstance(middleware_err, Exception):
+            return execution.CallResult(middleware_err)
+
+        # No memoized data means we're calling the function for the first time.
+        if self._memos.size == 0:
+            err = await self._middleware.before_execution()
+            if isinstance(err, Exception):
+                return execution.CallResult(err)
+
+        try:
+            output: object
+
+            try:
+                # # Determine whether the handler is async (i.e. if we need to await
+                # # it). Sync functions are OK in async contexts, so it's OK if the
+                # # handler is sync.
+                if is_function_handler_async(handler):
+                    output = await handler(
+                        ctx=ctx,
+                        step=step_lib.Step(
+                            client,
+                            self,
+                            self._memos,
+                            self._middleware,
+                            step_lib.StepIDCounter(),
+                            self._target_hashed_id,
+                        ),
+                    )
+                elif is_function_handler_sync(handler):
+                    output = handler(
+                        ctx=ctx,
+                        step=step_lib.StepSync(
+                            client,
+                            self._memos,
+                            self._middleware,
+                            step_lib.StepIDCounter(),
+                            self._target_hashed_id,
+                        ),
+                    )
+                else:
+                    # Should be unreachable but Python's custom type guards don't
+                    # support negative checks :(
+                    return execution.CallResult(
+                        errors.UnknownError(
+                            "unable to determine function handler type"
+                        )
+                    )
+            except Exception as user_err:
+                transforms.remove_first_traceback_frame(user_err)
+                raise execution.UserError(user_err)
+
+            err = await self._middleware.after_execution()
+            if isinstance(err, Exception):
+                return execution.CallResult(err)
+
+            return execution.CallResult(output=output)
+        except step_lib.ResponseInterrupt as interrupt:
+            err = await self._middleware.after_execution()
+            if isinstance(err, Exception):
+                return execution.CallResult(err)
+
+            return execution.CallResult.from_responses(interrupt.responses)
+        except execution.UserError as err:
+            return execution.CallResult(err.err)
+        except step_lib.SkipInterrupt as err:
+            # This should only happen in a non-deterministic scenario, where
+            # step targeting is enabled and an unexpected step is encountered.
+            # We don't currently have a way to recover from this scenario.
+
+            return execution.CallResult(
+                errors.StepUnexpectedError(
+                    f'found step "{err.step_id}" when targeting a different step'
+                )
+            )
+        except Exception as err:
+            return execution.CallResult(err)
+
+
+class OrchestratorV0Sync:
+    version = "0"
+
+    def __init__(
+        self,
+        memos: step_lib.StepMemos,
+        middleware: middleware_lib.MiddlewareManager,
+        target_hashed_id: typing.Optional[str],
+    ) -> None:
+        self._memos = memos
+        self._middleware = middleware
+        self._target_hashed_id = target_hashed_id
+
+    def run(
+        self,
+        client: client_lib.Inngest,
+        ctx: execution.Context,
+        handler: typing.Union[
+            execution.FunctionHandlerAsync, execution.FunctionHandlerSync
+        ],
+        fn: function.Function,
+    ) -> execution.CallResult:
+        # Give middleware the opportunity to change some of params passed to the
+        # user's handler.
+        middleware_err = self._middleware.transform_input_sync(
+            ctx, fn, self._memos
+        )
+        if isinstance(middleware_err, Exception):
+            return execution.CallResult(middleware_err)
+
+        # No memoized data means we're calling the function for the first time.
+        if self._memos.size == 0:
+            err = self._middleware.before_execution_sync()
+            if isinstance(err, Exception):
+                return execution.CallResult(err)
+
+        try:
+            if is_function_handler_sync(handler):
+                try:
+                    output: object = handler(
+                        ctx=ctx,
+                        step=step_lib.StepSync(
+                            client,
+                            self._memos,
+                            self._middleware,
+                            step_lib.StepIDCounter(),
+                            self._target_hashed_id,
+                        ),
+                    )
+                except Exception as user_err:
+                    transforms.remove_first_traceback_frame(user_err)
+                    raise execution.UserError(user_err)
+            else:
+                return execution.CallResult(
+                    errors.AsyncUnsupportedError(
+                        "encountered async function in non-async context"
+                    )
+                )
+
+            err = self._middleware.after_execution_sync()
+            if isinstance(err, Exception):
+                return execution.CallResult(err)
+
+            return execution.CallResult(output=output)
+        except step_lib.ResponseInterrupt as interrupt:
+            err = self._middleware.after_execution_sync()
+            if isinstance(err, Exception):
+                return execution.CallResult(err)
+
+            return execution.CallResult.from_responses(interrupt.responses)
+        except execution.UserError as err:
+            return execution.CallResult(err.err)
+        except step_lib.SkipInterrupt as err:
+            # This should only happen in a non-deterministic scenario, where
+            # step targeting is enabled and an unexpected step is encountered.
+            # We don't currently have a way to recover from this scenario.
+
+            return execution.CallResult(
+                errors.StepUnexpectedError(
+                    f'found step "{err.step_id}" when targeting a different step'
+                )
+            )
+        except Exception as err:
+            return execution.CallResult(err)

--- a/inngest/_internal/step_lib/__init__.py
+++ b/inngest/_internal/step_lib/__init__.py
@@ -1,12 +1,25 @@
-from .base import ResponseInterrupt, SkipInterrupt, StepIDCounter, StepMemos
+from .base import (
+    Opcode,
+    ParsedStepID,
+    ResponseInterrupt,
+    SkipInterrupt,
+    StepIDCounter,
+    StepInfo,
+    StepMemos,
+    StepResponse,
+)
 from .step_async import Step
 from .step_sync import StepSync
 
 __all__ = [
+    "ParsedStepID",
     "ResponseInterrupt",
     "SkipInterrupt",
     "Step",
     "StepIDCounter",
+    "StepInfo",
     "StepMemos",
+    "Opcode",
+    "StepResponse",
     "StepSync",
 ]

--- a/inngest/_internal/step_lib/step_sync.py
+++ b/inngest/_internal/step_lib/step_sync.py
@@ -1,18 +1,18 @@
+from __future__ import annotations
+
 import datetime
 import typing
 
 import typing_extensions
 
-from inngest._internal import errors, event_lib, execution, transforms, types
+from inngest._internal import errors, event_lib, transforms, types
 from inngest._internal.client_lib import models as client_models
 
 from . import base
 
 # Avoid circular import at runtime
 if typing.TYPE_CHECKING:
-    from inngest._internal.function import Function
-else:
-    Function = object
+    from inngest._internal import function
 
 
 class StepSync(base.StepBase):
@@ -20,7 +20,7 @@ class StepSync(base.StepBase):
         self,
         step_id: str,
         *,
-        function: Function,
+        function: function.Function,
         data: typing.Optional[types.JSON] = None,
         timeout: typing.Union[int, datetime.timedelta, None] = None,
         user: typing.Optional[types.JSON] = None,
@@ -116,12 +116,12 @@ class StepSync(base.StepBase):
             raise opts
 
         raise base.ResponseInterrupt(
-            execution.StepResponse(
-                step=execution.StepInfo(
+            base.StepResponse(
+                step=base.StepInfo(
                     display_name=parsed_step_id.user_facing,
                     id=parsed_step_id.hashed,
                     name=parsed_step_id.user_facing,
-                    op=execution.Opcode.INVOKE,
+                    op=base.Opcode.INVOKE,
                     opts=opts,
                 )
             )
@@ -142,7 +142,7 @@ class StepSync(base.StepBase):
         self._inside_parallel = True
 
         outputs = tuple[types.T]()
-        responses: list[execution.StepResponse] = []
+        responses: list[base.StepResponse] = []
         for cb in callables:
             try:
                 output = cb()
@@ -189,12 +189,12 @@ class StepSync(base.StepBase):
         if self._inside_parallel and not is_targeting_enabled:
             # Plan this step because we're in parallel mode.
             raise base.ResponseInterrupt(
-                execution.StepResponse(
-                    step=execution.StepInfo(
+                base.StepResponse(
+                    step=base.StepInfo(
                         display_name=parsed_step_id.user_facing,
                         id=parsed_step_id.hashed,
                         name=parsed_step_id.user_facing,
-                        op=execution.Opcode.PLANNED,
+                        op=base.Opcode.PLANNED,
                     )
                 )
             )
@@ -207,13 +207,13 @@ class StepSync(base.StepBase):
             output = handler(*handler_args)
 
             raise base.ResponseInterrupt(
-                execution.StepResponse(
+                base.StepResponse(
                     output=output,
-                    step=execution.StepInfo(
+                    step=base.StepInfo(
                         display_name=parsed_step_id.user_facing,
                         id=parsed_step_id.hashed,
                         name=parsed_step_id.user_facing,
-                        op=execution.Opcode.STEP_RUN,
+                        op=base.Opcode.STEP_RUN,
                     ),
                 )
             )
@@ -224,12 +224,12 @@ class StepSync(base.StepBase):
             transforms.remove_first_traceback_frame(err)
 
             raise base.ResponseInterrupt(
-                execution.StepResponse(
+                base.StepResponse(
                     original_error=err,
-                    step=execution.StepInfo(
+                    step=base.StepInfo(
                         display_name=parsed_step_id.user_facing,
                         id=parsed_step_id.hashed,
-                        op=execution.Opcode.STEP_ERROR,
+                        op=base.Opcode.STEP_ERROR,
                     ),
                 )
             )
@@ -331,12 +331,12 @@ class StepSync(base.StepBase):
             raise err
 
         raise base.ResponseInterrupt(
-            execution.StepResponse(
-                step=execution.StepInfo(
+            base.StepResponse(
+                step=base.StepInfo(
                     display_name=parsed_step_id.user_facing,
                     id=parsed_step_id.hashed,
                     name=transforms.to_iso_utc(until),
-                    op=execution.Opcode.SLEEP,
+                    op=base.Opcode.SLEEP,
                 )
             )
         )
@@ -392,12 +392,12 @@ class StepSync(base.StepBase):
             raise opts
 
         raise base.ResponseInterrupt(
-            execution.StepResponse(
-                step=execution.StepInfo(
+            base.StepResponse(
+                step=base.StepInfo(
                     display_name=parsed_step_id.user_facing,
                     id=parsed_step_id.hashed,
                     name=event,
-                    op=execution.Opcode.WAIT_FOR_EVENT,
+                    op=base.Opcode.WAIT_FOR_EVENT,
                     opts=opts,
                 )
             )

--- a/tests/test_function/cases/middleware_parallel_steps.py
+++ b/tests/test_function/cases/middleware_parallel_steps.py
@@ -1,6 +1,6 @@
 import inngest
 import tests.helper
-from inngest._internal import const, execution, middleware_lib
+from inngest._internal import const, middleware_lib, step_lib
 
 from . import base
 
@@ -94,7 +94,7 @@ def create(
                     output="1.1 (step)",
                     step=middleware_lib.TransformOutputStepInfo(
                         id="1.1",
-                        op=execution.Opcode.STEP_RUN,
+                        op=step_lib.Opcode.STEP_RUN,
                         opts=None,
                     ),
                 ),
@@ -103,7 +103,7 @@ def create(
                     output="1.2 (step)",
                     step=middleware_lib.TransformOutputStepInfo(
                         id="1.2",
-                        op=execution.Opcode.STEP_RUN,
+                        op=step_lib.Opcode.STEP_RUN,
                         opts=None,
                     ),
                 ),


### PR DESCRIPTION
Move execution orchestration out of the `function` package and into the `execution` and `orchestrator` packages. These 2 new packages are not combined into 1 because of circular import issues