### PR TITLE
Make in-band syncing opt-out

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff"
   },
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   "mypy-type-checker.importStrategy": "fromEnvironment",
   "mypy-type-checker.preferDaemon": true,
   "python.analysis.typeCheckingMode": "basic",

--- a/inngest/_internal/comm_lib/handler.py
+++ b/inngest/_internal/comm_lib/handler.py
@@ -43,10 +43,11 @@ class CommHandler:
         framework: server_lib.Framework,
         functions: list[function.Function],
     ) -> None:
-        # TODO: Default to true once in-band syncing is stable
-        self._allow_in_band_sync = env_lib.is_true(
+        # In-band syncing is opt-out.
+        self._allow_in_band_sync = not env_lib.is_false(
             const.EnvKey.ALLOW_IN_BAND_SYNC,
         )
+
         self._client = client
         self._mode = client._mode
         self._api_origin = client.api_origin

--- a/inngest/_internal/env_lib.py
+++ b/inngest/_internal/env_lib.py
@@ -38,6 +38,15 @@ def get_url(
     return parsed
 
 
+def is_false(env_var: const.EnvKey) -> bool:
+    val = os.getenv(env_var.value)
+    if val is None:
+        return False
+    val = val.strip()
+
+    return val.lower() in ("false", "0")
+
+
 def is_true(env_var: const.EnvKey) -> bool:
     val = os.getenv(env_var.value)
     if val is None:

--- a/tests/test_registration/cases/__init__.py
+++ b/tests/test_registration/cases/__init__.py
@@ -3,17 +3,19 @@ from inngest._internal import server_lib
 from . import (
     base,
     cloud_branch_env,
+    disallow_in_band,
     in_band_invalid_sig,
     in_band_missing_sig,
-    out_of_band,
+    missing_sync_kind_header,
     server_kind_mismatch,
 )
 
 _modules = (
     cloud_branch_env,
+    disallow_in_band,
     in_band_invalid_sig,
     in_band_missing_sig,
-    out_of_band,
+    missing_sync_kind_header,
     server_kind_mismatch,
 )
 

--- a/tests/test_registration/cases/missing_sync_kind_header.py
+++ b/tests/test_registration/cases/missing_sync_kind_header.py
@@ -1,0 +1,121 @@
+import dataclasses
+import json
+import typing
+
+import inngest
+import inngest.fast_api
+from inngest._internal import const, server_lib
+from tests import http_proxy
+
+from . import base
+
+_TEST_NAME = base.create_test_name(__file__)
+
+
+def create(framework: server_lib.Framework) -> base.Case:
+    def run_test(self: base.TestCase) -> None:
+        """
+        Fallback to out-of-band sync when the sync kind header is missing.
+        """
+
+        @dataclasses.dataclass
+        class State:
+            body: typing.Optional[bytes]
+            headers: dict[str, list[str]]
+
+        state = State(
+            body=None,
+            headers={},
+        )
+
+        def on_request(
+            *,
+            body: typing.Optional[bytes],
+            headers: dict[str, list[str]],
+            method: str,
+            path: str,
+        ) -> http_proxy.Response:
+            for k, v in headers.items():
+                state.headers[k] = v
+
+            if body is not None:
+                state.body = body
+
+            return http_proxy.Response(
+                body=json.dumps({}).encode("utf-8"),
+                headers={},
+                status_code=200,
+            )
+
+        mock_cloud = http_proxy.Proxy(on_request).start()
+        self.addCleanup(mock_cloud.stop)
+
+        client = inngest.Inngest(
+            api_base_url=f"http://localhost:{mock_cloud.port}",
+            app_id=f"{framework.value}-{_TEST_NAME}",
+            env="my-env",
+            signing_key="signkey-prod-0486c9",
+        )
+
+        @client.create_function(
+            fn_id="foo",
+            retries=0,
+            trigger=inngest.TriggerEvent(event="app/foo"),
+        )
+        def fn(
+            ctx: inngest.Context,
+            step: inngest.StepSync,
+        ) -> None:
+            pass
+
+        self.serve(client, [fn])
+        res = self.put(body={})
+        assert res.status_code == 200
+        assert json.loads(res.body.decode("utf-8")) == {}
+
+        assert state.headers.get("authorization") is not None
+        assert state.headers.get("x-inngest-env") == ["my-env"]
+        assert state.headers.get("x-inngest-framework") == [framework.value]
+        assert state.headers.get("x-inngest-sdk") == [
+            f"inngest-py:v{const.VERSION}"
+        ]
+
+        host: str
+        if framework == server_lib.Framework.FAST_API:
+            host = "http://testserver"
+        elif framework == server_lib.Framework.FLASK:
+            host = "http://localhost"
+
+        assert state.body is not None
+        assert json.loads(state.body.decode("utf-8")) == {
+            "appname": client.app_id,
+            "capabilities": {"in_band_sync": "v1", "trust_probe": "v1"},
+            "deploy_type": "ping",
+            "framework": framework.value,
+            "functions": [
+                {
+                    "id": fn.id,
+                    "name": "foo",
+                    "steps": {
+                        "step": {
+                            "id": "step",
+                            "name": "step",
+                            "retries": {"attempts": 0},
+                            "runtime": {
+                                "type": "http",
+                                "url": f"{host}/api/inngest?fnId={fn.id}&stepId=step",
+                            },
+                        }
+                    },
+                    "triggers": [{"event": "app/foo"}],
+                }
+            ],
+            "sdk": f"py:v{const.VERSION}",
+            "url": f"{host}/api/inngest",
+            "v": "0.1",
+        }
+
+    return base.Case(
+        name=_TEST_NAME,
+        run_test=run_test,
+    )

--- a/tests/test_registration/test_fast_api.py
+++ b/tests/test_registration/test_fast_api.py
@@ -1,5 +1,4 @@
 import json
-import os
 import typing
 import unittest
 
@@ -8,7 +7,7 @@ import fastapi.testclient
 
 import inngest
 import inngest.fast_api
-from inngest._internal import const, server_lib
+from inngest._internal import server_lib
 
 from . import base, cases
 
@@ -18,18 +17,8 @@ _framework = server_lib.Framework.FAST_API
 class TestRegistration(base.TestCase):
     def setUp(self) -> None:
         super().setUp()
-
-        # TODO: Delete this when we default to allowing in-band sync
-        os.environ[const.EnvKey.ALLOW_IN_BAND_SYNC.value] = "1"
-
         self.app = fastapi.FastAPI()
         self.app_client = fastapi.testclient.TestClient(self.app)
-
-    def tearDown(self) -> None:
-        super().tearDown()
-
-        # TODO: Delete this when we default to allowing in-band sync
-        os.environ.pop(const.EnvKey.ALLOW_IN_BAND_SYNC.value, None)
 
     def put(
         self,

--- a/tests/test_registration/test_flask.py
+++ b/tests/test_registration/test_flask.py
@@ -1,4 +1,3 @@
-import os
 import typing
 import unittest
 
@@ -8,7 +7,7 @@ import flask.testing
 
 import inngest
 import inngest.flask
-from inngest._internal import const, server_lib
+from inngest._internal import server_lib
 
 from . import base, cases
 
@@ -18,18 +17,8 @@ _framework = server_lib.Framework.FLASK
 class TestRegistration(base.TestCase):
     def setUp(self) -> None:
         super().setUp()
-
-        # TODO: Delete this when we default to allowing in-band sync
-        os.environ[const.EnvKey.ALLOW_IN_BAND_SYNC.value] = "1"
-
         self.app = flask.Flask(__name__)
         self.app_client = self.app.test_client()
-
-    def tearDown(self) -> None:
-        super().tearDown()
-
-        # TODO: Delete this when we default to allowing in-band sync
-        os.environ.pop(const.EnvKey.ALLOW_IN_BAND_SYNC.value, None)
 
     def put(
         self,


### PR DESCRIPTION
## Changes
- Change in-band syncing to opt-out. It's currently opt-in.
- Rename a test to `missing_sync_kind_header`.
- Add test for opting out of in-band syncs.
- Change VS Code settings to format on save.

## Context
The Inngest server asks the SDK to perform an in-band sync via the `x-inngest-sync-kind` header. The SDK can still perform an out-of-band sync if it chooses; the Inngest server does not require an in-band response.