### PR TITLE
Stop canonicalizing when signing responses

### DIFF
--- a/inngest/_internal/comm_lib/models.py
+++ b/inngest/_internal/comm_lib/models.py
@@ -188,7 +188,7 @@ class CommResponse:
         if isinstance(body_bytes, Exception):
             return body_bytes
 
-        sig = net.sign(body_bytes, signing_key)
+        sig = net.sign_response(body_bytes, signing_key)
         if isinstance(sig, Exception):
             return sig
 

--- a/inngest/_internal/comm_lib/utils.py
+++ b/inngest/_internal/comm_lib/utils.py
@@ -76,7 +76,7 @@ def wrap_handler(
         ) -> CommResponse:
             req.headers = net.normalize_headers(req.headers)
 
-            request_signing_key = net.validate_sig(
+            request_signing_key = net.validate_request_sig(
                 body=req.body,
                 headers=req.headers,
                 mode=self._client._mode,
@@ -145,7 +145,7 @@ def wrap_handler_sync(
         ) -> CommResponse:
             req.headers = net.normalize_headers(req.headers)
 
-            request_signing_key = net.validate_sig(
+            request_signing_key = net.validate_request_sig(
                 body=req.body,
                 headers=req.headers,
                 mode=self._client._mode,
@@ -177,6 +177,7 @@ def wrap_handler_sync(
             }
 
             if isinstance(request_signing_key, str):
+                print(request_signing_key)
                 err = res.sign(request_signing_key)
                 if err is not None:
                     self._client.logger.error(err)

--- a/inngest/_internal/comm_lib/utils.py
+++ b/inngest/_internal/comm_lib/utils.py
@@ -177,7 +177,6 @@ def wrap_handler_sync(
             }
 
             if isinstance(request_signing_key, str):
-                print(request_signing_key)
                 err = res.sign(request_signing_key)
                 if err is not None:
                     self._client.logger.error(err)

--- a/inngest/_internal/net_test.py
+++ b/inngest/_internal/net_test.py
@@ -109,7 +109,7 @@ class Test_RequestSignature(unittest.TestCase):
         }
 
         assert not isinstance(
-            net.validate_sig(
+            net.validate_request_sig(
                 body=body,
                 headers=headers,
                 mode=server_lib.ServerKind.CLOUD,
@@ -128,7 +128,7 @@ class Test_RequestSignature(unittest.TestCase):
         }
 
         assert not isinstance(
-            net.validate_sig(
+            net.validate_request_sig(
                 body=b'{"msg":"a \\u0026 b"}',
                 headers=headers,
                 mode=server_lib.ServerKind.CLOUD,
@@ -153,7 +153,7 @@ class Test_RequestSignature(unittest.TestCase):
 
         body = json.dumps({"msg": "you've been hacked"}).encode("utf-8")
 
-        validation = net.validate_sig(
+        validation = net.validate_request_sig(
             body=body,
             headers=headers,
             mode=server_lib.ServerKind.CLOUD,
@@ -177,7 +177,7 @@ class Test_RequestSignature(unittest.TestCase):
         }
 
         assert not isinstance(
-            net.validate_sig(
+            net.validate_request_sig(
                 body=body,
                 headers=headers,
                 mode=server_lib.ServerKind.CLOUD,
@@ -201,7 +201,7 @@ class Test_RequestSignature(unittest.TestCase):
         }
 
         assert isinstance(
-            net.validate_sig(
+            net.validate_request_sig(
                 body=body,
                 headers=headers,
                 mode=server_lib.ServerKind.CLOUD,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.4.15"
+version = "0.4.16"
 authors = [{ name = "Inngest Inc.", email = "hello@inngest.com" }]
 description = "Python SDK for Inngest"
 readme = "README.md"

--- a/tests/test_execution/test_fast_api.py
+++ b/tests/test_execution/test_fast_api.py
@@ -42,7 +42,7 @@ class TestExecution(base.BaseTest):
             )
         )
         wrong_signing_key = "signkey-prod-111111"
-        req_sig = net.sign(b"{}", wrong_signing_key)
+        req_sig = net.sign_request(b"{}", wrong_signing_key)
         if isinstance(req_sig, Exception):
             raise req_sig
 

--- a/tests/test_execution/test_flask.py
+++ b/tests/test_execution/test_flask.py
@@ -44,7 +44,7 @@ class TestExecution(base.BaseTest):
             )
         )
         wrong_signing_key = "signkey-prod-111111"
-        req_sig = net.sign(b"{}", wrong_signing_key)
+        req_sig = net.sign_request(b"{}", wrong_signing_key)
         if isinstance(req_sig, Exception):
             raise req_sig
 

--- a/tests/test_introspection/test_digital_ocean.py
+++ b/tests/test_introspection/test_digital_ocean.py
@@ -51,7 +51,7 @@ class TestIntrospection(base.BaseTestIntrospection):
             )
         )
 
-        req_sig = net.sign(b"", self.signing_key)
+        req_sig = net.sign_request(b"", self.signing_key)
         if isinstance(req_sig, Exception):
             raise req_sig
 
@@ -67,12 +67,11 @@ class TestIntrospection(base.BaseTestIntrospection):
             "has_signing_key_fallback": True,
         }
         assert isinstance(
-            net.validate_sig(
+            net.validate_response_sig(
                 body=res.get_data(),
                 headers=res.headers,
                 mode=server_lib.ServerKind.CLOUD,
                 signing_key=self.signing_key,
-                signing_key_fallback=None,
             ),
             str,
         )

--- a/tests/test_introspection/test_fast_api.py
+++ b/tests/test_introspection/test_fast_api.py
@@ -55,7 +55,7 @@ class TestIntrospection(base.BaseTestIntrospection):
             )
         )
 
-        req_sig = net.sign(b"", self.signing_key)
+        req_sig = net.sign_request(b"", self.signing_key)
         if isinstance(req_sig, Exception):
             raise req_sig
 
@@ -71,12 +71,11 @@ class TestIntrospection(base.BaseTestIntrospection):
             "has_signing_key_fallback": True,
         }
         assert isinstance(
-            net.validate_sig(
+            net.validate_response_sig(
                 body=res.content,
                 headers=dict(res.headers),
                 mode=server_lib.ServerKind.CLOUD,
                 signing_key=self.signing_key,
-                signing_key_fallback=None,
             ),
             str,
         )
@@ -95,7 +94,7 @@ class TestIntrospection(base.BaseTestIntrospection):
             )
         )
 
-        req_sig = net.sign(b"", signing_key_fallback)
+        req_sig = net.sign_request(b"", signing_key_fallback)
         if isinstance(req_sig, Exception):
             raise req_sig
 
@@ -112,12 +111,11 @@ class TestIntrospection(base.BaseTestIntrospection):
         }
 
         assert isinstance(
-            net.validate_sig(
+            net.validate_response_sig(
                 body=res.content,
                 headers=dict(res.headers),
                 mode=server_lib.ServerKind.CLOUD,
                 signing_key=signing_key_fallback,
-                signing_key_fallback=None,
             ),
             str,
         )

--- a/tests/test_introspection/test_flask.py
+++ b/tests/test_introspection/test_flask.py
@@ -56,7 +56,7 @@ class TestIntrospection(base.BaseTestIntrospection):
             )
         )
 
-        req_sig = net.sign(b"", self.signing_key)
+        req_sig = net.sign_request(b"", self.signing_key)
         if isinstance(req_sig, Exception):
             raise req_sig
 
@@ -74,12 +74,11 @@ class TestIntrospection(base.BaseTestIntrospection):
         }
 
         assert isinstance(
-            net.validate_sig(
+            net.validate_response_sig(
                 body=res.get_data(),
                 headers=res.headers,
                 mode=server_lib.ServerKind.CLOUD,
                 signing_key=self.signing_key,
-                signing_key_fallback=None,
             ),
             str,
         )
@@ -98,7 +97,7 @@ class TestIntrospection(base.BaseTestIntrospection):
             )
         )
 
-        req_sig = net.sign(b"", signing_key_fallback)
+        req_sig = net.sign_request(b"", signing_key_fallback)
         if isinstance(req_sig, Exception):
             raise req_sig
 
@@ -114,12 +113,11 @@ class TestIntrospection(base.BaseTestIntrospection):
             "has_signing_key_fallback": True,
         }
         assert isinstance(
-            net.validate_sig(
+            net.validate_response_sig(
                 body=res.get_data(),
                 headers=res.headers,
                 mode=server_lib.ServerKind.CLOUD,
                 signing_key=signing_key_fallback,
-                signing_key_fallback=None,
             ),
             str,
         )

--- a/tests/test_probes/test_fast_api.py
+++ b/tests/test_probes/test_fast_api.py
@@ -28,7 +28,7 @@ class TestIntrospection(base.BaseTest):
             )
         )
 
-        req_sig = net.sign(b"", self.signing_key)
+        req_sig = net.sign_request(b"", self.signing_key)
         if isinstance(req_sig, Exception):
             raise req_sig
 
@@ -43,12 +43,11 @@ class TestIntrospection(base.BaseTest):
         sig_header = res.headers.get(server_lib.HeaderKey.SIGNATURE.value)
         assert sig_header is not None
         assert isinstance(
-            net.validate_sig(
+            net.validate_response_sig(
                 body=res.content,
                 headers=dict(res.headers),
                 mode=server_lib.ServerKind.CLOUD,
                 signing_key=self.signing_key,
-                signing_key_fallback=None,
             ),
             str,
         )
@@ -87,7 +86,7 @@ class TestIntrospection(base.BaseTest):
             )
         )
 
-        req_sig = net.sign(b"", "wrong")
+        req_sig = net.sign_request(b"", "wrong")
         if isinstance(req_sig, Exception):
             raise req_sig
 

--- a/tests/test_probes/test_flask.py
+++ b/tests/test_probes/test_flask.py
@@ -29,7 +29,7 @@ class TestTrustProbe(base.BaseTest):
             )
         )
 
-        req_sig = net.sign(b"", self.signing_key)
+        req_sig = net.sign_request(b"", self.signing_key)
         if isinstance(req_sig, Exception):
             raise req_sig
 
@@ -44,12 +44,11 @@ class TestTrustProbe(base.BaseTest):
         sig_header = res.headers.get(server_lib.HeaderKey.SIGNATURE.value)
         assert sig_header is not None
         assert isinstance(
-            net.validate_sig(
+            net.validate_response_sig(
                 body=res.get_data(),
                 headers=res.headers,
                 mode=server_lib.ServerKind.CLOUD,
                 signing_key=self.signing_key,
-                signing_key_fallback=None,
             ),
             str,
         )
@@ -88,7 +87,7 @@ class TestTrustProbe(base.BaseTest):
             )
         )
 
-        req_sig = net.sign(b"", "wrong")
+        req_sig = net.sign_request(b"", "wrong")
         if isinstance(req_sig, Exception):
             raise req_sig
 

--- a/tests/test_registration/cases/cloud_branch_env.py
+++ b/tests/test_registration/cases/cloud_branch_env.py
@@ -43,7 +43,7 @@ def create(framework: server_lib.Framework) -> base.Case:
             ).to_dict()
         ).encode("utf-8")
 
-        req_sig = net.sign(req_body, signing_key)
+        req_sig = net.sign_request(req_body, signing_key)
         if isinstance(req_sig, Exception):
             raise req_sig
 
@@ -60,12 +60,11 @@ def create(framework: server_lib.Framework) -> base.Case:
         assert res.headers["x-inngest-sync-kind"] == "in_band"
 
         assert isinstance(
-            net.validate_sig(
+            net.validate_response_sig(
                 body=res.body,
                 headers=res.headers,
                 mode=server_lib.ServerKind.CLOUD,
                 signing_key=signing_key,
-                signing_key_fallback=None,
             ),
             str,
         )

--- a/tests/test_registration/cases/in_band_invalid_sig.py
+++ b/tests/test_registration/cases/in_band_invalid_sig.py
@@ -44,7 +44,7 @@ def create(framework: server_lib.Framework) -> base.Case:
         ).encode("utf-8")
 
         wrong_signing_key = "signkey-prod-111111"
-        req_sig = net.sign(req_body, wrong_signing_key)
+        req_sig = net.sign_request(req_body, wrong_signing_key)
         if isinstance(req_sig, Exception):
             raise req_sig
 


### PR DESCRIPTION
## Description
Stop canonicalizing when signing responses since Inngest servers don't do that with validating response signatures.

## Testing
- Updated existing tests.
- Did an in-band sync against Cloud. Both the sync and trust probe worked.