### PR TITLE
Add INNGEST_BASE_URL; allow INNGEST_DEV URLs

### DIFF
--- a/inngest/_internal/client_lib/utils.py
+++ b/inngest/_internal/client_lib/utils.py
@@ -1,0 +1,57 @@
+import typing
+
+from inngest._internal import const, env_lib, net, server_lib, types
+
+
+def get_api_origin(
+    constructor_param: typing.Optional[str],
+    mode: server_lib.ServerKind,
+) -> types.MaybeError[str]:
+    """
+    Get the API origin, properly considering precedence.
+
+    Args:
+    ----
+        constructor_param: Inngest client constructor's api_base_url param.
+        mode: Server mode.
+    """
+
+    origin = (
+        constructor_param
+        or env_lib.get_url(const.EnvKey.API_BASE_URL)
+        or env_lib.get_url(const.EnvKey.BASE_URL)
+        or env_lib.get_url(const.EnvKey.DEV)
+    )
+    if origin is None:
+        if mode == server_lib.ServerKind.DEV_SERVER:
+            origin = const.DEV_SERVER_ORIGIN
+        else:
+            origin = const.DEFAULT_API_ORIGIN
+    return net.parse_url(origin)
+
+
+def get_event_api_origin(
+    constructor_param: typing.Optional[str],
+    mode: server_lib.ServerKind,
+) -> types.MaybeError[str]:
+    """
+    Get the Event API origin, properly considering precedence.
+
+    Args:
+    ----
+        constructor_param: Inngest client constructor's event_api_base_url param.
+        mode: Server mode.
+    """
+
+    origin = (
+        constructor_param
+        or env_lib.get_url(const.EnvKey.EVENT_API_BASE_URL)
+        or env_lib.get_url(const.EnvKey.BASE_URL)
+        or env_lib.get_url(const.EnvKey.DEV)
+    )
+    if origin is None:
+        if mode == server_lib.ServerKind.DEV_SERVER:
+            origin = const.DEV_SERVER_ORIGIN
+        else:
+            origin = const.DEFAULT_EVENT_API_ORIGIN
+    return net.parse_url(origin)

--- a/inngest/_internal/comm_lib/handler.py
+++ b/inngest/_internal/comm_lib/handler.py
@@ -105,29 +105,13 @@ class CommHandler:
     def __init__(
         self,
         *,
-        api_base_url: typing.Optional[str] = None,
         client: client_lib.Inngest,
         framework: server_lib.Framework,
         functions: list[function.Function],
     ) -> None:
         self._client = client
-
         self._mode = client._mode
-
-        api_base_url = api_base_url or os.getenv(
-            const.EnvKey.API_BASE_URL.value
-        )
-        if api_base_url is None:
-            if self._mode == server_lib.ServerKind.DEV_SERVER:
-                api_base_url = const.DEV_SERVER_ORIGIN
-            else:
-                api_base_url = const.DEFAULT_API_ORIGIN
-
-        try:
-            self._api_origin = net.parse_url(api_base_url)
-        except Exception as err:
-            raise errors.URLInvalidError() from err
-
+        self._api_origin = client.api_origin
         self._fns = {fn.get_id(): fn for fn in functions}
         self._framework = framework
 
@@ -601,6 +585,8 @@ class CommHandler:
             signing_key=self._signing_key,
             signing_key_fallback=self._signing_key_fallback,
         )
+        if isinstance(res, Exception):
+            return res
 
         return self._parse_registration_response(res)
 
@@ -651,6 +637,8 @@ class CommHandler:
             signing_key=self._signing_key,
             signing_key_fallback=self._signing_key_fallback,
         )
+        if isinstance(res, Exception):
+            return res
 
         return self._parse_registration_response(res)
 

--- a/inngest/_internal/comm_lib/handler_test.py
+++ b/inngest/_internal/comm_lib/handler_test.py
@@ -11,7 +11,12 @@ from .handler import CommHandler
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
-client = inngest.Inngest(app_id="test", is_production=False, logger=logger)
+client = inngest.Inngest(
+    api_base_url="http://foo.bar",
+    app_id="test",
+    is_production=False,
+    logger=logger,
+)
 
 
 class Test_get_function_configs(unittest.TestCase):
@@ -52,7 +57,6 @@ class Test_get_function_configs(unittest.TestCase):
             return 1
 
         handler = CommHandler(
-            api_base_url="http://foo.bar",
             client=client,
             framework=server_lib.Framework.FLASK,
             functions=[fn],
@@ -67,7 +71,6 @@ class Test_get_function_configs(unittest.TestCase):
         functions: list[inngest.Function] = []
 
         handler = CommHandler(
-            api_base_url="http://foo.bar",
             client=client,
             framework=server_lib.Framework.FLASK,
             functions=functions,

--- a/inngest/_internal/const.py
+++ b/inngest/_internal/const.py
@@ -2,7 +2,7 @@ import enum
 import typing
 
 DEFAULT_API_ORIGIN: typing.Final = "https://api.inngest.com/"
-DEFAULT_EVENT_ORIGIN: typing.Final = "https://inn.gs/"
+DEFAULT_EVENT_API_ORIGIN: typing.Final = "https://inn.gs/"
 DEV_SERVER_ORIGIN: typing.Final = "http://127.0.0.1:8288/"
 LANGUAGE: typing.Final = "py"
 VERSION: typing.Final = "0.4.5"
@@ -10,7 +10,14 @@ VERSION: typing.Final = "0.4.5"
 
 class EnvKey(enum.Enum):
     API_BASE_URL = "INNGEST_API_BASE_URL"
+
+    # Sets both API and EVENT base URLs. API_BASE_URL and EVENT_API_BASE_URL
+    # take precedence
+    BASE_URL = "INNGEST_BASE_URL"
+
+    # Can be a boolean string ("true", "1", "false", "0") or a URL
     DEV = "INNGEST_DEV"
+
     EVENT_API_BASE_URL = "INNGEST_EVENT_API_BASE_URL"
     EVENT_KEY = "INNGEST_EVENT_KEY"
     ENV = "INNGEST_ENV"

--- a/inngest/_internal/env_lib.py
+++ b/inngest/_internal/env_lib.py
@@ -26,6 +26,7 @@ def get_url(env_var: const.EnvKey) -> typing.Optional[str]:
     val = os.getenv(env_var.value)
     if val is None:
         return None
+    val = val.strip()
 
     parsed = net.parse_url(val)
     if isinstance(parsed, Exception):
@@ -38,8 +39,9 @@ def is_truthy(env_var: const.EnvKey) -> bool:
     val = os.getenv(env_var.value)
     if val is None:
         return False
+    val = val.strip()
 
-    if val.lower() in ("false", "0"):
+    if val.lower() in ("false", "0", ""):
         return False
 
     return True

--- a/inngest/_internal/env_lib.py
+++ b/inngest/_internal/env_lib.py
@@ -1,7 +1,7 @@
 import os
 import typing
 
-from . import const
+from . import const, net
 
 
 def get_environment_name() -> typing.Optional[str]:
@@ -18,12 +18,28 @@ def get_environment_name() -> typing.Optional[str]:
     )
 
 
-def is_true(env_var: const.EnvKey) -> bool:
+def get_url(env_var: const.EnvKey) -> typing.Optional[str]:
+    """
+    Get a URL from an env var. Returns None if the env var is not set or if its value is not a valid URL
+    """
+
+    val = os.getenv(env_var.value)
+    if val is None:
+        return None
+
+    parsed = net.parse_url(val)
+    if isinstance(parsed, Exception):
+        return None
+
+    return parsed
+
+
+def is_truthy(env_var: const.EnvKey) -> bool:
     val = os.getenv(env_var.value)
     if val is None:
         return False
 
-    if val.lower() in ("true", "1"):
-        return True
+    if val.lower() in ("false", "0"):
+        return False
 
-    return False
+    return True

--- a/inngest/_internal/net_test.py
+++ b/inngest/_internal/net_test.py
@@ -249,6 +249,7 @@ class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
             signing_key=_signing_key,
             signing_key_fallback=_signing_key_fallback,
         )
+        assert not isinstance(res, Exception)
         assert res.status_code == 200
         assert req_count == 1
         req_count = 0
@@ -259,6 +260,7 @@ class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
             signing_key=_signing_key,
             signing_key_fallback=_signing_key_fallback,
         )
+        assert not isinstance(res, Exception)
         assert res.status_code == 200
         assert req_count == 1
 
@@ -294,6 +296,7 @@ class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
             signing_key=_signing_key,
             signing_key_fallback=_signing_key_fallback,
         )
+        assert not isinstance(res, Exception)
         assert res.status_code == 200
         assert req_count == 2
         req_count = 0
@@ -304,6 +307,7 @@ class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
             signing_key=_signing_key,
             signing_key_fallback=_signing_key_fallback,
         )
+        assert not isinstance(res, Exception)
         assert res.status_code == 200
         assert req_count == 2
 
@@ -339,6 +343,7 @@ class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
             signing_key="signkey-prod-aaaaaa",
             signing_key_fallback="signkey-prod-bbbbbb",
         )
+        assert not isinstance(res, Exception)
         assert res.status_code == 401
         assert req_count == 2
         req_count = 0
@@ -349,6 +354,7 @@ class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
             signing_key="signkey-prod-aaaaaa",
             signing_key_fallback="signkey-prod-bbbbbb",
         )
+        assert not isinstance(res, Exception)
         assert res.status_code == 401
         assert req_count == 2
 
@@ -379,6 +385,7 @@ class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
             signing_key=None,
             signing_key_fallback=None,
         )
+        assert not isinstance(res, Exception)
         assert res.status_code == 200
         assert req_count == 1
         req_count = 0
@@ -389,6 +396,7 @@ class Test_fetch_with_auth_fallback(unittest.IsolatedAsyncioTestCase):
             signing_key=None,
             signing_key_fallback=None,
         )
+        assert not isinstance(res, Exception)
         assert res.status_code == 200
         assert req_count == 1
 

--- a/inngest/digital_ocean.py
+++ b/inngest/digital_ocean.py
@@ -33,7 +33,6 @@ def serve(
     """
 
     handler = comm_lib.CommHandler(
-        api_base_url=client.api_origin,
         client=client,
         framework=FRAMEWORK,
         functions=functions,

--- a/inngest/django.py
+++ b/inngest/django.py
@@ -37,7 +37,6 @@ def serve(
     """
 
     handler = comm_lib.CommHandler(
-        api_base_url=client.api_origin,
         client=client,
         framework=FRAMEWORK,
         functions=functions,

--- a/inngest/fast_api.py
+++ b/inngest/fast_api.py
@@ -32,7 +32,6 @@ def serve(
     """
 
     handler = comm_lib.CommHandler(
-        api_base_url=client.api_origin,
         client=client,
         framework=FRAMEWORK,
         functions=functions,

--- a/inngest/flask.py
+++ b/inngest/flask.py
@@ -38,7 +38,6 @@ def serve(
     """
 
     handler = comm_lib.CommHandler(
-        api_base_url=client.api_origin,
         client=client,
         framework=FRAMEWORK,
         functions=functions,

--- a/inngest/tornado.py
+++ b/inngest/tornado.py
@@ -37,7 +37,6 @@ def serve(
         serve_path: Path to serve the functions from.
     """
     handler = comm_lib.CommHandler(
-        api_base_url=client.api_origin,
         client=client,
         framework=FRAMEWORK,
         functions=functions,


### PR DESCRIPTION
- Add `INNGEST_BASE_URL` support. This env var sets the origin for the 2 Inngest APIs (REST and Event), but has a lower precedence than `INNGEST_API_BASE_URL` and `INNGEST_EVENT_API_BASE_URL`.
- Allow `INNGEST_DEV` to be a URL.
- Catch and format raised errors when the SDK sends the sync request to an Inngest server. This can happen when the Inngest server is unreachable (e.g. misconfiguration when using Docker for local dev).