### PR TITLE
Fix escape sequences breaking signature verification

### DIFF
--- a/inngest/_internal/const.py
+++ b/inngest/_internal/const.py
@@ -5,7 +5,7 @@ DEFAULT_API_ORIGIN: typing.Final = "https://api.inngest.com/"
 DEFAULT_EVENT_API_ORIGIN: typing.Final = "https://inn.gs/"
 DEV_SERVER_ORIGIN: typing.Final = "http://127.0.0.1:8288/"
 LANGUAGE: typing.Final = "py"
-VERSION: typing.Final = "0.4.9"
+VERSION: typing.Final = "0.4.10"
 
 
 class EnvKey(enum.Enum):

--- a/inngest/_internal/net.py
+++ b/inngest/_internal/net.py
@@ -348,6 +348,10 @@ def validate_request(
         signing_key_fallback: Fallback signing key.
     """
 
+    # Decode escape sequences since decode("utf-8") doesn't handle them. For
+    # example, utf-8 won't decode "\u0026" to "&"
+    body = body.decode("unicode_escape").encode("utf-8")
+
     err = _validate_request(
         body=body,
         headers=headers,

--- a/inngest/_internal/net_test.py
+++ b/inngest/_internal/net_test.py
@@ -118,6 +118,24 @@ class Test_RequestSignature(unittest.TestCase):
             Exception,
         )
 
+    def test_escape_sequences(self) -> None:
+        unix_ms = round(time.time() * 1000)
+        sig = _sign(b"a & b", _signing_key, unix_ms)
+        headers = {
+            server_lib.HeaderKey.SIGNATURE.value: f"s={sig}&t={unix_ms}",
+        }
+
+        assert not isinstance(
+            net.validate_request(
+                body=b"a \\u0026 b",
+                headers=headers,
+                mode=server_lib.ServerKind.CLOUD,
+                signing_key=_signing_key,
+                signing_key_fallback=None,
+            ),
+            Exception,
+        )
+
     def test_body_tamper(self) -> None:
         """
         Validation fails if the body is changed after signature creation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.4.9"
+version = "0.4.10"
 description = "Python SDK for Inngest"
 readme = "README.md"
 classifiers = [


### PR DESCRIPTION
Escape sequences were breaking signature verification because Inngest Servers sign using unescaped values but Python's `decode("utf-8")` doesn't decode the escape values