### PR TITLE
Sign responses

### DIFF
--- a/inngest/_internal/client_lib/client.py
+++ b/inngest/_internal/client_lib/client.py
@@ -102,10 +102,6 @@ class Inngest:
             const.EnvKey.SIGNING_KEY.value
         )
 
-        self._signing_key_fallback = signing_key or os.getenv(
-            const.EnvKey.SIGNING_KEY_FALLBACK.value
-        )
-
         self._signing_key_fallback = os.getenv(
             const.EnvKey.SIGNING_KEY_FALLBACK.value
         )

--- a/inngest/_internal/comm_lib/__init__.py
+++ b/inngest/_internal/comm_lib/__init__.py
@@ -1,7 +1,8 @@
 from .handler import CommHandler
-from .models import CommResponse
+from .models import CommRequest, CommResponse
 
 __all__ = [
     "CommHandler",
+    "CommRequest",
     "CommResponse",
 ]

--- a/inngest/_internal/comm_lib/handler.py
+++ b/inngest/_internal/comm_lib/handler.py
@@ -7,7 +7,6 @@ import typing
 import urllib.parse
 
 import httpx
-import typing_extensions
 
 from inngest._internal import (
     client_lib,
@@ -25,72 +24,11 @@ from inngest._internal import (
 
 from .models import (
     AuthenticatedInspection,
+    CommRequest,
     CommResponse,
     UnauthenticatedInspection,
 )
-from .utils import parse_query_params
-
-_ParamsT = typing_extensions.ParamSpec("_ParamsT")
-
-
-def _prep_response(
-    f: typing.Callable[
-        _ParamsT, typing.Awaitable[typing.Union[CommResponse, Exception]]
-    ],
-) -> typing.Callable[_ParamsT, typing.Awaitable[CommResponse]]:
-    async def inner(
-        *args: _ParamsT.args,
-        **kwargs: _ParamsT.kwargs,
-    ) -> CommResponse:
-        comm_handler = args[0]
-        if not isinstance(comm_handler, CommHandler):
-            raise ValueError("First argument must be a CommHandler instance.")
-
-        res = await f(*args, **kwargs)
-        if isinstance(res, Exception):
-            res = CommResponse.from_error(comm_handler._client.logger, res)
-
-        res.headers = {
-            **res.headers,
-            **net.create_headers(
-                env=comm_handler._client.env,
-                framework=comm_handler._framework,
-                server_kind=comm_handler._client._mode,
-            ),
-        }
-
-        return res
-
-    return inner
-
-
-def _prep_response_sync(
-    f: typing.Callable[_ParamsT, typing.Union[CommResponse, Exception]],
-) -> typing.Callable[_ParamsT, CommResponse]:
-    def inner(
-        *args: _ParamsT.args,
-        **kwargs: _ParamsT.kwargs,
-    ) -> CommResponse:
-        comm_handler = args[0]
-        if not isinstance(comm_handler, CommHandler):
-            raise ValueError("First argument must be a CommHandler instance.")
-
-        res = f(*args, **kwargs)
-        if isinstance(res, Exception):
-            res = CommResponse.from_error(comm_handler._client.logger, res)
-
-        res.headers = {
-            **res.headers,
-            **net.create_headers(
-                env=comm_handler._client.env,
-                framework=comm_handler._framework,
-                server_kind=comm_handler._client._mode,
-            ),
-        }
-
-        return res
-
-    return inner
+from .utils import parse_query_params, wrap_handler, wrap_handler_sync
 
 
 class CommHandler:
@@ -173,18 +111,15 @@ class CommHandler:
             timeout=30,
         )
 
-    @_prep_response
-    async def call_function(
+    @wrap_handler
+    async def post(
         self,
-        *,
-        body: bytes,
-        headers: typing.Union[dict[str, str], dict[str, list[str]]],
-        query_params: typing.Union[dict[str, str], dict[str, list[str]]],
-        raw_request: object,
+        req: CommRequest,
+        request_signing_key: types.MaybeError[typing.Optional[str]],
     ) -> typing.Union[CommResponse, Exception]:
         """Handle a function call from the Executor."""
 
-        headers = net.normalize_headers(headers)
+        headers = net.normalize_headers(req.headers)
 
         server_kind = transforms.get_server_kind(headers)
         if isinstance(server_kind, Exception):
@@ -193,12 +128,12 @@ class CommHandler:
 
         middleware = middleware_lib.MiddlewareManager.from_client(
             self._client,
-            raw_request,
+            req.raw_request,
         )
 
         # Validate the request signature.
         err = net.validate_request(
-            body=body,
+            body=req.body,
             headers=headers,
             mode=self._client._mode,
             signing_key=self._signing_key,
@@ -207,11 +142,11 @@ class CommHandler:
         if isinstance(err, Exception):
             return err
 
-        request = server_lib.ServerRequest.from_raw(body)
+        request = server_lib.ServerRequest.from_raw(req.body)
         if isinstance(request, Exception):
             return request
 
-        params = parse_query_params(query_params)
+        params = parse_query_params(req.query_params)
         if isinstance(params, Exception):
             return params
         if params.fn_id is None:
@@ -270,45 +205,36 @@ class CommHandler:
             server_kind,
         )
 
-    @_prep_response_sync
-    def call_function_sync(
+    @wrap_handler_sync
+    def post_sync(
         self,
-        *,
-        body: bytes,
-        headers: typing.Union[dict[str, str], dict[str, list[str]]],
-        query_params: typing.Union[dict[str, str], dict[str, list[str]]],
-        raw_request: object,
+        req: CommRequest,
+        # *,
+        # body: bytes,
+        # headers: typing.Union[dict[str, str], dict[str, str]],
+        # query_params: typing.Union[dict[str, str], dict[str, list[str]]],
+        # raw_request: object,
+        request_signing_key: types.MaybeError[typing.Optional[str]],
+        # serve_origin: typing.Optional[str],
+        # serve_path: typing.Optional[str],
     ) -> typing.Union[CommResponse, Exception]:
         """Handle a function call from the Executor."""
 
-        headers = net.normalize_headers(headers)
-
-        server_kind = transforms.get_server_kind(headers)
+        server_kind = transforms.get_server_kind(req.headers)
         if isinstance(server_kind, Exception):
             self._client.logger.error(server_kind)
             server_kind = None
 
         middleware = middleware_lib.MiddlewareManager.from_client(
             self._client,
-            raw_request,
+            req.raw_request,
         )
 
-        # Validate the request signature.
-        err = net.validate_request(
-            body=body,
-            headers=headers,
-            mode=self._client._mode,
-            signing_key=self._signing_key,
-            signing_key_fallback=self._signing_key_fallback,
-        )
-        if isinstance(err, Exception):
-            return err
-
-        request = server_lib.ServerRequest.from_raw(body)
+        request = server_lib.ServerRequest.from_raw(req.body)
         if isinstance(request, Exception):
             return request
 
-        params = parse_query_params(query_params)
+        params = parse_query_params(req.query_params)
         if isinstance(params, Exception):
             return params
         if params.fn_id is None:
@@ -406,20 +332,15 @@ class CommHandler:
             return errors.FunctionConfigInvalidError("no functions found")
         return configs
 
-    @_prep_response_sync
-    def inspect(
+    @wrap_handler_sync
+    def get_sync(
         self,
-        *,
-        body: bytes,
-        headers: typing.Union[dict[str, str], dict[str, list[str]]],
-        serve_origin: typing.Optional[str],
-        serve_path: typing.Optional[str],
-    ) -> CommResponse:
+        req: CommRequest,
+        request_signing_key: types.MaybeError[typing.Optional[str]],
+    ) -> types.MaybeError[CommResponse]:
         """Handle Dev Server's auto-discovery."""
 
-        headers = net.normalize_headers(headers)
-
-        server_kind = transforms.get_server_kind(headers)
+        server_kind = transforms.get_server_kind(req.headers)
         if isinstance(server_kind, Exception):
             self._client.logger.error(server_kind)
             server_kind = None
@@ -431,16 +352,23 @@ class CommHandler:
                 body={},
                 status_code=403,
             )
+
+        res_body: typing.Union[
+            AuthenticatedInspection, UnauthenticatedInspection
+        ]
+
+        is_signed_and_valid = isinstance(request_signing_key, str)
         # Validate the request signature.
         err = net.validate_request(
-            body=body,
-            headers=headers,
+            body=req.body,
+            headers=req.headers,
             mode=self._client._mode,
             signing_key=self._signing_key,
             signing_key_fallback=self._signing_key_fallback,
         )
-        if self._client._mode != server_lib.ServerKind.CLOUD or isinstance(
-            err, Exception
+        if (
+            self._client._mode != server_lib.ServerKind.CLOUD
+            or is_signed_and_valid is False
         ):
             authentication_succeeded = None
             if isinstance(err, Exception):
@@ -454,7 +382,7 @@ class CommHandler:
                 has_signing_key_fallback=self._signing_key_fallback is not None,
                 mode=self._mode,
             )
-        else:
+        elif is_signed_and_valid is True:
             event_key_hash = (
                 transforms.hash_event_key(self._client.event_key)
                 if self._client.event_key
@@ -486,14 +414,14 @@ class CommHandler:
                 has_signing_key=self._signing_key is not None,
                 has_signing_key_fallback=self._signing_key_fallback is not None,
                 mode=self._mode,
-                serve_origin=serve_origin,
-                serve_path=serve_path,
+                serve_origin=req.serve_origin,
+                serve_path=req.serve_path,
                 signing_key_fallback_hash=signing_key_fallback_hash,
                 signing_key_hash=signing_key_hash,
             )
 
         body_json = res_body.to_dict()
-        if isinstance(body, Exception):
+        if isinstance(req.body, Exception):
             body_json = {
                 "error": "failed to serialize inspection data",
             }
@@ -537,24 +465,20 @@ class CommHandler:
         comm_res.status_code = server_res.status_code
         return comm_res
 
-    @_prep_response
-    async def register(
+    @wrap_handler
+    async def put(
         self: CommHandler,
-        *,
-        headers: typing.Union[dict[str, str], dict[str, list[str]]],
-        query_params: typing.Union[dict[str, str], dict[str, list[str]]],
-        request_url: str,
-        serve_origin: typing.Optional[str],
-        serve_path: typing.Optional[str],
+        req: CommRequest,
+        request_signing_key: types.MaybeError[typing.Optional[str]],
     ) -> typing.Union[CommResponse, Exception]:
         """Handle a registration call."""
 
-        headers = net.normalize_headers(headers)
+        headers = net.normalize_headers(req.headers)
 
         app_url = net.create_serve_url(
-            request_url=request_url,
-            serve_origin=serve_origin,
-            serve_path=serve_path,
+            request_url=req.request_url,
+            serve_origin=req.serve_origin,
+            serve_path=req.serve_path,
         )
 
         server_kind = transforms.get_server_kind(headers)
@@ -566,22 +490,22 @@ class CommHandler:
         if comm_res is not None:
             return comm_res
 
-        params = parse_query_params(query_params)
+        params = parse_query_params(req.query_params)
         if isinstance(params, Exception):
             return params
 
-        req = self._build_register_request(
+        outgoing_req = self._build_register_request(
             app_url=app_url,
             server_kind=server_kind,
             sync_id=params.sync_id,
         )
-        if isinstance(req, Exception):
-            return req
+        if isinstance(outgoing_req, Exception):
+            return outgoing_req
 
         res = await net.fetch_with_auth_fallback(
             self._client._http_client,
             self._client._http_client_sync,
-            req,
+            outgoing_req,
             signing_key=self._signing_key,
             signing_key_fallback=self._signing_key_fallback,
         )
@@ -590,27 +514,21 @@ class CommHandler:
 
         return self._parse_registration_response(res)
 
-    @_prep_response_sync
-    def register_sync(
+    @wrap_handler_sync
+    def put_sync(
         self: CommHandler,
-        *,
-        headers: typing.Union[dict[str, str], dict[str, list[str]]],
-        query_params: typing.Union[dict[str, str], dict[str, list[str]]],
-        request_url: str,
-        serve_origin: typing.Optional[str],
-        serve_path: typing.Optional[str],
+        req: CommRequest,
+        request_signing_key: types.MaybeError[typing.Optional[str]],
     ) -> typing.Union[CommResponse, Exception]:
         """Handle a registration call."""
 
-        headers = net.normalize_headers(headers)
-
         app_url = net.create_serve_url(
-            request_url=request_url,
-            serve_origin=serve_origin,
-            serve_path=serve_path,
+            request_url=req.request_url,
+            serve_origin=req.serve_origin,
+            serve_path=req.serve_path,
         )
 
-        server_kind = transforms.get_server_kind(headers)
+        server_kind = transforms.get_server_kind(req.headers)
         if isinstance(server_kind, Exception):
             self._client.logger.error(server_kind)
             server_kind = None
@@ -619,21 +537,21 @@ class CommHandler:
         if comm_res is not None:
             return comm_res
 
-        params = parse_query_params(query_params)
+        params = parse_query_params(req.query_params)
         if isinstance(params, Exception):
             return params
 
-        req = self._build_register_request(
+        outgoing_req = self._build_register_request(
             app_url=app_url,
             server_kind=server_kind,
             sync_id=params.sync_id,
         )
-        if isinstance(req, Exception):
-            return req
+        if isinstance(outgoing_req, Exception):
+            return outgoing_req
 
         res = net.fetch_with_auth_fallback_sync(
             self._client._http_client_sync,
-            req,
+            outgoing_req,
             signing_key=self._signing_key,
             signing_key_fallback=self._signing_key_fallback,
         )

--- a/inngest/_internal/comm_lib/handler.py
+++ b/inngest/_internal/comm_lib/handler.py
@@ -111,7 +111,7 @@ class CommHandler:
             timeout=30,
         )
 
-    @wrap_handler
+    @wrap_handler()
     async def post(
         self,
         req: CommRequest,
@@ -130,17 +130,6 @@ class CommHandler:
             self._client,
             req.raw_request,
         )
-
-        # Validate the request signature.
-        err = net.validate_request(
-            body=req.body,
-            headers=headers,
-            mode=self._client._mode,
-            signing_key=self._signing_key,
-            signing_key_fallback=self._signing_key_fallback,
-        )
-        if isinstance(err, Exception):
-            return err
 
         request = server_lib.ServerRequest.from_raw(req.body)
         if isinstance(request, Exception):
@@ -205,7 +194,7 @@ class CommHandler:
             server_kind,
         )
 
-    @wrap_handler_sync
+    @wrap_handler_sync()
     def post_sync(
         self,
         req: CommRequest,
@@ -332,7 +321,7 @@ class CommHandler:
             return errors.FunctionConfigInvalidError("no functions found")
         return configs
 
-    @wrap_handler_sync
+    @wrap_handler_sync(require_signature=False)
     def get_sync(
         self,
         req: CommRequest,
@@ -465,7 +454,7 @@ class CommHandler:
         comm_res.status_code = server_res.status_code
         return comm_res
 
-    @wrap_handler
+    @wrap_handler(require_signature=False)
     async def put(
         self: CommHandler,
         req: CommRequest,
@@ -514,7 +503,7 @@ class CommHandler:
 
         return self._parse_registration_response(res)
 
-    @wrap_handler_sync
+    @wrap_handler_sync(require_signature=False)
     def put_sync(
         self: CommHandler,
         req: CommRequest,

--- a/inngest/_internal/comm_lib/handler_test.py
+++ b/inngest/_internal/comm_lib/handler_test.py
@@ -105,6 +105,8 @@ class TestSignatureVerification(unittest.IsolatedAsyncioTestCase):
             functions=functions,
         )
 
+        # Create a request that mimics an execution request, but without a
+        # signature
         req = CommRequest(
             body=b"{}",
             headers={},
@@ -118,6 +120,7 @@ class TestSignatureVerification(unittest.IsolatedAsyncioTestCase):
             serve_path=None,
         )
 
+        # Test both POST handlers
         for res in [await handler.post(req), handler.post_sync(req)]:
             assert res.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
             assert isinstance(res.body, dict)
@@ -139,6 +142,8 @@ class TestSignatureVerification(unittest.IsolatedAsyncioTestCase):
         body = b"{}"
         wrong_signing_key = "signkey-prod-111111"
 
+        # Create a request that mimics an execution request, but with an invalid
+        # signature
         req = CommRequest(
             body=body,
             headers={
@@ -157,6 +162,7 @@ class TestSignatureVerification(unittest.IsolatedAsyncioTestCase):
             serve_path=None,
         )
 
+        # Test both POST handlers
         for res in [await handler.post(req), handler.post_sync(req)]:
             assert res.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
             assert isinstance(res.body, dict)

--- a/inngest/_internal/comm_lib/handler_test.py
+++ b/inngest/_internal/comm_lib/handler_test.py
@@ -11,19 +11,11 @@ from .handler import CommHandler
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
-
-dev_client = inngest.Inngest(
+client = inngest.Inngest(
     api_base_url="http://foo.bar",
     app_id="test",
     is_production=False,
     logger=logger,
-)
-
-prod_client = inngest.Inngest(
-    api_base_url="http://foo.bar",
-    app_id="test",
-    logger=logger,
-    signing_key="signkey-prod-000000",
 )
 
 
@@ -39,7 +31,7 @@ class Test_get_function_configs(unittest.TestCase):
         fully-specified config.
         """
 
-        @dev_client.create_function(
+        @client.create_function(
             batch_events=inngest.Batch(
                 max_size=2, timeout=datetime.timedelta(minutes=1)
             ),
@@ -65,7 +57,7 @@ class Test_get_function_configs(unittest.TestCase):
             return 1
 
         handler = CommHandler(
-            client=dev_client,
+            client=client,
             framework=server_lib.Framework.FLASK,
             functions=[fn],
         )
@@ -79,7 +71,7 @@ class Test_get_function_configs(unittest.TestCase):
         functions: list[inngest.Function] = []
 
         handler = CommHandler(
-            client=dev_client,
+            client=client,
             framework=server_lib.Framework.FLASK,
             functions=functions,
         )

--- a/inngest/_internal/comm_lib/handler_test.py
+++ b/inngest/_internal/comm_lib/handler_test.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
 import datetime
-import http
 import logging
 import unittest
 
 import inngest
-from inngest._internal import errors, net, server_lib
+from inngest._internal import errors, server_lib
 
 from .handler import CommHandler
-from .models import CommRequest
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -89,81 +87,3 @@ class Test_get_function_configs(unittest.TestCase):
         configs = handler.get_function_configs("http://foo.bar")
         assert isinstance(configs, errors.FunctionConfigInvalidError)
         assert str(configs) == "no functions found"
-
-
-class TestSignatureVerification(unittest.IsolatedAsyncioTestCase):
-    async def test_post_without_signature(self) -> None:
-        # Ensure that a request without a signature is rejected. Ideally we'd
-        # test this during execution, but the Dev Server doesn't support signing
-        # keys yet
-
-        functions: list[inngest.Function] = []
-
-        handler = CommHandler(
-            client=prod_client,
-            framework=server_lib.Framework.FLASK,
-            functions=functions,
-        )
-
-        # Create a request that mimics an execution request, but without a
-        # signature
-        req = CommRequest(
-            body=b"{}",
-            headers={},
-            query_params={
-                "fnId": "fn",
-                "stepId": "step",
-            },
-            raw_request=None,
-            request_url="http://foo.local",
-            serve_origin=None,
-            serve_path=None,
-        )
-
-        # Test both POST handlers
-        for res in [await handler.post(req), handler.post_sync(req)]:
-            assert res.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
-            assert isinstance(res.body, dict)
-            assert res.body["code"] == "header_missing"
-
-    async def test_post_wrong_signing_key(self) -> None:
-        # Ensure that a request with an invalid signature is rejected. Ideally
-        # we'd test this during execution, but the Dev Server doesn't support
-        # signing keys yet
-
-        functions: list[inngest.Function] = []
-
-        handler = CommHandler(
-            client=prod_client,
-            framework=server_lib.Framework.FLASK,
-            functions=functions,
-        )
-
-        body = b"{}"
-        wrong_signing_key = "signkey-prod-111111"
-
-        # Create a request that mimics an execution request, but with an invalid
-        # signature
-        req = CommRequest(
-            body=body,
-            headers={
-                server_lib.HeaderKey.SIGNATURE.value: net.sign(
-                    body,
-                    wrong_signing_key,
-                ),
-            },
-            query_params={
-                "fnId": "fn",
-                "stepId": "step",
-            },
-            raw_request=None,
-            request_url="http://foo.local",
-            serve_origin=None,
-            serve_path=None,
-        )
-
-        # Test both POST handlers
-        for res in [await handler.post(req), handler.post_sync(req)]:
-            assert res.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
-            assert isinstance(res.body, dict)
-            assert res.body["code"] == "sig_verification_failed"

--- a/inngest/_internal/comm_lib/models.py
+++ b/inngest/_internal/comm_lib/models.py
@@ -181,12 +181,19 @@ class CommResponse:
 
         return d
 
-    def sign(self, signing_key: str) -> types.MaybeError[str]:
+    def sign(self, signing_key: str) -> types.MaybeError[None]:
         body_bytes = self.body_bytes()
         if isinstance(body_bytes, Exception):
             return body_bytes
 
-        return net.sign(body_bytes, signing_key)
+        self.headers = {
+            **self.headers,
+            server_lib.HeaderKey.SIGNATURE.value: net.sign(
+                body_bytes, signing_key
+            ),
+        }
+
+        return None
 
 
 def _prep_call_result(

--- a/inngest/_internal/comm_lib/models.py
+++ b/inngest/_internal/comm_lib/models.py
@@ -115,6 +115,9 @@ class CommResponse:
                 "message": str(err),
                 "name": type(err).__name__,
             },
+            headers={
+                server_lib.HeaderKey.CONTENT_TYPE.value: "application/json",
+            },
             status_code=status.value,
         )
 

--- a/inngest/_internal/comm_lib/models.py
+++ b/inngest/_internal/comm_lib/models.py
@@ -14,6 +14,16 @@ from inngest._internal import (
 )
 
 
+class CommRequest(types.BaseModel):
+    body: bytes
+    headers: typing.Union[dict[str, str], dict[str, str]]
+    query_params: typing.Union[dict[str, str], dict[str, list[str]]]
+    raw_request: object
+    request_url: str
+    serve_origin: typing.Optional[str]
+    serve_path: typing.Optional[str]
+
+
 class CommResponse:
     def __init__(
         self,
@@ -123,6 +133,12 @@ class CommResponse:
             status_code=status.value,
         )
 
+    def body_bytes(self) -> types.MaybeError[bytes]:
+        dumped = transforms.dump_json(self.body)
+        if isinstance(dumped, Exception):
+            return dumped
+        return dumped.encode("utf-8")
+
     def prep_call_result(
         self,
         call_res: execution_lib.CallResult,
@@ -164,6 +180,13 @@ class CommResponse:
             return d.get("error") or d.get("data")
 
         return d
+
+    def sign(self, signing_key: str) -> types.MaybeError[str]:
+        body_bytes = self.body_bytes()
+        if isinstance(body_bytes, Exception):
+            return body_bytes
+
+        return net.sign(body_bytes, signing_key)
 
 
 def _prep_call_result(

--- a/inngest/_internal/comm_lib/utils.py
+++ b/inngest/_internal/comm_lib/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import http
 import typing
 
 from inngest._internal import net, server_lib, types
@@ -74,7 +75,9 @@ def wrap_handler(
             )
             if isinstance(request_signing_key, Exception) and require_signature:
                 return CommResponse.from_error(
-                    self._client.logger, request_signing_key
+                    self._client.logger,
+                    request_signing_key,
+                    status=http.HTTPStatus.UNAUTHORIZED,
                 )
 
             res = await method(
@@ -141,7 +144,9 @@ def wrap_handler_sync(
             )
             if isinstance(request_signing_key, Exception) and require_signature:
                 return CommResponse.from_error(
-                    self._client.logger, request_signing_key
+                    self._client.logger,
+                    request_signing_key,
+                    status=http.HTTPStatus.UNAUTHORIZED,
                 )
 
             res = method(

--- a/inngest/_internal/comm_lib/utils.py
+++ b/inngest/_internal/comm_lib/utils.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 import typing
 
-from inngest._internal import server_lib, types
+from inngest._internal import net, server_lib, types
+
+from .models import CommRequest, CommResponse
+
+if typing.TYPE_CHECKING:
+    from .handler import CommHandler
 
 
 class _QueryParams(types.BaseModel):
@@ -30,3 +35,107 @@ def parse_query_params(
         step_id=step_id,
         sync_id=normalized.get(server_lib.QueryParamKey.SYNC_ID.value),
     )
+
+
+def wrap_handler(
+    method: typing.Callable[
+        [typing.Any, CommRequest, types.MaybeError[typing.Optional[str]]],
+        typing.Awaitable[typing.Union[CommResponse, Exception]],
+    ],
+) -> typing.Callable[[typing.Any, CommRequest], typing.Awaitable[CommResponse]]:
+    """
+    Perform request signature validation, error handling, header setting, and
+    response signing.
+    """
+
+    async def wrapper(
+        self: CommHandler,
+        req: CommRequest,
+    ) -> CommResponse:
+        req.headers = net.normalize_headers(req.headers)
+
+        request_signing_key = net.validate_request(
+            body=req.body,
+            headers=req.headers,
+            mode=self._client._mode,
+            signing_key=self._signing_key,
+            signing_key_fallback=self._signing_key_fallback,
+        )
+
+        res = await method(
+            self,
+            req,
+            request_signing_key,
+        )
+        if isinstance(res, Exception):
+            res = CommResponse.from_error(self._client.logger, res)
+
+        res.headers = {
+            **res.headers,
+            **net.create_headers(
+                env=self._client.env,
+                framework=self._framework,
+                server_kind=self._client._mode,
+            ),
+        }
+
+        if isinstance(request_signing_key, str):
+            err = res.sign(request_signing_key)
+            if err is not None:
+                self._client.logger.error(err)
+
+        return res
+
+    return wrapper
+
+
+def wrap_handler_sync(
+    method: typing.Callable[
+        [typing.Any, CommRequest, types.MaybeError[typing.Optional[str]]],
+        typing.Union[CommResponse, Exception],
+    ],
+) -> typing.Callable[[typing.Any, CommRequest], CommResponse]:
+    """
+    Perform request signature validation, error handling, header setting, and
+    response signing.
+    """
+
+    def wrapper(
+        self: CommHandler,
+        req: CommRequest,
+    ) -> CommResponse:
+        req.headers = net.normalize_headers(req.headers)
+
+        request_signing_key = net.validate_request(
+            body=req.body,
+            headers=req.headers,
+            mode=self._client._mode,
+            signing_key=self._signing_key,
+            signing_key_fallback=self._signing_key_fallback,
+        )
+
+        res = method(
+            self,
+            req,
+            request_signing_key,
+        )
+        if isinstance(res, Exception):
+            res = CommResponse.from_error(self._client.logger, res)
+
+        res.headers = {
+            **res.headers,
+            **net.create_headers(
+                env=self._client.env,
+                framework=self._framework,
+                server_kind=self._client._mode,
+            ),
+        }
+
+        if isinstance(request_signing_key, str):
+            err = res.sign(request_signing_key)
+            if err is not None:
+                self._client.logger.error(err)
+
+        return res
+
+    return wrapper

--- a/inngest/_internal/comm_lib/utils.py
+++ b/inngest/_internal/comm_lib/utils.py
@@ -37,105 +37,137 @@ def parse_query_params(
     )
 
 
+_MethodHandler = typing.Callable[
+    [typing.Any, CommRequest, types.MaybeError[typing.Optional[str]]],
+    typing.Awaitable[typing.Union[CommResponse, Exception]],
+]
+
+
 def wrap_handler(
-    method: typing.Callable[
-        [typing.Any, CommRequest, types.MaybeError[typing.Optional[str]]],
-        typing.Awaitable[typing.Union[CommResponse, Exception]],
-    ],
-) -> typing.Callable[[typing.Any, CommRequest], typing.Awaitable[CommResponse]]:
-    """
-    Perform request signature validation, error handling, header setting, and
-    response signing.
-    """
+    require_signature: bool = True,
+) -> typing.Callable[
+    [_MethodHandler],
+    typing.Callable[[typing.Any, CommRequest], typing.Awaitable[CommResponse]],
+]:
+    def decorator(
+        method: _MethodHandler,
+    ) -> typing.Callable[
+        [typing.Any, CommRequest], typing.Awaitable[CommResponse]
+    ]:
+        """
+        Perform request signature validation, error handling, header setting, and
+        response signing.
+        """
 
-    async def wrapper(
-        self: CommHandler,
-        req: CommRequest,
-    ) -> CommResponse:
-        req.headers = net.normalize_headers(req.headers)
+        async def wrapper(
+            self: CommHandler,
+            req: CommRequest,
+        ) -> CommResponse:
+            req.headers = net.normalize_headers(req.headers)
 
-        request_signing_key = net.validate_request(
-            body=req.body,
-            headers=req.headers,
-            mode=self._client._mode,
-            signing_key=self._signing_key,
-            signing_key_fallback=self._signing_key_fallback,
-        )
+            request_signing_key = net.validate_request(
+                body=req.body,
+                headers=req.headers,
+                mode=self._client._mode,
+                signing_key=self._signing_key,
+                signing_key_fallback=self._signing_key_fallback,
+            )
+            if isinstance(request_signing_key, Exception) and require_signature:
+                return CommResponse.from_error(
+                    self._client.logger, request_signing_key
+                )
 
-        res = await method(
-            self,
-            req,
-            request_signing_key,
-        )
-        if isinstance(res, Exception):
-            res = CommResponse.from_error(self._client.logger, res)
+            res = await method(
+                self,
+                req,
+                request_signing_key,
+            )
+            if isinstance(res, Exception):
+                res = CommResponse.from_error(self._client.logger, res)
 
-        res.headers = {
-            **res.headers,
-            **net.create_headers(
-                env=self._client.env,
-                framework=self._framework,
-                server_kind=self._client._mode,
-            ),
-        }
+            res.headers = {
+                **res.headers,
+                **net.create_headers(
+                    env=self._client.env,
+                    framework=self._framework,
+                    server_kind=self._client._mode,
+                ),
+            }
 
-        if isinstance(request_signing_key, str):
-            err = res.sign(request_signing_key)
-            if err is not None:
-                self._client.logger.error(err)
+            if isinstance(request_signing_key, str):
+                err = res.sign(request_signing_key)
+                if err is not None:
+                    self._client.logger.error(err)
 
-        return res
+            return res
 
-    return wrapper
+        return wrapper
+
+    return decorator
+
+
+_MethodHandlerSync = typing.Callable[
+    [typing.Any, CommRequest, types.MaybeError[typing.Optional[str]]],
+    typing.Union[CommResponse, Exception],
+]
 
 
 def wrap_handler_sync(
-    method: typing.Callable[
-        [typing.Any, CommRequest, types.MaybeError[typing.Optional[str]]],
-        typing.Union[CommResponse, Exception],
-    ],
-) -> typing.Callable[[typing.Any, CommRequest], CommResponse]:
-    """
-    Perform request signature validation, error handling, header setting, and
-    response signing.
-    """
+    require_signature: bool = True,
+) -> typing.Callable[
+    [_MethodHandlerSync],
+    typing.Callable[[typing.Any, CommRequest], CommResponse],
+]:
+    def decorator(
+        method: _MethodHandlerSync,
+    ) -> typing.Callable[[typing.Any, CommRequest], CommResponse]:
+        """
+        Perform request signature validation, error handling, header setting, and
+        response signing.
+        """
 
-    def wrapper(
-        self: CommHandler,
-        req: CommRequest,
-    ) -> CommResponse:
-        req.headers = net.normalize_headers(req.headers)
+        def wrapper(
+            self: CommHandler,
+            req: CommRequest,
+        ) -> CommResponse:
+            req.headers = net.normalize_headers(req.headers)
 
-        request_signing_key = net.validate_request(
-            body=req.body,
-            headers=req.headers,
-            mode=self._client._mode,
-            signing_key=self._signing_key,
-            signing_key_fallback=self._signing_key_fallback,
-        )
+            request_signing_key = net.validate_request(
+                body=req.body,
+                headers=req.headers,
+                mode=self._client._mode,
+                signing_key=self._signing_key,
+                signing_key_fallback=self._signing_key_fallback,
+            )
+            if isinstance(request_signing_key, Exception) and require_signature:
+                return CommResponse.from_error(
+                    self._client.logger, request_signing_key
+                )
 
-        res = method(
-            self,
-            req,
-            request_signing_key,
-        )
-        if isinstance(res, Exception):
-            res = CommResponse.from_error(self._client.logger, res)
+            res = method(
+                self,
+                req,
+                request_signing_key,
+            )
+            if isinstance(res, Exception):
+                res = CommResponse.from_error(self._client.logger, res)
 
-        res.headers = {
-            **res.headers,
-            **net.create_headers(
-                env=self._client.env,
-                framework=self._framework,
-                server_kind=self._client._mode,
-            ),
-        }
+            res.headers = {
+                **res.headers,
+                **net.create_headers(
+                    env=self._client.env,
+                    framework=self._framework,
+                    server_kind=self._client._mode,
+                ),
+            }
 
-        if isinstance(request_signing_key, str):
-            err = res.sign(request_signing_key)
-            if err is not None:
-                self._client.logger.error(err)
+            if isinstance(request_signing_key, str):
+                err = res.sign(request_signing_key)
+                if err is not None:
+                    self._client.logger.error(err)
 
-        return res
+            return res
 
-    return wrapper
+        return wrapper
+
+    return decorator

--- a/inngest/django.py
+++ b/inngest/django.py
@@ -73,38 +73,32 @@ def _create_handler_sync(
     def inngest_api(
         request: django.http.HttpRequest,
     ) -> django.http.HttpResponse:
+        comm_req = comm_lib.CommRequest(
+            body=request.body,
+            headers=dict(request.headers.items()),
+            query_params=dict(request.GET.items()),
+            raw_request=request,
+            request_url=request.build_absolute_uri(),
+            serve_origin=serve_origin,
+            serve_path=serve_path,
+        )
+
         if request.method == "GET":
             return _to_response(
                 client,
-                handler.inspect(
-                    body=request.body,
-                    headers=dict(request.headers.items()),
-                    serve_origin=serve_origin,
-                    serve_path=serve_path,
-                ),
+                handler.get_sync(comm_req),
             )
 
         if request.method == "POST":
             return _to_response(
                 client,
-                handler.call_function_sync(
-                    body=request.body,
-                    headers=dict(request.headers.items()),
-                    query_params=dict(request.GET.items()),
-                    raw_request=request,
-                ),
+                handler.post_sync(comm_req),
             )
 
         if request.method == "PUT":
             return _to_response(
                 client,
-                handler.register_sync(
-                    headers=dict(request.headers.items()),
-                    query_params=dict(request.GET.items()),
-                    request_url=request.build_absolute_uri(),
-                    serve_origin=serve_origin,
-                    serve_path=serve_path,
-                ),
+                handler.put_sync(comm_req),
             )
 
         return django.http.JsonResponse(
@@ -138,38 +132,32 @@ def _create_handler_async(
     async def inngest_api(
         request: django.http.HttpRequest,
     ) -> django.http.HttpResponse:
+        comm_req = comm_lib.CommRequest(
+            body=request.body,
+            headers=dict(request.headers.items()),
+            query_params=dict(request.GET.items()),
+            raw_request=request,
+            request_url=request.build_absolute_uri(),
+            serve_origin=serve_origin,
+            serve_path=serve_path,
+        )
+
         if request.method == "GET":
             return _to_response(
                 client,
-                handler.inspect(
-                    body=json.loads(request.body),
-                    headers=dict(request.headers.items()),
-                    serve_origin=serve_origin,
-                    serve_path=serve_path,
-                ),
+                handler.get_sync(comm_req),
             )
 
         if request.method == "POST":
             return _to_response(
                 client,
-                await handler.call_function(
-                    body=json.loads(request.body),
-                    headers=dict(request.headers.items()),
-                    query_params=dict(request.GET.items()),
-                    raw_request=request,
-                ),
+                await handler.post(comm_req),
             )
 
         if request.method == "PUT":
             return _to_response(
                 client,
-                await handler.register(
-                    headers=dict(request.headers.items()),
-                    query_params=dict(request.GET.items()),
-                    request_url=request.build_absolute_uri(),
-                    serve_origin=serve_origin,
-                    serve_path=serve_path,
-                ),
+                await handler.put(comm_req),
             )
 
         return django.http.JsonResponse(

--- a/inngest/fast_api.py
+++ b/inngest/fast_api.py
@@ -43,11 +43,16 @@ def serve(
     ) -> fastapi.Response:
         return _to_response(
             client,
-            handler.inspect(
-                body=await request.body(),
-                headers=dict(request.headers.items()),
-                serve_origin=serve_origin,
-                serve_path=serve_path,
+            handler.get_sync(
+                comm_lib.CommRequest(
+                    body=await request.body(),
+                    headers=dict(request.headers.items()),
+                    query_params=dict(request.query_params.items()),
+                    raw_request=request,
+                    request_url=str(request.url),
+                    serve_origin=serve_origin,
+                    serve_path=serve_path,
+                )
             ),
         )
 
@@ -57,11 +62,16 @@ def serve(
     ) -> fastapi.Response:
         return _to_response(
             client,
-            await handler.call_function(
-                body=await request.body(),
-                headers=dict(request.headers.items()),
-                query_params=dict(request.query_params.items()),
-                raw_request=request,
+            await handler.post(
+                comm_lib.CommRequest(
+                    body=await request.body(),
+                    headers=dict(request.headers.items()),
+                    query_params=dict(request.query_params.items()),
+                    raw_request=request,
+                    request_url=str(request.url),
+                    serve_origin=serve_origin,
+                    serve_path=serve_path,
+                )
             ),
         )
 
@@ -71,12 +81,16 @@ def serve(
     ) -> fastapi.Response:
         return _to_response(
             client,
-            await handler.register(
-                headers=dict(request.headers.items()),
-                query_params=dict(request.query_params.items()),
-                request_url=str(request.url),
-                serve_origin=serve_origin,
-                serve_path=serve_path,
+            await handler.put(
+                comm_lib.CommRequest(
+                    body=await request.body(),
+                    headers=dict(request.headers.items()),
+                    query_params=dict(request.query_params.items()),
+                    raw_request=request,
+                    request_url=str(request.url),
+                    serve_origin=serve_origin,
+                    serve_path=serve_path,
+                )
             ),
         )
 

--- a/inngest/flask.py
+++ b/inngest/flask.py
@@ -75,38 +75,32 @@ def _create_handler_async(
 ) -> None:
     @app.route("/api/inngest", methods=["GET", "POST", "PUT"])
     async def inngest_api() -> typing.Union[flask.Response, str]:
+        comm_req = comm_lib.CommRequest(
+            body=flask.request.data,
+            headers=dict(flask.request.headers.items()),
+            query_params=flask.request.args,
+            raw_request=flask.request,
+            request_url=flask.request.url,
+            serve_origin=serve_origin,
+            serve_path=serve_path,
+        )
+
         if flask.request.method == "GET":
             return _to_response(
                 client,
-                handler.inspect(
-                    body=flask.request.data,
-                    headers=dict(flask.request.headers.items()),
-                    serve_origin=serve_origin,
-                    serve_path=serve_path,
-                ),
+                handler.get_sync(comm_req),
             )
 
         if flask.request.method == "POST":
             return _to_response(
                 client,
-                await handler.call_function(
-                    body=flask.request.data,
-                    headers=dict(flask.request.headers.items()),
-                    query_params=flask.request.args,
-                    raw_request=flask.request,
-                ),
+                await handler.post(comm_req),
             )
 
         if flask.request.method == "PUT":
             return _to_response(
                 client,
-                await handler.register(
-                    headers=dict(flask.request.headers.items()),
-                    query_params=flask.request.args,
-                    request_url=flask.request.url,
-                    serve_origin=serve_origin,
-                    serve_path=serve_path,
-                ),
+                await handler.put(comm_req),
             )
 
         # Should be unreachable
@@ -123,38 +117,32 @@ def _create_handler_sync(
 ) -> None:
     @app.route("/api/inngest", methods=["GET", "POST", "PUT"])
     def inngest_api() -> typing.Union[flask.Response, str]:
+        comm_req = comm_lib.CommRequest(
+            body=flask.request.data,
+            headers=dict(flask.request.headers.items()),
+            query_params=flask.request.args,
+            raw_request=flask.request,
+            request_url=flask.request.url,
+            serve_origin=serve_origin,
+            serve_path=serve_path,
+        )
+
         if flask.request.method == "GET":
             return _to_response(
                 client,
-                handler.inspect(
-                    body=flask.request.data,
-                    headers=dict(flask.request.headers.items()),
-                    serve_origin=serve_origin,
-                    serve_path=serve_path,
-                ),
+                handler.get_sync(comm_req),
             )
 
         if flask.request.method == "POST":
             return _to_response(
                 client,
-                handler.call_function_sync(
-                    body=flask.request.data,
-                    headers=dict(flask.request.headers.items()),
-                    query_params=flask.request.args,
-                    raw_request=flask.request,
-                ),
+                handler.post_sync(comm_req),
             )
 
         if flask.request.method == "PUT":
             return _to_response(
                 client,
-                handler.register_sync(
-                    headers=dict(flask.request.headers.items()),
-                    query_params=flask.request.args,
-                    request_url=flask.request.url,
-                    serve_origin=serve_origin,
-                    serve_path=serve_path,
-                ),
+                handler.put_sync(comm_req),
             )
 
         # Should be unreachable

--- a/inngest/tornado.py
+++ b/inngest/tornado.py
@@ -49,32 +49,52 @@ def serve(
             return None
 
         def get(self) -> None:
-            comm_res = handler.inspect(
-                body=self.request.body,
-                headers=dict(self.request.headers.items()),
-                serve_origin=serve_origin,
-                serve_path=serve_path,
+            comm_res = handler.get_sync(
+                comm_lib.CommRequest(
+                    body=self.request.body,
+                    headers=dict(self.request.headers.items()),
+                    query_params=_parse_query_params(
+                        self.request.query_arguments
+                    ),
+                    raw_request=self.request,
+                    request_url=self.request.full_url(),
+                    serve_origin=serve_origin,
+                    serve_path=serve_path,
+                )
             )
 
             self._write_comm_response(comm_res)
 
         def post(self) -> None:
-            comm_res = handler.call_function_sync(
-                body=self.request.body,
-                headers=dict(self.request.headers.items()),
-                query_params=_parse_query_params(self.request.query_arguments),
-                raw_request=self.request,
+            comm_res = handler.post_sync(
+                comm_lib.CommRequest(
+                    body=self.request.body,
+                    headers=dict(self.request.headers.items()),
+                    query_params=_parse_query_params(
+                        self.request.query_arguments
+                    ),
+                    raw_request=self.request,
+                    request_url=self.request.full_url(),
+                    serve_origin=serve_origin,
+                    serve_path=serve_path,
+                )
             )
 
             self._write_comm_response(comm_res)
 
         def put(self) -> None:
-            comm_res = handler.register_sync(
-                headers=dict(self.request.headers.items()),
-                query_params=_parse_query_params(self.request.query_arguments),
-                request_url=self.request.full_url(),
-                serve_origin=serve_origin,
-                serve_path=serve_path,
+            comm_res = handler.put_sync(
+                comm_lib.CommRequest(
+                    body=self.request.body,
+                    headers=dict(self.request.headers.items()),
+                    query_params=_parse_query_params(
+                        self.request.query_arguments
+                    ),
+                    raw_request=self.request,
+                    request_url=self.request.full_url(),
+                    serve_origin=serve_origin,
+                    serve_path=serve_path,
+                )
             )
 
             self._write_comm_response(comm_res)

--- a/tests/base.py
+++ b/tests/base.py
@@ -107,9 +107,28 @@ class IntrospectionResponse(types.BaseModel):
     status_code: int
 
 
-class BaseTestIntrospection(unittest.TestCase):
-    framework: server_lib.Framework
+class BaseTest(unittest.TestCase):
     signing_key = "signkey-prod-123abc"
+
+    def create_functions(
+        self,
+        client: inngest.Inngest,
+    ) -> list[inngest.Function]:
+        @client.create_function(
+            fn_id="test",
+            trigger=inngest.TriggerEvent(event="test"),
+        )
+        def fn(
+            ctx: inngest.Context,
+            step: inngest.StepSync,
+        ) -> None:
+            pass
+
+        return [fn]
+
+
+class BaseTestIntrospection(BaseTest):
+    framework: server_lib.Framework
 
     def setUp(self) -> None:
         self.expected_unauthed_body = {
@@ -138,21 +157,6 @@ class BaseTestIntrospection(unittest.TestCase):
             "signing_key_fallback_hash": "a820760dee6119fcf76498ab8d94be2f8cf04e786add2a4569e427462a84dd47",
             "signing_key_hash": "94bab7f22b92278ccab46e15da43a9fb8b079c05fa099d4134c6c39bbcee49f6",
         }
-
-    def create_functions(
-        self, client: inngest.Inngest
-    ) -> list[inngest.Function]:
-        @client.create_function(
-            fn_id="test",
-            trigger=inngest.TriggerEvent(event="test"),
-        )
-        def fn(
-            ctx: inngest.Context,
-            step: inngest.StepSync,
-        ) -> None:
-            pass
-
-        return [fn]
 
     def create_signature(self) -> str:
         mac = hmac.new(

--- a/tests/base.py
+++ b/tests/base.py
@@ -167,6 +167,25 @@ class BaseTestIntrospection(unittest.TestCase):
         sig = mac.hexdigest()
         return f"s={sig}&t={unix_ms}"
 
+    def validate_signature(self, sig: str, body: bytes) -> None:
+        parsed = urllib.parse.parse_qs(sig)
+        timestamp = int(parsed["t"][0])
+        signature = parsed["s"][0]
+
+        mac = hmac.new(
+            transforms.remove_signing_key_prefix(self.signing_key).encode(
+                "utf-8"
+            ),
+            body,
+            hashlib.sha256,
+        )
+
+        if timestamp:
+            mac.update(str(timestamp).encode("utf-8"))
+
+        if not hmac.compare_digest(signature, mac.hexdigest()):
+            raise Exception("invalid signature")
+
     def set_signing_key_fallback_env_var(self) -> None:
         os.environ[
             const.EnvKey.SIGNING_KEY_FALLBACK.value

--- a/tests/test_execution/README.md
+++ b/tests/test_execution/README.md
@@ -1,0 +1,3 @@
+# Test execution
+
+This directory contains tests for execution logic that isn't covered by `test_functions`.

--- a/tests/test_execution/test_fast_api.py
+++ b/tests/test_execution/test_fast_api.py
@@ -1,0 +1,60 @@
+import http
+import unittest
+
+import fastapi
+import fastapi.testclient
+
+import inngest
+import inngest.fast_api
+from inngest._internal import net, server_lib
+from tests import base
+
+
+class TestExecution(base.BaseTest):
+    def _serve(self, client: inngest.Inngest) -> fastapi.testclient.TestClient:
+        app = fastapi.FastAPI()
+        inngest.fast_api.serve(
+            app,
+            client,
+            self.create_functions(client),
+        )
+        return fastapi.testclient.TestClient(app)
+
+    def test_no_signature(self) -> None:
+        fast_api_client = self._serve(
+            inngest.Inngest(
+                app_id="my-app",
+                event_key="test",
+                signing_key=self.signing_key,
+            )
+        )
+        res = fast_api_client.post("/api/inngest?fnId=my-fn&stepId=step")
+        assert res.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
+        assert res.json()["code"] == "header_missing"
+        assert res.headers.get(server_lib.HeaderKey.SIGNATURE.value) is None
+
+    def test_invalid_signature(self) -> None:
+        fast_api_client = self._serve(
+            inngest.Inngest(
+                app_id="my-app",
+                event_key="test",
+                signing_key=self.signing_key,
+            )
+        )
+        wrong_signing_key = "signkey-prod-111111"
+        res = fast_api_client.post(
+            "/api/inngest?fnId=my-fn&stepId=step",
+            headers={
+                server_lib.HeaderKey.SIGNATURE.value: net.sign(
+                    b"{}",
+                    wrong_signing_key,
+                ),
+            },
+        )
+        assert res.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
+        assert res.json()["code"] == "sig_verification_failed"
+        assert res.headers.get(server_lib.HeaderKey.SIGNATURE.value) is None
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_execution/test_fast_api.py
+++ b/tests/test_execution/test_fast_api.py
@@ -29,7 +29,7 @@ class TestExecution(base.BaseTest):
             )
         )
         res = fast_api_client.post("/api/inngest?fnId=my-fn&stepId=step")
-        assert res.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
+        assert res.status_code == http.HTTPStatus.UNAUTHORIZED
         assert res.json()["code"] == "header_missing"
         assert res.headers.get(server_lib.HeaderKey.SIGNATURE.value) is None
 
@@ -51,7 +51,7 @@ class TestExecution(base.BaseTest):
                 ),
             },
         )
-        assert res.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
+        assert res.status_code == http.HTTPStatus.UNAUTHORIZED
         assert res.json()["code"] == "sig_verification_failed"
         assert res.headers.get(server_lib.HeaderKey.SIGNATURE.value) is None
 

--- a/tests/test_execution/test_flask.py
+++ b/tests/test_execution/test_flask.py
@@ -30,7 +30,7 @@ class TestExecution(base.BaseTest):
             )
         )
         res = flask_client.post("/api/inngest?fnId=my-fn&stepId=step")
-        assert res.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
+        assert res.status_code == http.HTTPStatus.UNAUTHORIZED
         assert res.json is not None
         assert res.json["code"] == "header_missing"
         assert res.headers.get(server_lib.HeaderKey.SIGNATURE.value) is None
@@ -53,7 +53,7 @@ class TestExecution(base.BaseTest):
                 ),
             },
         )
-        assert res.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
+        assert res.status_code == http.HTTPStatus.UNAUTHORIZED
         assert res.json is not None
         assert res.json["code"] == "sig_verification_failed"
         assert res.headers.get(server_lib.HeaderKey.SIGNATURE.value) is None

--- a/tests/test_execution/test_flask.py
+++ b/tests/test_execution/test_flask.py
@@ -1,0 +1,63 @@
+import http
+import unittest
+
+import flask
+import flask.logging
+import flask.testing
+
+import inngest
+import inngest.flask
+from inngest._internal import net, server_lib
+from tests import base
+
+
+class TestExecution(base.BaseTest):
+    def _serve(self, client: inngest.Inngest) -> flask.testing.FlaskClient:
+        app = flask.Flask(__name__)
+        inngest.flask.serve(
+            app,
+            client,
+            self.create_functions(client),
+        )
+        return app.test_client()
+
+    def test_no_signature(self) -> None:
+        flask_client = self._serve(
+            inngest.Inngest(
+                app_id="my-app",
+                event_key="test",
+                signing_key=self.signing_key,
+            )
+        )
+        res = flask_client.post("/api/inngest?fnId=my-fn&stepId=step")
+        assert res.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
+        assert res.json is not None
+        assert res.json["code"] == "header_missing"
+        assert res.headers.get(server_lib.HeaderKey.SIGNATURE.value) is None
+
+    def test_invalid_signature(self) -> None:
+        flask_client = self._serve(
+            inngest.Inngest(
+                app_id="my-app",
+                event_key="test",
+                signing_key=self.signing_key,
+            )
+        )
+        wrong_signing_key = "signkey-prod-111111"
+        res = flask_client.post(
+            "/api/inngest?fnId=my-fn&stepId=step",
+            headers={
+                server_lib.HeaderKey.SIGNATURE.value: net.sign(
+                    b"{}",
+                    wrong_signing_key,
+                ),
+            },
+        )
+        assert res.status_code == http.HTTPStatus.INTERNAL_SERVER_ERROR
+        assert res.json is not None
+        assert res.json["code"] == "sig_verification_failed"
+        assert res.headers.get(server_lib.HeaderKey.SIGNATURE.value) is None
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_introspection/test_digital_ocean.py
+++ b/tests/test_introspection/test_digital_ocean.py
@@ -38,6 +38,7 @@ class TestIntrospection(base.BaseTestIntrospection):
             **self.expected_unauthed_body,
             "authentication_succeeded": False,
         }
+        assert res.headers.get(server_lib.HeaderKey.SIGNATURE.value) is None
 
     def test_cloud_mode_with_signature(self) -> None:
         self.set_signing_key_fallback_env_var()
@@ -61,6 +62,10 @@ class TestIntrospection(base.BaseTestIntrospection):
             **self.expected_authed_body,
             "has_signing_key_fallback": True,
         }
+        self.validate_signature(
+            res.headers[server_lib.HeaderKey.SIGNATURE.value],
+            res.get_data(),
+        )
 
     def test_dev_mode_with_no_signature(self) -> None:
         app_client = self._serve(
@@ -78,6 +83,7 @@ class TestIntrospection(base.BaseTestIntrospection):
             **self.expected_unauthed_body,
             "mode": "dev",
         }
+        assert res.headers.get(server_lib.HeaderKey.SIGNATURE.value) is None
 
 
 if __name__ == "__main__":

--- a/tests/test_introspection/test_fast_api.py
+++ b/tests/test_introspection/test_fast_api.py
@@ -63,6 +63,38 @@ class TestIntrospection(base.BaseTestIntrospection):
             res.text.encode("utf-8"),
         )
 
+    def test_cloud_mode_with_signature_fallback(self) -> None:
+        # Ensure that everything still works when signing with the fallback
+        # signing key
+
+        signing_key_fallback = self.set_signing_key_fallback_env_var()
+
+        fast_api_client = self._serve(
+            inngest.Inngest(
+                app_id="my-app",
+                event_key="test",
+                signing_key=self.signing_key,
+            )
+        )
+        res = fast_api_client.get(
+            "/api/inngest",
+            headers={
+                server_lib.HeaderKey.SIGNATURE.value: self.create_signature(
+                    signing_key_fallback
+                ),
+            },
+        )
+        assert res.status_code == 200
+        assert res.json() == {
+            **self.expected_authed_body,
+            "has_signing_key_fallback": True,
+        }
+        self.validate_signature(
+            res.headers[server_lib.HeaderKey.SIGNATURE.value],
+            res.text.encode("utf-8"),
+            signing_key_fallback,
+        )
+
     def test_dev_mode_with_no_signature(self) -> None:
         fast_api_client = self._serve(
             inngest.Inngest(

--- a/tests/test_introspection/test_fast_api.py
+++ b/tests/test_introspection/test_fast_api.py
@@ -35,6 +35,7 @@ class TestIntrospection(base.BaseTestIntrospection):
             **self.expected_unauthed_body,
             "authentication_succeeded": False,
         }
+        assert res.headers.get(server_lib.HeaderKey.SIGNATURE.value) is None
 
     def test_cloud_mode_with_signature(self) -> None:
         self.set_signing_key_fallback_env_var()
@@ -57,6 +58,10 @@ class TestIntrospection(base.BaseTestIntrospection):
             **self.expected_authed_body,
             "has_signing_key_fallback": True,
         }
+        self.validate_signature(
+            res.headers[server_lib.HeaderKey.SIGNATURE.value],
+            res.text.encode("utf-8"),
+        )
 
     def test_dev_mode_with_no_signature(self) -> None:
         fast_api_client = self._serve(
@@ -73,6 +78,7 @@ class TestIntrospection(base.BaseTestIntrospection):
             **self.expected_unauthed_body,
             "mode": "dev",
         }
+        assert res.headers.get(server_lib.HeaderKey.SIGNATURE.value) is None
 
 
 if __name__ == "__main__":

--- a/tests/test_introspection/test_flask.py
+++ b/tests/test_introspection/test_flask.py
@@ -36,6 +36,7 @@ class TestIntrospection(base.BaseTestIntrospection):
             **self.expected_unauthed_body,
             "authentication_succeeded": False,
         }
+        assert res.headers.get(server_lib.HeaderKey.SIGNATURE.value) is None
 
     def test_cloud_mode_with_signature(self) -> None:
         self.set_signing_key_fallback_env_var()
@@ -58,6 +59,10 @@ class TestIntrospection(base.BaseTestIntrospection):
             **self.expected_authed_body,
             "has_signing_key_fallback": True,
         }
+        self.validate_signature(
+            res.headers[server_lib.HeaderKey.SIGNATURE.value],
+            res.get_data(),
+        )
 
     def test_dev_mode_with_no_signature(self) -> None:
         flask_client = self._serve(
@@ -74,6 +79,7 @@ class TestIntrospection(base.BaseTestIntrospection):
             **self.expected_unauthed_body,
             "mode": "dev",
         }
+        assert res.headers.get(server_lib.HeaderKey.SIGNATURE.value) is None
 
 
 if __name__ == "__main__":

--- a/tests/test_introspection/test_flask.py
+++ b/tests/test_introspection/test_flask.py
@@ -64,6 +64,38 @@ class TestIntrospection(base.BaseTestIntrospection):
             res.get_data(),
         )
 
+    def test_cloud_mode_with_signature_fallback(self) -> None:
+        # Ensure that everything still works when signing with the fallback
+        # signing key
+
+        signing_key_fallback = self.set_signing_key_fallback_env_var()
+
+        flask_client = self._serve(
+            inngest.Inngest(
+                app_id="my-app",
+                event_key="test",
+                signing_key=self.signing_key,
+            )
+        )
+        res = flask_client.get(
+            "/api/inngest",
+            headers={
+                server_lib.HeaderKey.SIGNATURE.value: self.create_signature(
+                    signing_key_fallback
+                ),
+            },
+        )
+        assert res.status_code == 200
+        assert res.json == {
+            **self.expected_authed_body,
+            "has_signing_key_fallback": True,
+        }
+        self.validate_signature(
+            res.headers[server_lib.HeaderKey.SIGNATURE.value],
+            res.get_data(),
+            signing_key_fallback,
+        )
+
     def test_dev_mode_with_no_signature(self) -> None:
         flask_client = self._serve(
             inngest.Inngest(


### PR DESCRIPTION
## Description
If the SDK receives a request with a valid signature, then it signs the response with the same signing key. This will be important for future work, including the trust probe

## Changes
- Refactor the `_prep_response` decorator to `wrap_handler`. This new decorator still does the same "convert errors to `CommResponse` objects" logic, but also validates the request signature and signs the response.
- Rename `CommHandler` method handlers to match their respective HTTP methods (`get`, `post`, and `put`).
- Make `CommHandler` method handlers accept a new standard `CommRequest` object. This simplifies consumption and unifies their function signatures.