### PR TITLE
Fix result UnboundLocalError

### DIFF
--- a/pkg/inngest/inngest/_internal/step_lib/step_sync.py
+++ b/pkg/inngest/inngest/_internal/step_lib/step_sync.py
@@ -281,6 +281,9 @@ class StepSync(base.StepBase):
             if isinstance(middleware_err, Exception):
                 raise middleware_err
 
+            # Need to initialize `result` because of the `finally` block.
+            result: typing.Optional[client_models.SendEventsResult] = None
+
             try:
                 result = client_models.SendEventsResult(
                     ids=self._client.send_sync(
@@ -303,9 +306,15 @@ class StepSync(base.StepBase):
                 )
                 raise err
             finally:
-                middleware_err = self._middleware.after_send_events_sync(result)
-                if isinstance(middleware_err, Exception):
-                    raise middleware_err
+                if result is not None:
+                    middleware_err = self._middleware.after_send_events_sync(
+                        result
+                    )
+                    if isinstance(middleware_err, Exception):
+                        raise middleware_err
+
+            if result is None:
+                raise Exception("unreachable")
 
             return result.ids
 

--- a/pkg/inngest/pyproject.toml
+++ b/pkg/inngest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.4.18"
+version = "0.4.19a0"
 authors = [{ name = "Inngest Inc.", email = "hello@inngest.com" }]
 description = "Python SDK for Inngest"
 readme = "README.md"

--- a/pkg/inngest/pyproject.toml
+++ b/pkg/inngest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.4.19a0"
+version = "0.4.19"
 authors = [{ name = "Inngest Inc.", email = "hello@inngest.com" }]
 description = "Python SDK for Inngest"
 readme = "README.md"


### PR DESCRIPTION
Fix an issue where `result` isn't set, resulting in `UnboundLocalError` at runtime.

Fixes #199 