### PR TITLE
Fix configured serve path in serve functions

### DIFF
--- a/inngest/_internal/config_lib.py
+++ b/inngest/_internal/config_lib.py
@@ -1,0 +1,26 @@
+import os
+import typing
+
+import inngest._internal.const as const
+
+
+def get_serve_origin(code_value: typing.Optional[str]) -> typing.Optional[str]:
+    if code_value is not None:
+        return code_value
+
+    env_var_value = os.getenv(const.EnvKey.SERVE_ORIGIN.value)
+    if env_var_value:
+        return env_var_value
+
+    return None
+
+
+def get_serve_path(code_value: typing.Optional[str]) -> str:
+    if code_value is not None:
+        return code_value
+
+    env_var_value = os.getenv(const.EnvKey.SERVE_PATH.value)
+    if env_var_value:
+        return env_var_value
+
+    return const.DEFAULT_SERVE_PATH

--- a/inngest/_internal/const.py
+++ b/inngest/_internal/const.py
@@ -5,6 +5,7 @@ import typing
 AUTHOR: typing.Final = "inngest"
 DEFAULT_API_ORIGIN: typing.Final = "https://api.inngest.com/"
 DEFAULT_EVENT_API_ORIGIN: typing.Final = "https://inn.gs/"
+DEFAULT_SERVE_PATH: typing.Final = "/api/inngest"
 DEV_SERVER_ORIGIN: typing.Final = "http://127.0.0.1:8288/"
 LANGUAGE: typing.Final = "py"
 VERSION: typing.Final = importlib.metadata.version("inngest")

--- a/inngest/_internal/net.py
+++ b/inngest/_internal/net.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import hashlib
 import hmac
 import http
-import os
 import threading
 import time
 import typing
@@ -13,6 +12,7 @@ import httpx
 
 from inngest._internal import (
     async_lib,
+    config_lib,
     const,
     errors,
     server_lib,
@@ -90,8 +90,8 @@ def create_serve_url(
     """
 
     # User can also specify these via env vars. The env vars take precedence.
-    serve_origin = os.getenv(const.EnvKey.SERVE_ORIGIN.value, serve_origin)
-    serve_path = os.getenv(const.EnvKey.SERVE_PATH.value, serve_path)
+    serve_origin = config_lib.get_serve_origin(serve_origin)
+    serve_path = config_lib.get_serve_path(serve_path)
 
     parsed_url = urllib.parse.urlparse(request_url)
     new_scheme = parsed_url.scheme

--- a/inngest/django.py
+++ b/inngest/django.py
@@ -11,7 +11,14 @@ import django.http
 import django.urls
 import django.views.decorators.csrf
 
-from ._internal import client_lib, comm_lib, function, server_lib, transforms
+from ._internal import (
+    client_lib,
+    comm_lib,
+    config_lib,
+    function,
+    server_lib,
+    transforms,
+)
 
 FRAMEWORK = server_lib.Framework.DJANGO
 
@@ -35,6 +42,8 @@ def serve(
         serve_origin: Origin to serve Inngest from.
         serve_path: Path to serve Inngest from.
     """
+
+    serve_path = config_lib.get_serve_path(serve_path)
 
     handler = comm_lib.CommHandler(
         client=client,
@@ -68,7 +77,7 @@ def _create_handler_sync(
     handler: comm_lib.CommHandler,
     *,
     serve_origin: typing.Optional[str],
-    serve_path: typing.Optional[str],
+    serve_path: str,
 ) -> django.urls.URLPattern:
     def inngest_api(
         request: django.http.HttpRequest,
@@ -107,7 +116,7 @@ def _create_handler_sync(
         )
 
     return django.urls.path(
-        "api/inngest",
+        serve_path,
         django.views.decorators.csrf.csrf_exempt(inngest_api),
     )
 
@@ -117,7 +126,7 @@ def _create_handler_async(
     handler: comm_lib.CommHandler,
     *,
     serve_origin: typing.Optional[str],
-    serve_path: typing.Optional[str],
+    serve_path: str,
 ) -> django.urls.URLPattern:
     major_version = transforms.get_major_version(django.get_version())
     if isinstance(major_version, Exception):
@@ -166,7 +175,7 @@ def _create_handler_async(
         )
 
     return django.urls.path(
-        "api/inngest",
+        serve_path,
         django.views.decorators.csrf.csrf_exempt(inngest_api),
     )
 

--- a/inngest/fast_api.py
+++ b/inngest/fast_api.py
@@ -5,7 +5,14 @@ import typing
 
 import fastapi
 
-from ._internal import client_lib, comm_lib, function, server_lib, transforms
+from ._internal import (
+    client_lib,
+    comm_lib,
+    config_lib,
+    function,
+    server_lib,
+    transforms,
+)
 
 FRAMEWORK = server_lib.Framework.FAST_API
 
@@ -31,13 +38,15 @@ def serve(
         serve_path: Path to serve the functions from.
     """
 
+    serve_path = config_lib.get_serve_path(serve_path)
+
     handler = comm_lib.CommHandler(
         client=client,
         framework=FRAMEWORK,
         functions=functions,
     )
 
-    @app.get("/api/inngest")
+    @app.get(serve_path)
     async def get_api_inngest(
         request: fastapi.Request,
     ) -> fastapi.Response:
@@ -56,7 +65,7 @@ def serve(
             ),
         )
 
-    @app.post("/api/inngest")
+    @app.post(serve_path)
     async def post_inngest_api(
         request: fastapi.Request,
     ) -> fastapi.Response:
@@ -75,7 +84,7 @@ def serve(
             ),
         )
 
-    @app.put("/api/inngest")
+    @app.put(serve_path)
     async def put_inngest_api(
         request: fastapi.Request,
     ) -> fastapi.Response:

--- a/inngest/flask.py
+++ b/inngest/flask.py
@@ -5,7 +5,13 @@ import typing
 
 import flask
 
-from inngest._internal import client_lib, comm_lib, function, server_lib
+from inngest._internal import (
+    client_lib,
+    comm_lib,
+    config_lib,
+    function,
+    server_lib,
+)
 
 FRAMEWORK = server_lib.Framework.FLASK
 
@@ -30,6 +36,8 @@ def serve(
         serve_origin: Origin to serve the functions from.
         serve_path: Path to serve the functions from.
     """
+
+    serve_path = config_lib.get_serve_path(serve_path)
 
     handler = comm_lib.CommHandler(
         client=client,
@@ -65,9 +73,9 @@ def _create_handler_async(
     handler: comm_lib.CommHandler,
     *,
     serve_origin: typing.Optional[str],
-    serve_path: typing.Optional[str],
+    serve_path: str,
 ) -> None:
-    @app.route("/api/inngest", methods=["GET", "POST", "PUT"])
+    @app.route(serve_path, methods=["GET", "POST", "PUT"])
     async def inngest_api() -> typing.Union[flask.Response, str]:
         comm_req = comm_lib.CommRequest(
             body=_get_body_bytes(),
@@ -107,9 +115,9 @@ def _create_handler_sync(
     handler: comm_lib.CommHandler,
     *,
     serve_origin: typing.Optional[str],
-    serve_path: typing.Optional[str],
+    serve_path: str,
 ) -> None:
-    @app.route("/api/inngest", methods=["GET", "POST", "PUT"])
+    @app.route(serve_path, methods=["GET", "POST", "PUT"])
     def inngest_api() -> typing.Union[flask.Response, str]:
         comm_req = comm_lib.CommRequest(
             body=_get_body_bytes(),

--- a/inngest/tornado.py
+++ b/inngest/tornado.py
@@ -8,6 +8,7 @@ import tornado.web
 from inngest._internal import (
     client_lib,
     comm_lib,
+    config_lib,
     function,
     server_lib,
     transforms,
@@ -36,6 +37,9 @@ def serve(
         serve_origin: Origin to serve the functions from.
         serve_path: Path to serve the functions from.
     """
+
+    serve_path = config_lib.get_serve_path(serve_path)
+
     handler = comm_lib.CommHandler(
         client=client,
         framework=FRAMEWORK,
@@ -115,7 +119,7 @@ def serve(
 
             self.set_status(comm_res.status_code)
 
-    app.add_handlers(r".*", [("/api/inngest", InngestHandler)])
+    app.add_handlers(r".*", [(serve_path, InngestHandler)])
 
 
 def _parse_query_params(raw: dict[str, list[bytes]]) -> dict[str, str]:

--- a/tests/base.py
+++ b/tests/base.py
@@ -158,7 +158,7 @@ class BaseTestIntrospection(BaseTest):
             "sdk_language": const.LANGUAGE,
             "sdk_version": const.VERSION,
             "serve_origin": None,
-            "serve_path": None,
+            "serve_path": "/api/inngest",
             "signing_key_fallback_hash": "a820760dee6119fcf76498ab8d94be2f8cf04e786add2a4569e427462a84dd47",
             "signing_key_hash": "94bab7f22b92278ccab46e15da43a9fb8b079c05fa099d4134c6c39bbcee49f6",
         }

--- a/tests/test_introspection/test_digital_ocean.py
+++ b/tests/test_introspection/test_digital_ocean.py
@@ -65,6 +65,7 @@ class TestIntrospection(base.BaseTestIntrospection):
         assert res.json == {
             **self.expected_authed_body,
             "has_signing_key_fallback": True,
+            "serve_path": None,
         }
         assert isinstance(
             net.validate_sig(


### PR DESCRIPTION
Fix a bug where the user's configured serve path (`serve_path` param or `INNGEST_SERVE_PATH` env var) is not used when `serve` functions are registering the Inngest endpoint.

Builds on the work in #163