### PR TITLE
Fix send event error handling

### DIFF
--- a/inngest/_internal/client_lib/models.py
+++ b/inngest/_internal/client_lib/models.py
@@ -1,8 +1,10 @@
 import typing
 
+import pydantic
+
 from inngest._internal import types
 
 
 class SendEventsResult(types.BaseModel):
     error: typing.Optional[str] = None
-    ids: list[str]
+    ids: list[str] = pydantic.Field(default_factory=list)

--- a/inngest/_internal/errors.py
+++ b/inngest/_internal/errors.py
@@ -13,7 +13,7 @@ class Error(Exception):
     Base error for all our custom errors
     """
 
-    code: server_lib.ErrorCode
+    code: server_lib.ErrorCode = server_lib.ErrorCode.UNKNOWN
     include_stack: bool = True
     is_retriable: bool = True
 
@@ -170,6 +170,8 @@ class RetryAfterError(Error):
 
 
 class SendEventsError(Error):
+    code = server_lib.ErrorCode.SEND_EVENT_FAILED
+
     def __init__(self, message: str, ids: list[str]) -> None:
         """
         Args:

--- a/inngest/_internal/server_lib/consts.py
+++ b/inngest/_internal/server_lib/consts.py
@@ -18,6 +18,7 @@ class ErrorCode(enum.Enum):
     QUERY_PARAM_MISSING = "query_param_missing"
     REGISTRATION_FAILED = "registration_failed"
     RETRY_AFTER_ERROR = "retry_after_error"
+    SEND_EVENT_FAILED = "send_event_failed"
     SERVER_KIND_MISMATCH = "server_kind_mismatch"
     SIGNING_KEY_UNSPECIFIED = "signing_key_unspecified"
     SIG_VERIFICATION_FAILED = "sig_verification_failed"

--- a/inngest/_internal/step_lib/step_async.py
+++ b/inngest/_internal/step_lib/step_async.py
@@ -308,6 +308,12 @@ class Step(base.StepBase):
                     ids=err.ids,
                 )
                 raise err
+            except Exception as err:
+                result = client_models.SendEventsResult(
+                    error=str(err),
+                    ids=[],
+                )
+                raise err
             finally:
                 middleware_err = await self._middleware.after_send_events(
                     result

--- a/inngest/_internal/step_lib/step_sync.py
+++ b/inngest/_internal/step_lib/step_sync.py
@@ -293,6 +293,12 @@ class StepSync(base.StepBase):
                     ids=err.ids,
                 )
                 raise err
+            except Exception as err:
+                result = client_models.SendEventsResult(
+                    error=str(err),
+                    ids=[],
+                )
+                raise err
             finally:
                 middleware_err = self._middleware.after_send_events_sync(result)
                 if isinstance(middleware_err, Exception):


### PR DESCRIPTION
Fix some issues when an error happens during event sending:
1. Pydantic validation error when no `ids` array in response body.
1. No error code on `SendEventsError`.
1. `result` variable can be unbound.