### PR TITLE
Remove invoke opt in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ format-check: check-venv
 	@ruff format --check .
 
 install: check-venv
-	@pip install -e '.[extra]' -e ./pkg/inngest -e ./pkg/test_core -c constraints.txt
+	@pip install -e '.[extra]' -e ./pkg/inngest -e ./pkg/inngest_encryption -e ./pkg/test_core -c constraints.txt
 
 itest: check-venv
 	@cd pkg/inngest && make itest

--- a/pkg/inngest_encryption/README.md
+++ b/pkg/inngest_encryption/README.md
@@ -1,3 +1,87 @@
 # Inngest Python SDK: Encryption
 
 This package provides encryption for the Inngest Python SDK.
+
+## Usage
+
+Setting encryption middleware on the client will turn on encryption for events and steps in all functions:
+
+```py
+import inngest
+from inngest_encryption import EncryptionMiddleware
+
+inngest.Inngest(
+    name="my-app",
+    encryption_key="my-encryption-key",
+    middleware=[EncryptionMiddleware.factory("my-secret-key")],
+)
+```
+
+When sending events or invoking functions, only the `encrypted` field will be encrypted:
+
+```py
+await step.send_event(
+    "my-step",
+    inngest.Event(
+        data={
+            # Everything in this field will be encrypted.
+            "encrypted": {
+                "phone": "867-5309",
+            },
+
+            # Not encrypted.
+            "user_id": "abc123",
+        },
+        name="my-event",
+    ),
+)
+
+await step.invoke(
+    "invoke",
+    function=child_fn_async,
+    data={
+        # Everything in this field will be encrypted.
+        "encrypted": {
+            "phone": "867-5309",
+        },
+
+        # Not encrypted.
+        "user_id": "abc123",
+    },
+)
+```
+
+> [!NOTE]  
+> Only a portion of the event data is encrypted because that allows for control flow settings (e.g. concurrency key) to work. Since the Inngest server receives encrypted data, it can't perform control flow on values that are encrypted.
+
+The entire `step.run` output is encrypted:
+
+```py
+def _my_step() -> dict[str, object]:
+    # Encrypted when sending back to the Inngest server.
+    return {"msg": "hello"}
+
+output = await step.run("my-step", _my_step)
+
+# Decrypted within this function.
+print(output)
+```
+
+## Key rotation
+
+When rotating the encryption key, you may still have active functions runs whose data is encrypted with the old key. To decrypt these, you can use the `fallback_decryption_keys` option:
+
+```py
+inngest.Inngest(
+    name="my-app",
+    encryption_key="my-encryption-key",
+    middleware=[
+        EncryptionMiddleware.factory(
+            "new-secret-key",
+            fallback_decryption_keys=["old-secret-key"],
+        ),
+    ],
+)
+```
+
+If decryption fails with the new key, the encryption middleware will fall back to the old key.

--- a/pkg/inngest_encryption/inngest_encryption/main.py
+++ b/pkg/inngest_encryption/inngest_encryption/main.py
@@ -53,7 +53,6 @@ class EncryptionMiddleware(inngest.MiddlewareSync):
         secret_key: typing.Union[bytes, str],
         *,
         decrypt_only: bool = False,
-        encrypt_invoke_data: bool = False,
         event_encryption_field: str = _default_event_encryption_field,
         fallback_decryption_keys: typing.Optional[
             list[typing.Union[bytes, str]]
@@ -66,7 +65,6 @@ class EncryptionMiddleware(inngest.MiddlewareSync):
             raw_request: Framework/platform specific request object.
             secret_key: Secret key used for encryption and decryption.
             decrypt_only: Only decrypt data (do not encrypt).
-            encrypt_invoke_data: Encrypt the data sent to invoked functions. Deprecated: Will be removed in a future release, where invoke data will always be encrypted (equivalent to encrypt_invoke_data=True).
             event_encryption_field: Automatically encrypt and decrypt this field in event data.
             fallback_decryption_keys: Fallback secret keys used for decryption.
         """
@@ -79,7 +77,6 @@ class EncryptionMiddleware(inngest.MiddlewareSync):
         )
 
         self._decrypt_only = decrypt_only
-        self._encrypt_invoke_data = encrypt_invoke_data
         self._event_encryption_field = event_encryption_field
 
         self._fallback_decryption_boxes = [
@@ -96,7 +93,6 @@ class EncryptionMiddleware(inngest.MiddlewareSync):
         secret_key: typing.Union[bytes, str],
         *,
         decrypt_only: bool = False,
-        encrypt_invoke_data: bool = False,
         event_encryption_field: str = _default_event_encryption_field,
         fallback_decryption_keys: typing.Optional[
             list[typing.Union[bytes, str]]
@@ -124,7 +120,6 @@ class EncryptionMiddleware(inngest.MiddlewareSync):
                 raw_request,
                 secret_key,
                 decrypt_only=decrypt_only,
-                encrypt_invoke_data=encrypt_invoke_data,
                 event_encryption_field=event_encryption_field,
                 fallback_decryption_keys=fallback_decryption_keys,
             )
@@ -269,8 +264,7 @@ class EncryptionMiddleware(inngest.MiddlewareSync):
 
         # Encrypt invoke data if present.
         if (
-            self._encrypt_invoke_data
-            and result.step is not None
+            result.step is not None
             and result.step.op is server_lib.Opcode.INVOKE
             and result.step.opts is not None
         ):

--- a/pkg/inngest_encryption/pyproject.toml
+++ b/pkg/inngest_encryption/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest_encryption"
-version = "0.0.1"
+version = "0.1.0"
 authors = [{ name = "Inngest Inc.", email = "hello@inngest.com" }]
 description = "Encryption for the Inngest SDK"
 readme = "README.md"

--- a/pkg/test_core/test_core/__init__.py
+++ b/pkg/test_core/test_core/__init__.py
@@ -1,0 +1,4 @@
+from .base import wait_for
+from .helper import RunStatus, client
+
+__all__ = ["client", "RunStatus", "wait_for"]

--- a/tests/test_inngest_encryption/cases/__init__.py
+++ b/tests/test_inngest_encryption/cases/__init__.py
@@ -9,6 +9,9 @@ from . import (
     encrypt_overridden_encryption_field,
     fallback_decryption_key,
     invoke,
+    invoke_custom_encryption_field,
+    send_event,
+    send_event_custom_encryption_field,
     step_and_fn_output,
 )
 
@@ -19,6 +22,9 @@ _modules = (
     encrypt_overridden_encryption_field,
     fallback_decryption_key,
     invoke,
+    invoke_custom_encryption_field,
+    send_event,
+    send_event_custom_encryption_field,
     step_and_fn_output,
 )
 
@@ -44,6 +50,3 @@ def create_sync_cases(
         cases.append(case)
 
     return cases
-
-
-__all__ = ["create_async_cases", "create_sync_cases"]

--- a/tests/test_inngest_encryption/cases/decrypt_event.py
+++ b/tests/test_inngest_encryption/cases/decrypt_event.py
@@ -9,7 +9,7 @@ import nacl.secret
 import nacl.utils
 import test_core.helper
 from inngest._internal import server_lib
-from inngest.experimental.encryption_middleware import EncryptionMiddleware
+from inngest_encryption import EncryptionMiddleware
 
 from . import base
 

--- a/tests/test_inngest_encryption/cases/decrypt_only.py
+++ b/tests/test_inngest_encryption/cases/decrypt_only.py
@@ -12,7 +12,7 @@ import nacl.secret
 import nacl.utils
 import test_core.helper
 from inngest._internal import server_lib
-from inngest.experimental.encryption_middleware import EncryptionMiddleware
+from inngest_encryption import EncryptionMiddleware
 
 from . import base
 

--- a/tests/test_inngest_encryption/cases/decrypt_unexpected_encryption_field.py
+++ b/tests/test_inngest_encryption/cases/decrypt_unexpected_encryption_field.py
@@ -10,7 +10,7 @@ import nacl.secret
 import nacl.utils
 import test_core.helper
 from inngest._internal import server_lib
-from inngest.experimental.encryption_middleware import EncryptionMiddleware
+from inngest_encryption import EncryptionMiddleware
 
 from . import base
 

--- a/tests/test_inngest_encryption/cases/encrypt_overridden_encryption_field.py
+++ b/tests/test_inngest_encryption/cases/encrypt_overridden_encryption_field.py
@@ -11,7 +11,7 @@ import nacl.utils
 import test_core.helper
 from inngest._internal import server_lib
 from inngest.experimental import dev_server
-from inngest.experimental.encryption_middleware import EncryptionMiddleware
+from inngest_encryption import EncryptionMiddleware
 
 from . import base
 

--- a/tests/test_inngest_encryption/cases/fallback_decryption_key.py
+++ b/tests/test_inngest_encryption/cases/fallback_decryption_key.py
@@ -10,7 +10,7 @@ import nacl.secret
 import nacl.utils
 import test_core.helper
 from inngest._internal import server_lib
-from inngest.experimental.encryption_middleware import EncryptionMiddleware
+from inngest_encryption import EncryptionMiddleware
 
 from . import base
 

--- a/tests/test_inngest_encryption/cases/invoke.py
+++ b/tests/test_inngest_encryption/cases/invoke.py
@@ -11,7 +11,7 @@ import nacl.secret
 import nacl.utils
 import test_core.helper
 from inngest._internal import server_lib
-from inngest.experimental.encryption_middleware import EncryptionMiddleware
+from inngest_encryption import EncryptionMiddleware
 
 from . import base
 
@@ -40,10 +40,7 @@ def create(
     event_name = base.create_event_name(framework, test_name)
     fn_id = base.create_fn_id(test_name)
     state = _State()
-    mw = EncryptionMiddleware.factory(
-        _secret_key,
-        encrypt_invoke_data=True,
-    )
+    mw = EncryptionMiddleware.factory(_secret_key)
 
     @client.create_function(
         fn_id=f"{fn_id}/child",

--- a/tests/test_inngest_encryption/cases/send_event_custom_encryption_field.py
+++ b/tests/test_inngest_encryption/cases/send_event_custom_encryption_field.py
@@ -1,6 +1,6 @@
 """
-step.invoke properly encrypts the event data. The triggered function receives
-decrypted data.
+step.invoke properly encrypts the event data when event_encryption_field is
+specified. The triggered function receives decrypted data.
 """
 
 import typing
@@ -47,15 +47,19 @@ def create(
 ) -> base.Case:
     test_name = base.create_test_name(__file__)
     event_name = base.create_event_name(framework, test_name)
+    child_event_name = f"{event_name}/child"
     fn_id = base.create_fn_id(test_name)
     state = _State()
-    mw = EncryptionMiddleware.factory(_secret_key)
+    mw = EncryptionMiddleware.factory(
+        _secret_key,
+        event_encryption_field="foo",
+    )
 
     @client.create_function(
         fn_id=f"{fn_id}/child",
         middleware=[mw],
         retries=0,
-        trigger=inngest.TriggerEvent(event="never"),
+        trigger=inngest.TriggerEvent(event=child_event_name),
     )
     def child_fn_sync(
         ctx: inngest.Context,
@@ -64,7 +68,7 @@ def create(
         state.child_run_id = ctx.run_id
         state.child_event = ctx.event
 
-        encrypted = ctx.event.data["encrypted"]
+        encrypted = ctx.event.data["foo"]
         assert isinstance(encrypted, dict)
         phone = encrypted["phone"]
         assert isinstance(phone, str)
@@ -82,24 +86,24 @@ def create(
     ) -> None:
         state.run_id = ctx.run_id
 
-        result = step.invoke(
+        step.send_event(
             "invoke",
-            function=child_fn_async,
-            data={
-                "encrypted": {
-                    "phone": "867-5309",
+            inngest.Event(
+                data={
+                    "foo": {
+                        "phone": "867-5309",
+                    },
+                    "user_id": "abc123",
                 },
-                "user_id": "abc123",
-            },
+                name=child_event_name,
+            ),
         )
-        assert isinstance(result, dict)
-        assert result == {"msg": "Number is 867-5309"}
 
     @client.create_function(
         fn_id=f"{fn_id}/child",
         middleware=[mw],
         retries=0,
-        trigger=inngest.TriggerEvent(event="never"),
+        trigger=inngest.TriggerEvent(event=child_event_name),
     )
     async def child_fn_async(
         ctx: inngest.Context,
@@ -108,7 +112,7 @@ def create(
         state.child_run_id = ctx.run_id
         state.child_event = ctx.event
 
-        encrypted = ctx.event.data["encrypted"]
+        encrypted = ctx.event.data["foo"]
         assert isinstance(encrypted, dict)
         phone = encrypted["phone"]
         assert isinstance(phone, str)
@@ -130,7 +134,7 @@ def create(
             "invoke",
             function=child_fn_async,
             data={
-                "encrypted": {
+                "foo": {
                     "phone": "867-5309",
                 },
                 "user_id": "abc123",
@@ -177,12 +181,12 @@ def _assert_event_in_child_run(event: inngest.Event) -> None:
     # Only the _inngest field was added.
     assert sorted(event.data.keys()) == [
         "_inngest",
-        "encrypted",
+        "foo",
         "user_id",
     ]
 
     # The encrypted data was decrypted for the child run.
-    assert event.data["encrypted"] == {
+    assert event.data["foo"] == {
         "phone": "867-5309",
     }
 
@@ -196,12 +200,12 @@ def _assert_event_in_db(event: inngest.Event) -> None:
     # Only the _inngest field was added.
     assert sorted(event.data.keys()) == [
         "_inngest",
-        "encrypted",
+        "foo",
         "user_id",
     ]
 
     # The encrypted data schema is correct.
-    encrypted = event.data["encrypted"]
+    encrypted = event.data["foo"]
     assert isinstance(encrypted, dict)
     assert sorted(encrypted.keys()) == [
         "__ENCRYPTED__",

--- a/tests/test_inngest_encryption/cases/send_event_custom_encryption_field.py
+++ b/tests/test_inngest_encryption/cases/send_event_custom_encryption_field.py
@@ -1,5 +1,5 @@
 """
-step.invoke properly encrypts the event data when event_encryption_field is
+step.send_event properly encrypts the event data when event_encryption_field is
 specified. The triggered function receives decrypted data.
 """
 
@@ -87,7 +87,7 @@ def create(
         state.run_id = ctx.run_id
 
         step.send_event(
-            "invoke",
+            "send",
             inngest.Event(
                 data={
                     "foo": {
@@ -130,18 +130,18 @@ def create(
     ) -> None:
         state.run_id = ctx.run_id
 
-        result = await step.invoke(
-            "invoke",
-            function=child_fn_async,
-            data={
-                "foo": {
-                    "phone": "867-5309",
+        await step.send_event(
+            "send",
+            inngest.Event(
+                data={
+                    "foo": {
+                        "phone": "867-5309",
+                    },
+                    "user_id": "abc123",
                 },
-                "user_id": "abc123",
-            },
+                name=child_event_name,
+            ),
         )
-        assert isinstance(result, dict)
-        assert result == {"msg": "Number is 867-5309"}
 
     async def run_test(self: base.TestClass) -> None:
         self.client.send_sync(inngest.Event(name=event_name))
@@ -180,7 +180,6 @@ def _assert_event_in_child_run(event: inngest.Event) -> None:
 
     # Only the _inngest field was added.
     assert sorted(event.data.keys()) == [
-        "_inngest",
         "foo",
         "user_id",
     ]
@@ -199,7 +198,6 @@ def _assert_event_in_db(event: inngest.Event) -> None:
 
     # Only the _inngest field was added.
     assert sorted(event.data.keys()) == [
-        "_inngest",
         "foo",
         "user_id",
     ]

--- a/tests/test_inngest_encryption/cases/step_and_fn_output.py
+++ b/tests/test_inngest_encryption/cases/step_and_fn_output.py
@@ -94,7 +94,6 @@ def create(
         return "function output"
 
     async def run_test(self: base.TestClass) -> None:
-        print("running step and fn output test")
         self.client.send_sync(inngest.Event(name=event_name))
 
         run_id = await state.wait_for_run_id()
@@ -131,7 +130,6 @@ def create(
         run_output = json.loads(run.output)
         assert isinstance(run_output, dict)
         assert enc.decrypt(run_output["data"]) == "function output"
-        print("step and fn output test passed")
 
     if is_sync:
         fn = fn_sync

--- a/tests/test_inngest_encryption/cases/step_and_fn_output.py
+++ b/tests/test_inngest_encryption/cases/step_and_fn_output.py
@@ -11,7 +11,7 @@ import nacl.secret
 import nacl.utils
 import test_core.helper
 from inngest._internal import server_lib
-from inngest.experimental.encryption_middleware import EncryptionMiddleware
+from inngest_encryption import EncryptionMiddleware
 
 from . import base
 

--- a/tests/test_inngest_encryption/test_flask.py
+++ b/tests/test_inngest_encryption/test_flask.py
@@ -76,9 +76,6 @@ class TestEncryptionMiddleware(unittest.IsolatedAsyncioTestCase):
             path=path,
         )
 
-    async def test_foo(self) -> None:
-        assert True
-
 
 for case in _cases:
     test_name = f"test_{case.name}"

--- a/tests/test_inngest_encryption/test_flask.py
+++ b/tests/test_inngest_encryption/test_flask.py
@@ -54,10 +54,8 @@ class TestEncryptionMiddleware(unittest.IsolatedAsyncioTestCase):
 
     @classmethod
     def tearDownClass(cls) -> None:
-        print("tearing down Flask")
         super().tearDownClass()
         cls.proxy.stop()
-        print("Flask torn down")
 
     @classmethod
     def on_proxy_request(


### PR DESCRIPTION
Remove invoke encryption opt-in. It was only there to add a graceful upgrade flow for a bug fix. This is a breaking change, so also bump the version to `0.1.0`.

Change `step.invoke` to encrypt a specific field like we do with events. Previously, we encrypted the entire `data` object. This change is necessary to allow flow control to work (since that can't work on encrypted fields)