### PR TITLE
Fix step.invoke data is not encrypted

### DIFF
--- a/tests/gql.py
+++ b/tests/gql.py
@@ -28,7 +28,10 @@ class Client:
             return Error(message=f"failed to parse response as JSON: {e}")
 
         if gql_res.errors is not None:
-            return Error(message="GraphQL error", response=gql_res)
+            msg = "GraphQL error"
+            if len(gql_res.errors) > 0:
+                msg += f": {gql_res.errors[0].get('message')}"
+            return Error(message=msg, response=gql_res)
 
         return gql_res
 

--- a/tests/test_experimental/test_encryption_middleware/cases/invoke.py
+++ b/tests/test_experimental/test_encryption_middleware/cases/invoke.py
@@ -49,8 +49,10 @@ def create(
     def child_fn_sync(
         ctx: inngest.Context,
         step: inngest.StepSync,
-    ) -> str:
-        return f"Hello, {ctx.event.data['name']}!"
+    ) -> dict[str, str]:
+        return {
+            "msg": f"Hello, {ctx.event.data['name']}!",
+        }
 
     @client.create_function(
         fn_id=fn_id,
@@ -69,8 +71,8 @@ def create(
             function=child_fn_sync,
             data={"name": "Alice"},
         )
-        assert isinstance(result, str)
-        assert result == "Hello, Alice!"
+        assert isinstance(result, dict)
+        assert result["msg"] == "Hello, Alice!"
 
     @client.create_function(
         fn_id=f"{fn_id}/child",
@@ -81,8 +83,10 @@ def create(
     async def child_fn_async(
         ctx: inngest.Context,
         step: inngest.Step,
-    ) -> str:
-        return f"Hello, {ctx.event.data['name']}!"
+    ) -> dict[str, str]:
+        return {
+            "msg": f"Hello, {ctx.event.data['name']}!",
+        }
 
     @client.create_function(
         fn_id=fn_id,
@@ -96,13 +100,13 @@ def create(
     ) -> None:
         state.run_id = ctx.run_id
 
-        result = step.invoke(
+        result = await step.invoke(
             "invoke",
-            function=child_fn_sync,
+            function=child_fn_async,
             data={"name": "Alice"},
         )
-        assert isinstance(result, str)
-        assert result == "Hello, Alice!"
+        assert isinstance(result, dict)
+        assert result["msg"] == "Hello, Alice!"
 
     async def run_test(self: base.TestClass) -> None:
         self.client.send_sync(inngest.Event(name=event_name))

--- a/tests/test_experimental/test_encryption_middleware/test_fast_api.py
+++ b/tests/test_experimental/test_encryption_middleware/test_fast_api.py
@@ -1,0 +1,73 @@
+import threading
+import unittest
+
+import fastapi
+import uvicorn
+
+import inngest
+import inngest.fast_api
+from inngest._internal import server_lib
+from inngest.experimental import dev_server
+from tests import base, net
+
+from . import cases
+
+_framework = server_lib.Framework.FAST_API
+_app_id = f"{_framework.value}-encryption-middleware"
+
+_client = inngest.Inngest(
+    api_base_url=dev_server.server.origin,
+    app_id=_app_id,
+    event_api_base_url=dev_server.server.origin,
+    is_production=False,
+)
+
+_cases = cases.create_async_cases(_client, _framework)
+_fns: list[inngest.Function] = []
+for case in _cases:
+    if isinstance(case.fn, list):
+        _fns.extend(case.fn)
+    else:
+        _fns.append(case.fn)
+
+
+class TestEncryptionMiddleware(unittest.IsolatedAsyncioTestCase):
+    client = _client
+    app_thread: threading.Thread
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        port = net.get_available_port()
+
+        def start_app() -> None:
+            app = fastapi.FastAPI()
+            inngest.fast_api.serve(
+                app,
+                _client,
+                _fns,
+            )
+            uvicorn.run(app, host="0.0.0.0", port=port, log_level="warning")
+
+        # Start FastAPI in a thread instead of using their test client, since
+        # their test client doesn't seem to actually run requests in parallel
+        # (this is evident in the flakiness of our asyncio race test). If we fix
+        # this issue, we can go back to their test client
+        cls.app_thread = threading.Thread(daemon=True, target=start_app)
+        cls.app_thread.start()
+        base.register(port)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        super().tearDownClass()
+        cls.app_thread.join(timeout=1)
+
+
+for case in _cases:
+    test_name = f"test_{case.name}"
+    setattr(TestEncryptionMiddleware, test_name, case.run_test)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_function/cases/batch_that_needs_api.py
+++ b/tests/test_function/cases/batch_that_needs_api.py
@@ -72,7 +72,7 @@ def create(
             )
         self.client.send_sync(events)
 
-        run_id = state.wait_for_run_id()
+        run_id = state.wait_for_run_id(timeout=datetime.timedelta(seconds=10))
         tests.helper.client.wait_for_run_status(
             run_id,
             tests.helper.RunStatus.COMPLETED,


### PR DESCRIPTION
- Fix `step.invoke` arg `data` is not encrypted.
- Run encryption tests for FastAPI.

This is technically a breaking change, since this PR also adds invoke event data decryption