### PR TITLE
Handle disable_immediate_execution

### DIFF
--- a/inngest/_internal/comm_lib/handler.py
+++ b/inngest/_internal/comm_lib/handler.py
@@ -370,6 +370,7 @@ class CommHandler:
             ),
             params.fn_id,
             middleware,
+            request,
             step_lib.StepMemos.from_raw(steps),
             params.step_id,
         )

--- a/inngest/_internal/comm_lib/handler.py
+++ b/inngest/_internal/comm_lib/handler.py
@@ -273,7 +273,7 @@ class CommHandler:
             ),
             params.fn_id,
             middleware,
-            request.ctx.stack.stack or [],
+            request,
             step_lib.StepMemos.from_raw(steps),
             params.step_id,
         )

--- a/inngest/_internal/execution_lib/experimental.py
+++ b/inngest/_internal/execution_lib/experimental.py
@@ -98,6 +98,7 @@ class ExecutionExperimental:
                             self,
                             self._memos,
                             self._middleware,
+                            self._request,
                             step_lib.StepIDCounter(),
                             self._target_hashed_id,
                         ),
@@ -109,6 +110,7 @@ class ExecutionExperimental:
                             client,
                             self._memos,
                             self._middleware,
+                            self._request,
                             step_lib.StepIDCounter(),
                             self._target_hashed_id,
                         ),
@@ -289,11 +291,13 @@ class ExecutionV0Sync:
         self,
         memos: step_lib.StepMemos,
         middleware: middleware_lib.MiddlewareManager,
+        request: server_lib.ServerRequest,
     ) -> None:
         self._condition = asyncio.Condition()
         self._memos = memos
         self._middleware = middleware
         self._pending_report_count = 0
+        self._request = request
 
     def run(
         self,
@@ -329,6 +333,7 @@ class ExecutionV0Sync:
                             client,
                             self._memos,
                             self._middleware,
+                            self._request,
                             step_lib.StepIDCounter(),
                             target_hashed_id,
                         ),

--- a/inngest/_internal/function.py
+++ b/inngest/_internal/function.py
@@ -132,7 +132,7 @@ class Function:
         ctx: execution_lib.Context,
         fn_id: str,
         middleware: middleware_lib.MiddlewareManager,
-        stack: list[str],
+        request: server_lib.ServerRequest,
         steps: step_lib.StepMemos,
         target_hashed_id: typing.Optional[str],
     ) -> execution_lib.CallResult:
@@ -162,7 +162,7 @@ class Function:
             execution = execution_lib.ExecutionExperimental(
                 steps,
                 middleware,
-                stack,
+                request,
                 target_hashed_id,
             )
         else:

--- a/inngest/_internal/function.py
+++ b/inngest/_internal/function.py
@@ -169,6 +169,7 @@ class Function:
             execution = execution_lib.ExecutionV0(
                 steps,
                 middleware,
+                request,
                 target_hashed_id,
             )
 
@@ -195,6 +196,7 @@ class Function:
         ctx: execution_lib.Context,
         fn_id: str,
         middleware: middleware_lib.MiddlewareManager,
+        request: server_lib.ServerRequest,
         steps: step_lib.StepMemos,
         target_hashed_id: typing.Optional[str],
     ) -> execution_lib.CallResult:
@@ -222,6 +224,7 @@ class Function:
         call_res = execution_lib.ExecutionV0Sync(
             steps,
             middleware,
+            request,
             target_hashed_id,
         ).run(
             client,

--- a/inngest/_internal/server_lib/execution_request.py
+++ b/inngest/_internal/server_lib/execution_request.py
@@ -17,6 +17,7 @@ class ServerRequest(types.BaseModel):
 
 class ServerRequestCtx(types.BaseModel):
     attempt: int
+    disable_immediate_execution: bool
     run_id: str
     stack: ServerRequestCtxStack
 

--- a/inngest/_internal/step_lib/base.py
+++ b/inngest/_internal/step_lib/base.py
@@ -87,6 +87,7 @@ class StepBase:
         client: client_lib.Inngest,
         memos: StepMemos,
         middleware: middleware_lib.MiddlewareManager,
+        request: server_lib.ServerRequest,
         step_id_counter: StepIDCounter,
         target_hashed_id: typing.Optional[str],
     ) -> None:
@@ -94,6 +95,7 @@ class StepBase:
         self._inside_parallel = False
         self._memos = memos
         self._middleware = middleware
+        self._request = request
         self._step_id_counter = step_id_counter
         self._target_hashed_id = target_hashed_id
 

--- a/inngest/_internal/step_lib/step_async.py
+++ b/inngest/_internal/step_lib/step_async.py
@@ -22,6 +22,7 @@ class Step(base.StepBase):
         exe: execution_lib.BaseExecution,
         memos: base.StepMemos,
         middleware: middleware_lib.MiddlewareManager,
+        request: server_lib.ServerRequest,
         step_id_counter: base.StepIDCounter,
         target_hashed_id: typing.Optional[str],
     ) -> None:
@@ -29,6 +30,7 @@ class Step(base.StepBase):
             client,
             memos,
             middleware,
+            request,
             step_id_counter,
             target_hashed_id,
         )

--- a/tests/test_function/cases/__init__.py
+++ b/tests/test_function/cases/__init__.py
@@ -4,6 +4,7 @@ from inngest._internal import server_lib
 from . import (
     asyncio_first_completed,
     asyncio_gather,
+    asyncio_immediate_execution,
     base,
     batch_that_needs_api,
     cancel,
@@ -47,6 +48,7 @@ from . import (
 _modules = (
     asyncio_gather,
     asyncio_first_completed,
+    asyncio_immediate_execution,
     batch_that_needs_api,
     cancel,
     change_step_error,

--- a/tests/test_function/cases/asyncio_first_completed.py
+++ b/tests/test_function/cases/asyncio_first_completed.py
@@ -105,10 +105,6 @@ def create(
         await step.run("after", after)
 
     async def run_test(self: base.TestClass) -> None:
-        if is_sync:
-            # This test is not applicable for sync functions
-            return
-
         self.client.send_sync(inngest.Event(name=event_name))
         tests.helper.client.wait_for_run_status(
             state.wait_for_run_id(),


### PR DESCRIPTION
Properly handle `disable_immediate_execution`. When this field is true, the Inngest Server is saying "plan each new step" (i.e. 2 HTTP requests per step)