### PR TITLE
Support Python 3.13

### DIFF
--- a/.github/workflows/inngest.yml
+++ b/.github/workflows/inngest.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9", "3.13"]
     timeout-minutes: 10
     steps:
       - uses: "actions/checkout@v2"
@@ -54,7 +54,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9", "3.13"]
     steps:
       - uses: "actions/checkout@v2"
       - name: "Set up Python ${{ matrix.python-version }}"
@@ -103,7 +103,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9", "3.13"]
     steps:
       - uses: "actions/checkout@v2"
       - name: "Set up Python ${{ matrix.python-version }}"
@@ -120,7 +120,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9", "3.13"]
     steps:
       - uses: "actions/checkout@v2"
       - name: "Set up Python ${{ matrix.python-version }}"

--- a/constraints.txt
+++ b/constraints.txt
@@ -3,5 +3,5 @@
 # constraints won't affect installed versions by consumers.
 httpx==0.24.0
 jcs==0.2.1
-pydantic==2.1.1
+pydantic==2.8.0
 typing-extensions==4.8.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -4,4 +4,4 @@
 httpx==0.24.0
 jcs==0.2.1
 pydantic==2.8.0
-typing-extensions==4.8.0
+typing-extensions==4.12.2

--- a/pkg/inngest/pyproject.toml
+++ b/pkg/inngest/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "httpx>=0.24.0",
     "jcs>=0.2.1",
     "pydantic>=2.8.0",
-    "typing-extensions>=4.8.0",
+    "typing-extensions>=4.12.2",
 ]
 
 [project.urls]

--- a/pkg/inngest/pyproject.toml
+++ b/pkg/inngest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.4.20"
+version = "0.5.0a0+dev1"
 authors = [{ name = "Inngest Inc.", email = "hello@inngest.com" }]
 description = "Python SDK for Inngest"
 readme = "README.md"

--- a/pkg/inngest/pyproject.toml
+++ b/pkg/inngest/pyproject.toml
@@ -14,13 +14,14 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.9"
 
 dependencies = [
     "httpx>=0.24.0",
     "jcs>=0.2.1",
-    "pydantic>=2.1.1",
+    "pydantic>=2.8.0",
     "typing-extensions>=4.8.0",
 ]
 

--- a/pkg/inngest/pyproject.toml
+++ b/pkg/inngest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.5.0a0+dev1"
+version = "0.5.0"
 authors = [{ name = "Inngest Inc.", email = "hello@inngest.com" }]
 description = "Python SDK for Inngest"
 readme = "README.md"


### PR DESCRIPTION
- Update `pydantic` to `2.8.0` since that's their oldest version that supports Python 3.13.
- Update `typing-extensions` to `4.12.2` since that's the minimum constraint in `pydantic==2.8.0`.