### PR TITLE
Fix type error when returning TypedDict

### DIFF
--- a/inngest/_internal/const.py
+++ b/inngest/_internal/const.py
@@ -5,7 +5,7 @@ DEFAULT_API_ORIGIN: typing.Final = "https://api.inngest.com/"
 DEFAULT_EVENT_ORIGIN: typing.Final = "https://inn.gs/"
 DEV_SERVER_ORIGIN: typing.Final = "http://127.0.0.1:8288/"
 LANGUAGE: typing.Final = "py"
-VERSION: typing.Final = "0.4.4"
+VERSION: typing.Final = "0.4.5"
 
 
 class EnvKey(enum.Enum):

--- a/inngest/_internal/types.py
+++ b/inngest/_internal/types.py
@@ -23,36 +23,22 @@ class EmptySentinel:
 empty_sentinel = EmptySentinel()
 
 
-# Type checking conditional is necessary because of some mutual exclusivity
-# between Mypy and Pydantic. Seems like recursive types are finicky right now,
-# but hopefully we can simplify this code as support improves
-if typing.TYPE_CHECKING:
-    # Mypy uses this statically. Pydantic can't use this at runtime since it'll
-    # error with "name 'JSON' is not defined"
-    JSON = typing.Union[
+# Ideally this would be recursive, but we can't do that for 2 reasons:
+# 1. TypedDict is compatible with Mapping[str, object], but not anything with a
+#   more restrictive value type (e.g. Mapping[str, "JSON"])
+# 2. Mypy errors with "possible cyclic definition"
+JSON = typing_extensions.TypeAliasType(
+    "JSON",
+    typing.Union[
         bool,
-        float,
         int,
+        float,
         str,
-        typing.Mapping[str, "JSON"],
-        typing.Sequence["JSON"],
+        typing.Mapping[str, object],
+        typing.Sequence[object],
         None,
-    ]
-else:
-    # Pydantic uses this at runtime. Mypy can't use this since it'll error with
-    # "possible cyclic definition"
-    JSON = typing_extensions.TypeAliasType(
-        "JSON",
-        typing.Union[
-            bool,
-            int,
-            float,
-            str,
-            dict[str, "JSON"],
-            list["JSON"],
-            None,
-        ],
-    )
+    ],
+)
 
 
 JSONT = typing.TypeVar("JSONT", bound=JSON)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.4.4"
+version = "0.4.5"
 description = "Python SDK for Inngest"
 readme = "README.md"
 classifiers = [

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -341,3 +341,63 @@ def parallel_iterator() -> None:
 
         output = step.parallel(steps)
         assert_type(output, tuple[bool, ...])
+
+
+def step_return_types() -> None:
+    """
+    Test that a sync function cannot use an async step type
+    """
+
+    class MyTypedDict(typing.TypedDict):
+        foo: str
+
+    @client.create_function(
+        fn_id="foo",
+        trigger=inngest.TriggerEvent(event="foo"),
+    )
+    async def fn(
+        ctx: inngest.Context,
+        step: inngest.Step,
+    ) -> None:
+        def fn_bool() -> bool:
+            return True
+
+        assert_type(await step.run("fn_bool", fn_bool), bool)
+
+        def fn_int() -> int:
+            return 1
+
+        assert_type(await step.run("fn_int", fn_int), int)
+
+        def fn_float() -> float:
+            return 1.0
+
+        assert_type(await step.run("fn_float", fn_float), float)
+
+        def fn_str() -> str:
+            return "foo"
+
+        assert_type(await step.run("fn_str", fn_str), str)
+
+        def fn_dict() -> dict[str, int]:
+            return {"foo": 1}
+
+        assert_type(await step.run("fn_dict", fn_dict), dict[str, int])
+
+        class MyTypedDict(typing.TypedDict):
+            foo: str
+
+        def fn_typed_dict() -> MyTypedDict:
+            return {"foo": "bar"}
+
+        assert_type(await step.run("fn_typed_dict", fn_typed_dict), MyTypedDict)
+
+        def fn_list() -> list[dict[str, int]]:
+            return [{"foo": 1}]
+
+        assert_type(await step.run("fn_list", fn_list), list[dict[str, int]])
+
+        def fn_none() -> None:
+            return None
+
+        assert_type(await step.run("fn_none", fn_none), None)


### PR DESCRIPTION
Fix a type error when returning `TypedDict` in a step or function.

This happened because our `JSON` type contains `Mapping[str, "JSON"]` (it's recursive), but `TypedDict` is compatible with `Mapping[str, object]`