### PR TITLE
Fix step.parallel broken for steps besides step.run

### DIFF
--- a/inngest/_internal/execution_lib/base.py
+++ b/inngest/_internal/execution_lib/base.py
@@ -2,8 +2,17 @@ from __future__ import annotations
 
 import typing
 
+from .models import (
+    CallResult,
+    Context,
+    FunctionHandlerAsync,
+    FunctionHandlerSync,
+    ReportedStep,
+    ReportedStepSync,
+)
+
 if typing.TYPE_CHECKING:
-    from inngest._internal import client_lib, execution_lib, function, step_lib
+    from inngest._internal import client_lib, function, step_lib
 
 
 class BaseExecution(typing.Protocol):
@@ -13,33 +22,40 @@ class BaseExecution(typing.Protocol):
         self,
         step_info: step_lib.StepInfo,
         inside_parallel: bool,
-    ) -> execution_lib.ReportedStep:
+    ) -> ReportedStep:
         ...
 
     async def run(
         self,
         client: client_lib.Inngest,
-        ctx: execution_lib.Context,
+        ctx: Context,
         handler: typing.Union[
-            execution_lib.FunctionHandlerAsync,
-            execution_lib.FunctionHandlerSync,
+            FunctionHandlerAsync,
+            FunctionHandlerSync,
         ],
         fn: function.Function,
-    ) -> execution_lib.CallResult:
+    ) -> CallResult:
         ...
 
 
 class BaseExecutionSync(typing.Protocol):
     version: str
 
+    def report_step(
+        self,
+        step_info: step_lib.StepInfo,
+        inside_parallel: bool,
+    ) -> ReportedStepSync:
+        ...
+
     def run(
         self,
         client: client_lib.Inngest,
-        ctx: execution_lib.Context,
+        ctx: Context,
         handler: typing.Union[
-            execution_lib.FunctionHandlerAsync,
-            execution_lib.FunctionHandlerSync,
+            FunctionHandlerAsync,
+            FunctionHandlerSync,
         ],
         fn: function.Function,
-    ) -> execution_lib.CallResult:
+    ) -> CallResult:
         ...

--- a/inngest/_internal/execution_lib/experimental.py
+++ b/inngest/_internal/execution_lib/experimental.py
@@ -17,6 +17,7 @@ from .utils import (
     is_function_handler_sync,
     wait_for_next_loop,
 )
+from .v0 import ExecutionV0Sync
 
 if typing.TYPE_CHECKING:
     from inngest._internal import client_lib, function, middleware_lib
@@ -38,6 +39,12 @@ class ExecutionExperimental:
         self._request = request
         self._skipped_steps: list[execution_lib.ReportedStep] = []
         self._staged_steps: list[execution_lib.ReportedStep] = []
+        self._sync = ExecutionV0Sync(
+            memos,
+            middleware,
+            request,
+            target_hashed_id,
+        )
         self._target_hashed_id = target_hashed_id
 
     async def report_step(
@@ -108,6 +115,7 @@ class ExecutionExperimental:
                         ctx=ctx,
                         step=step_lib.StepSync(
                             client,
+                            self._sync,
                             self._memos,
                             self._middleware,
                             self._request,
@@ -235,13 +243,19 @@ class ExecutionExperimental:
         self._staged_steps = []
 
     def _plan(self) -> None:
-        if (
+        # Skip plan if all of the following are true:
+        # - There's only one step
+        # - The step is a step.run
+        # - Immediate execution is not disabled
+        # The above scenario happens if we find a new step.run and there haven't
+        # been parallel steps
+        skip_plan = (
             len(self._pending_steps) == 1
+            and next(iter(self._pending_steps.values())).info.op
+            == server_lib.Opcode.STEP_RUN
             and self._request.ctx.disable_immediate_execution is False
-        ):
-            # Don't plan since there aren't parallel steps and the Server didn't
-            # disable immediate execution. We expect immediate execution to be
-            # disabled if we previously had parallel steps
+        )
+        if skip_plan:
             return
 
         plans = []
@@ -284,92 +298,3 @@ class ExecutionExperimental:
 
         for step in self._staged_steps:
             self._pending_steps.pop(step.info.id)
-
-
-class ExecutionV0Sync:
-    def __init__(
-        self,
-        memos: step_lib.StepMemos,
-        middleware: middleware_lib.MiddlewareManager,
-        request: server_lib.ServerRequest,
-    ) -> None:
-        self._condition = asyncio.Condition()
-        self._memos = memos
-        self._middleware = middleware
-        self._pending_report_count = 0
-        self._request = request
-
-    def run(
-        self,
-        client: client_lib.Inngest,
-        ctx: execution_lib.Context,
-        handler: typing.Union[
-            execution_lib.FunctionHandlerAsync,
-            execution_lib.FunctionHandlerSync,
-        ],
-        fn: function.Function,
-        target_hashed_id: typing.Optional[str],
-    ) -> execution_lib.CallResult:
-        # Give middleware the opportunity to change some of params passed to the
-        # user's handler.
-        middleware_err = self._middleware.transform_input_sync(
-            ctx, fn, self._memos
-        )
-        if isinstance(middleware_err, Exception):
-            return execution_lib.CallResult(middleware_err)
-
-        # No memoized data means we're calling the function for the first time.
-        if self._memos.size == 0:
-            err = self._middleware.before_execution_sync()
-            if isinstance(err, Exception):
-                return execution_lib.CallResult(err)
-
-        try:
-            if is_function_handler_sync(handler):
-                try:
-                    output: object = handler(
-                        ctx=ctx,
-                        step=step_lib.StepSync(
-                            client,
-                            self._memos,
-                            self._middleware,
-                            self._request,
-                            step_lib.StepIDCounter(),
-                            target_hashed_id,
-                        ),
-                    )
-                except Exception as user_err:
-                    transforms.remove_first_traceback_frame(user_err)
-                    raise execution_lib.UserError(user_err)
-            else:
-                return execution_lib.CallResult(
-                    errors.AsyncUnsupportedError(
-                        "encountered async function in non-async context"
-                    )
-                )
-
-            err = self._middleware.after_execution_sync()
-            if isinstance(err, Exception):
-                return execution_lib.CallResult(err)
-
-            return execution_lib.CallResult(output=output)
-        except step_lib.ResponseInterrupt as interrupt:
-            err = self._middleware.after_execution_sync()
-            if isinstance(err, Exception):
-                return execution_lib.CallResult(err)
-
-            return execution_lib.CallResult.from_responses(interrupt.responses)
-        except execution_lib.UserError as err:
-            return execution_lib.CallResult(err.err)
-        except step_lib.SkipInterrupt as err:
-            # This should only happen in a non-deterministic scenario, where
-            # step targeting is enabled and an unexpected step is encountered.
-            # We don't currently have a way to recover from this scenario.
-
-            return execution_lib.CallResult(
-                errors.StepUnexpectedError(
-                    f'found step "{err.step_id}" when targeting a different step'
-                )
-            )
-        except Exception as err:
-            return execution_lib.CallResult(err)

--- a/inngest/_internal/execution_lib/models.py
+++ b/inngest/_internal/execution_lib/models.py
@@ -130,6 +130,20 @@ class ReportedStep:
         await self._done_signal
 
 
+class ReportedStepSync:
+    def __init__(self, step_info: step_lib.StepInfo) -> None:
+        self.error: typing.Optional[errors.StepError] = None
+        self.info = step_info
+        self.output: object = types.empty_sentinel
+        self.skip = False
+
+    def __enter__(self) -> ReportedStepSync:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        pass
+
+
 class UserError(Exception):
     """
     Wrap an error that occurred in user code.

--- a/inngest/_internal/execution_lib/v0.py
+++ b/inngest/_internal/execution_lib/v0.py
@@ -3,15 +3,17 @@ from __future__ import annotations
 import asyncio
 import typing
 
-from inngest._internal import (
-    errors,
-    execution_lib,
-    server_lib,
-    step_lib,
-    transforms,
-    types,
-)
+from inngest._internal import errors, server_lib, step_lib, transforms, types
 
+from .models import (
+    CallResult,
+    Context,
+    FunctionHandlerAsync,
+    FunctionHandlerSync,
+    ReportedStep,
+    ReportedStepSync,
+    UserError,
+)
 from .utils import is_function_handler_async, is_function_handler_sync
 
 if typing.TYPE_CHECKING:
@@ -31,6 +33,12 @@ class ExecutionV0:
         self._memos = memos
         self._middleware = middleware
         self._request = request
+        self._sync = ExecutionV0Sync(
+            memos,
+            middleware,
+            request,
+            target_hashed_id,
+        )
         self._target_hashed_id = target_hashed_id
 
     def _handle_skip(
@@ -52,10 +60,10 @@ class ExecutionV0:
         self,
         step_info: step_lib.StepInfo,
         inside_parallel: bool,
-    ) -> execution_lib.ReportedStep:
-        step_signal = asyncio.Future[execution_lib.ReportedStep]()
+    ) -> ReportedStep:
+        step_signal = asyncio.Future[ReportedStep]()
 
-        step = execution_lib.ReportedStep(step_signal, step_info)
+        step = ReportedStep(step_signal, step_info)
         await step.release()
 
         memo = self._memos.pop(step.info.id)
@@ -110,13 +118,13 @@ class ExecutionV0:
     async def run(
         self,
         client: client_lib.Inngest,
-        ctx: execution_lib.Context,
+        ctx: Context,
         handler: typing.Union[
-            execution_lib.FunctionHandlerAsync,
-            execution_lib.FunctionHandlerSync,
+            FunctionHandlerAsync,
+            FunctionHandlerSync,
         ],
         fn: function.Function,
-    ) -> execution_lib.CallResult:
+    ) -> CallResult:
         # Give middleware the opportunity to change some of params passed to the
         # user's handler.
         middleware_err = await self._middleware.transform_input(
@@ -125,13 +133,13 @@ class ExecutionV0:
             self._memos,
         )
         if isinstance(middleware_err, Exception):
-            return execution_lib.CallResult(middleware_err)
+            return CallResult(middleware_err)
 
         # No memoized data means we're calling the function for the first time.
         if self._memos.size == 0:
             err = await self._middleware.before_execution()
             if isinstance(err, Exception):
-                return execution_lib.CallResult(err)
+                return CallResult(err)
 
         try:
             output: object
@@ -158,6 +166,7 @@ class ExecutionV0:
                         ctx=ctx,
                         step=step_lib.StepSync(
                             client,
+                            self._sync,
                             self._memos,
                             self._middleware,
                             self._request,
@@ -168,40 +177,40 @@ class ExecutionV0:
                 else:
                     # Should be unreachable but Python's custom type guards don't
                     # support negative checks :(
-                    return execution_lib.CallResult(
+                    return CallResult(
                         errors.UnknownError(
                             "unable to determine function handler type"
                         )
                     )
             except Exception as user_err:
                 transforms.remove_first_traceback_frame(user_err)
-                raise execution_lib.UserError(user_err)
+                raise UserError(user_err)
 
             err = await self._middleware.after_execution()
             if isinstance(err, Exception):
-                return execution_lib.CallResult(err)
+                return CallResult(err)
 
-            return execution_lib.CallResult(output=output)
+            return CallResult(output=output)
         except step_lib.ResponseInterrupt as interrupt:
             err = await self._middleware.after_execution()
             if isinstance(err, Exception):
-                return execution_lib.CallResult(err)
+                return CallResult(err)
 
-            return execution_lib.CallResult.from_responses(interrupt.responses)
-        except execution_lib.UserError as err:
-            return execution_lib.CallResult(err.err)
+            return CallResult.from_responses(interrupt.responses)
+        except UserError as err:
+            return CallResult(err.err)
         except step_lib.SkipInterrupt as err:
             # This should only happen in a non-deterministic scenario, where
             # step targeting is enabled and an unexpected step is encountered.
             # We don't currently have a way to recover from this scenario.
 
-            return execution_lib.CallResult(
+            return CallResult(
                 errors.StepUnexpectedError(
                     f'found step "{err.step_id}" when targeting a different step'
                 )
             )
         except Exception as err:
-            return execution_lib.CallResult(err)
+            return CallResult(err)
 
 
 class ExecutionV0Sync:
@@ -219,29 +228,100 @@ class ExecutionV0Sync:
         self._request = request
         self._target_hashed_id = target_hashed_id
 
+    def _handle_skip(
+        self,
+        step_info: step_lib.StepInfo,
+    ) -> None:
+        """
+        Handle a skip interrupt. Step targeting is enabled and this step is not
+        the target then skip the step.
+        """
+
+        is_targeting_enabled = self._target_hashed_id is not None
+        is_targeted = self._target_hashed_id == step_info.id
+        if is_targeting_enabled and not is_targeted:
+            # Skip this step because a different step is targeted.
+            raise step_lib.SkipInterrupt(step_info.display_name)
+
+    def report_step(
+        self,
+        step_info: step_lib.StepInfo,
+        inside_parallel: bool,
+    ) -> ReportedStepSync:
+        step = ReportedStepSync(step_info)
+
+        memo = self._memos.pop(step.info.id)
+
+        # If there are no more memos then all future code is new.
+        if self._memos.size == 0:
+            self._middleware.before_execution_sync()
+
+        if not isinstance(memo, types.EmptySentinel):
+            if memo.error is not None:
+                step.error = errors.StepError(
+                    message=memo.error.message,
+                    name=memo.error.name,
+                    stack=memo.error.stack,
+                )
+            elif not isinstance(memo.data, types.EmptySentinel):
+                step.output = memo.data
+
+            return step
+
+        self._handle_skip(step_info)
+
+        is_targeting_enabled = self._target_hashed_id is not None
+        if inside_parallel and not is_targeting_enabled:
+            if step_info.op == server_lib.Opcode.STEP_RUN:
+                step_info.op = server_lib.Opcode.PLANNED
+
+            # Plan this step because we're in parallel mode.
+            raise step_lib.ResponseInterrupt(
+                step_lib.StepResponse(step=step_info)
+            )
+
+        if (
+            step_info.op == server_lib.Opcode.STEP_RUN
+            and self._request.ctx.disable_immediate_execution is True
+            and not is_targeting_enabled
+        ):
+            # We should only get here when encountering a new, single step.run
+            # after parallel steps
+
+            step_info.op = server_lib.Opcode.PLANNED
+
+            raise step_lib.ResponseInterrupt(
+                step_lib.StepResponse(step=step_info)
+            )
+
+        if step_info.op == server_lib.Opcode.STEP_RUN:
+            return step
+
+        raise step_lib.ResponseInterrupt(step_lib.StepResponse(step=step_info))
+
     def run(
         self,
         client: client_lib.Inngest,
-        ctx: execution_lib.Context,
+        ctx: Context,
         handler: typing.Union[
-            execution_lib.FunctionHandlerAsync,
-            execution_lib.FunctionHandlerSync,
+            FunctionHandlerAsync,
+            FunctionHandlerSync,
         ],
         fn: function.Function,
-    ) -> execution_lib.CallResult:
+    ) -> CallResult:
         # Give middleware the opportunity to change some of params passed to the
         # user's handler.
         middleware_err = self._middleware.transform_input_sync(
             ctx, fn, self._memos
         )
         if isinstance(middleware_err, Exception):
-            return execution_lib.CallResult(middleware_err)
+            return CallResult(middleware_err)
 
         # No memoized data means we're calling the function for the first time.
         if self._memos.size == 0:
             err = self._middleware.before_execution_sync()
             if isinstance(err, Exception):
-                return execution_lib.CallResult(err)
+                return CallResult(err)
 
         try:
             if is_function_handler_sync(handler):
@@ -250,6 +330,7 @@ class ExecutionV0Sync:
                         ctx=ctx,
                         step=step_lib.StepSync(
                             client,
+                            self,
                             self._memos,
                             self._middleware,
                             self._request,
@@ -259,9 +340,9 @@ class ExecutionV0Sync:
                     )
                 except Exception as user_err:
                     transforms.remove_first_traceback_frame(user_err)
-                    raise execution_lib.UserError(user_err)
+                    raise UserError(user_err)
             else:
-                return execution_lib.CallResult(
+                return CallResult(
                     errors.AsyncUnsupportedError(
                         "encountered async function in non-async context"
                     )
@@ -269,26 +350,26 @@ class ExecutionV0Sync:
 
             err = self._middleware.after_execution_sync()
             if isinstance(err, Exception):
-                return execution_lib.CallResult(err)
+                return CallResult(err)
 
-            return execution_lib.CallResult(output=output)
+            return CallResult(output=output)
         except step_lib.ResponseInterrupt as interrupt:
             err = self._middleware.after_execution_sync()
             if isinstance(err, Exception):
-                return execution_lib.CallResult(err)
+                return CallResult(err)
 
-            return execution_lib.CallResult.from_responses(interrupt.responses)
-        except execution_lib.UserError as err:
-            return execution_lib.CallResult(err.err)
+            return CallResult.from_responses(interrupt.responses)
+        except UserError as err:
+            return CallResult(err.err)
         except step_lib.SkipInterrupt as err:
             # This should only happen in a non-deterministic scenario, where
             # step targeting is enabled and an unexpected step is encountered.
             # We don't currently have a way to recover from this scenario.
 
-            return execution_lib.CallResult(
+            return CallResult(
                 errors.StepUnexpectedError(
                     f'found step "{err.step_id}" when targeting a different step'
                 )
             )
         except Exception as err:
-            return execution_lib.CallResult(err)
+            return CallResult(err)

--- a/inngest/_internal/step_lib/step_sync.py
+++ b/inngest/_internal/step_lib/step_sync.py
@@ -12,10 +12,36 @@ from . import base
 
 # Avoid circular import at runtime
 if typing.TYPE_CHECKING:
-    from inngest._internal import function
+    from inngest._internal import (
+        client_lib,
+        execution_lib,
+        function,
+        middleware_lib,
+    )
 
 
 class StepSync(base.StepBase):
+    def __init__(
+        self,
+        client: client_lib.Inngest,
+        exe: execution_lib.BaseExecutionSync,
+        memos: base.StepMemos,
+        middleware: middleware_lib.MiddlewareManager,
+        request: server_lib.ServerRequest,
+        step_id_counter: base.StepIDCounter,
+        target_hashed_id: typing.Optional[str],
+    ) -> None:
+        super().__init__(
+            client,
+            memos,
+            middleware,
+            request,
+            step_id_counter,
+            target_hashed_id,
+        )
+
+        self._execution = exe
+
     def invoke(
         self,
         step_id: str,
@@ -115,17 +141,26 @@ class StepSync(base.StepBase):
         if isinstance(opts, Exception):
             raise opts
 
-        raise base.ResponseInterrupt(
-            base.StepResponse(
-                step=base.StepInfo(
-                    display_name=parsed_step_id.user_facing,
-                    id=parsed_step_id.hashed,
-                    name=parsed_step_id.user_facing,
-                    op=server_lib.Opcode.INVOKE,
-                    opts=opts,
-                )
-            )
+        step_info = base.StepInfo(
+            display_name=parsed_step_id.user_facing,
+            id=parsed_step_id.hashed,
+            name=parsed_step_id.user_facing,
+            op=server_lib.Opcode.INVOKE,
+            opts=opts,
         )
+
+        with self._execution.report_step(
+            step_info,
+            self._inside_parallel,
+        ) as step:
+            if step.skip:
+                raise base.SkipInterrupt(parsed_step_id.user_facing)
+            if step.error is not None:
+                raise step.error
+            elif not isinstance(step.output, types.EmptySentinel):
+                return step.output
+
+        raise Exception("unreachable")
 
     def parallel(
         self,
@@ -326,26 +361,25 @@ class StepSync(base.StepBase):
 
         parsed_step_id = self._parse_step_id(step_id)
 
-        memo = self._get_memo_sync(parsed_step_id.hashed)
-        if not isinstance(memo, types.EmptySentinel):
-            return memo.data  # type: ignore
-
-        self._handle_skip(parsed_step_id)
-
-        err = self._middleware.before_execution_sync()
-        if isinstance(err, Exception):
-            raise err
-
-        raise base.ResponseInterrupt(
-            base.StepResponse(
-                step=base.StepInfo(
-                    display_name=parsed_step_id.user_facing,
-                    id=parsed_step_id.hashed,
-                    name=transforms.to_iso_utc(until),
-                    op=server_lib.Opcode.SLEEP,
-                )
-            )
+        step_info = base.StepInfo(
+            display_name=parsed_step_id.user_facing,
+            id=parsed_step_id.hashed,
+            name=transforms.to_iso_utc(until),
+            op=server_lib.Opcode.SLEEP,
         )
+
+        with self._execution.report_step(
+            step_info,
+            self._inside_parallel,
+        ) as step:
+            if step.skip:
+                raise base.SkipInterrupt(parsed_step_id.user_facing)
+            if step.error is not None:
+                raise step.error
+            elif not isinstance(step.output, types.EmptySentinel):
+                return step.output  # type: ignore
+
+        raise Exception("unreachable")
 
     def wait_for_event(
         self,
@@ -397,14 +431,28 @@ class StepSync(base.StepBase):
         if isinstance(opts, Exception):
             raise opts
 
-        raise base.ResponseInterrupt(
-            base.StepResponse(
-                step=base.StepInfo(
-                    display_name=parsed_step_id.user_facing,
-                    id=parsed_step_id.hashed,
-                    name=event,
-                    op=server_lib.Opcode.WAIT_FOR_EVENT,
-                    opts=opts,
-                )
-            )
+        step_info = base.StepInfo(
+            id=parsed_step_id.hashed,
+            display_name=parsed_step_id.user_facing,
+            name=event,
+            op=server_lib.Opcode.WAIT_FOR_EVENT,
+            opts=opts,
         )
+
+        with self._execution.report_step(
+            step_info,
+            self._inside_parallel,
+        ) as step:
+            if step.skip:
+                raise base.SkipInterrupt(parsed_step_id.user_facing)
+            if step.error is not None:
+                raise step.error
+            elif not isinstance(step.output, types.EmptySentinel):
+                if step.output is None:
+                    # Timeout
+                    return None
+
+                # Fulfilled by an event
+                return server_lib.Event.model_validate(step.output)
+
+        raise Exception("unreachable")

--- a/tests/test_function/cases/asyncio_first_completed.py
+++ b/tests/test_function/cases/asyncio_first_completed.py
@@ -43,7 +43,7 @@ def create(
         ctx: inngest.Context,
         step: inngest.Step,
     ) -> None:
-        await asyncio.sleep(1)
+        await step.sleep("sleep", datetime.timedelta(seconds=1))
 
     @client.create_function(
         fn_id=fn_id,

--- a/tests/test_function/cases/asyncio_gather.py
+++ b/tests/test_function/cases/asyncio_gather.py
@@ -35,7 +35,7 @@ def create(
         ctx: inngest.Context,
         step: inngest.Step,
     ) -> None:
-        await asyncio.sleep(1)
+        await step.sleep("sleep", datetime.timedelta(seconds=1))
 
     @client.create_function(
         fn_id=fn_id,


### PR DESCRIPTION
- Fix `step.parallel` broken for steps besides `step.run`
- Fix experimental execution broken when encountering a new, non-`step.run` while immediate execution is not disabled