### PR TITLE
Connect: add thread pool

### DIFF
--- a/pkg/inngest/inngest/_internal/function.py
+++ b/pkg/inngest/inngest/_internal/function.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import concurrent.futures
 import dataclasses
 import inspect
 import typing
@@ -137,6 +138,9 @@ class Function:
         request: server_lib.ServerRequest,
         steps: step_lib.StepMemos,
         target_hashed_id: typing.Optional[str],
+        thread_pool: typing.Optional[
+            concurrent.futures.ThreadPoolExecutor
+        ] = None,
     ) -> execution_lib.CallResult:
         middleware = middleware_lib.MiddlewareManager.from_manager(middleware)
         for m in self._middleware:
@@ -173,6 +177,7 @@ class Function:
                 middleware,
                 request,
                 target_hashed_id,
+                thread_pool,
             )
 
         call_res = await execution.run(
@@ -223,6 +228,8 @@ class Function:
                 errors.FunctionNotFoundError("function ID mismatch")
             )
 
+        # We don't need to pass a thread pool here because the sync handler is
+        # not used by Connect.
         call_res = execution_lib.ExecutionV0Sync(
             steps,
             middleware,

--- a/pkg/inngest/inngest/experimental/connect/connection.py
+++ b/pkg/inngest/inngest/experimental/connect/connection.py
@@ -116,7 +116,7 @@ class _WebSocketWorkerConnection(WorkerConnection):
             max_thread_pool_workers = int(
                 os.getenv("INNGEST_MAX_THREAD_POOL_WORKERS", "10")
             )
-        except Exception:
+        except ValueError:
             max_thread_pool_workers = 10
 
         # We need a thread pool to run sync Inngest functions in a non-blocking

--- a/pkg/inngest/pyproject.toml
+++ b/pkg/inngest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.4.21"
+version = "0.4.22a0"
 authors = [{ name = "Inngest Inc.", email = "hello@inngest.com" }]
 description = "Python SDK for Inngest"
 readme = "README.md"

--- a/tests/test_inngest/test_connect/test_concurrent_sync_functions.py
+++ b/tests/test_inngest/test_connect/test_concurrent_sync_functions.py
@@ -29,13 +29,11 @@ class TestConcurrentSyncFunctions(BaseTest):
             trigger=inngest.TriggerEvent(event=event_name),
         )
         def fn(ctx: inngest.Context, step: inngest.StepSync) -> None:
-            nonlocal run_ids
             run_ids.add(ctx.run_id)
 
             # This will loop forever if the function run is blocking the event
             # loop, causing the test to timeout.
             while True:
-                print(ctx.run_id, len(run_ids))
                 if len(run_ids) == 2:
                     break
                 time.sleep(0.1)

--- a/tests/test_inngest/test_connect/test_concurrent_sync_functions.py
+++ b/tests/test_inngest/test_connect/test_concurrent_sync_functions.py
@@ -1,0 +1,66 @@
+import asyncio
+import time
+
+import inngest
+import test_core
+from inngest.experimental.connect import ConnectionState, connect
+
+from .base import BaseTest
+
+
+class TestConcurrentSyncFunctions(BaseTest):
+    async def test_cloud(self) -> None:
+        """
+        Test that sync functions can be run concurrently. Under-the-hood, this
+        is accomplished with a ThreadPoolExecutor that is shared across all
+        functions.
+        """
+
+        client = inngest.Inngest(
+            app_id=test_core.random_suffix("app"),
+            is_production=False,
+        )
+        event_name = test_core.random_suffix("event")
+        run_ids = set[str]()
+
+        @client.create_function(
+            fn_id="fn",
+            retries=0,
+            trigger=inngest.TriggerEvent(event=event_name),
+        )
+        def fn(ctx: inngest.Context, step: inngest.StepSync) -> None:
+            run_ids.add(ctx.run_id)
+
+            # This will loop forever if the function run is blocking the event
+            # loop, causing the test to timeout.
+            while True:
+                if len(run_ids) == 2:
+                    break
+
+        conn = connect([(client, [fn])])
+        task = asyncio.create_task(conn.start())
+        self.addCleanup(conn.close, wait=True)
+        self.addCleanup(task.cancel)
+        await conn.wait_for_state(ConnectionState.ACTIVE)
+
+        # Trigger the function and wait for it to complete.
+        await client.send(
+            [
+                inngest.Event(name=event_name),
+                inngest.Event(name=event_name),
+            ]
+        )
+
+        def assert_runs() -> None:
+            assert len(run_ids) == 2
+
+        await test_core.wait_for(assert_runs)
+
+        await test_core.helper.client.wait_for_run_status(
+            run_ids.pop(),
+            test_core.helper.RunStatus.COMPLETED,
+        )
+        await test_core.helper.client.wait_for_run_status(
+            run_ids.pop(),
+            test_core.helper.RunStatus.COMPLETED,
+        )

--- a/tests/test_inngest/test_connect/test_concurrent_sync_functions.py
+++ b/tests/test_inngest/test_connect/test_concurrent_sync_functions.py
@@ -36,6 +36,7 @@ class TestConcurrentSyncFunctions(BaseTest):
             while True:
                 if len(run_ids) == 2:
                     break
+                time.sleep(0.1)
 
         conn = connect([(client, [fn])])
         task = asyncio.create_task(conn.start())


### PR DESCRIPTION
Add a thread pool to Connect. This is only used when running a synchronous (i.e. not `async`) Inngest function.

This is a special need for Connect because it bypasses HTTP frameworks. For example, when using `serve` with Flask, Flask will already create a new thread for each request