### PR TITLE
Automate runtime version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ format-check: check-venv
 	@ruff format .
 
 install: check-venv
-	@pip install '.[extra]' -c constraints.txt
+	@pip install -e '.[extra]' -c constraints.txt
 
 itest: check-venv
 	@pytest -n 4 -v tests

--- a/inngest/_internal/const.py
+++ b/inngest/_internal/const.py
@@ -1,12 +1,12 @@
 import enum
+import importlib.metadata
 import typing
-from importlib.metadata import version
 
 DEFAULT_API_ORIGIN: typing.Final = "https://api.inngest.com/"
 DEFAULT_EVENT_API_ORIGIN: typing.Final = "https://inn.gs/"
 DEV_SERVER_ORIGIN: typing.Final = "http://127.0.0.1:8288/"
 LANGUAGE: typing.Final = "py"
-VERSION: typing.Final = version("inngest")
+VERSION: typing.Final = importlib.metadata.version("inngest")
 
 
 class EnvKey(enum.Enum):

--- a/inngest/_internal/const.py
+++ b/inngest/_internal/const.py
@@ -1,11 +1,12 @@
 import enum
 import typing
+from importlib.metadata import version
 
 DEFAULT_API_ORIGIN: typing.Final = "https://api.inngest.com/"
 DEFAULT_EVENT_API_ORIGIN: typing.Final = "https://inn.gs/"
 DEV_SERVER_ORIGIN: typing.Final = "http://127.0.0.1:8288/"
 LANGUAGE: typing.Final = "py"
-VERSION: typing.Final = "0.4.12"
+VERSION: typing.Final = version("inngest")
 
 
 class EnvKey(enum.Enum):

--- a/inngest/_internal/const_test.py
+++ b/inngest/_internal/const_test.py
@@ -10,4 +10,4 @@ def test_version_matches_pyproject() -> None:
         pyproject: dict[str, object] = toml.load(f)
         project = pyproject.get("project")
         assert isinstance(project, dict)
-        assert const.VERSION == project.get("version")
+        assert const.VERSION == project.get("version"), "If this is local development, run `make install`"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.4.12"
+version = "0.4.13a0"
 description = "Python SDK for Inngest"
 readme = "README.md"
 classifiers = [


### PR DESCRIPTION
Replace `const.VERSION` with the real version in metadata