### PR TITLE
Fix ctx.stack.stack is not optional

### DIFF
--- a/inngest/_internal/execution.py
+++ b/inngest/_internal/execution.py
@@ -25,7 +25,7 @@ class CallContext(types.BaseModel):
 
 
 class CallStack(types.BaseModel):
-    stack: typing.Optional[list[str]]
+    stack: typing.Optional[list[str]] = None
 
 
 class CallError(types.BaseModel):


### PR DESCRIPTION
Fix `ctx.stack.stack` is not optional. It may be `None` because Inngest servers use Go, which defaults slices to `nil`. In other words, even though the `stack` field appears non-nullable in our Go code it can actually be null if it defaults