### PR TITLE
Fix blocking thread pool

### DIFF
--- a/pkg/inngest/inngest/_internal/async_lib.py
+++ b/pkg/inngest/inngest/_internal/async_lib.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
 import asyncio
+import concurrent.futures
 import typing
+
+from inngest._internal import types
 
 
 def get_event_loop() -> typing.Optional[asyncio.AbstractEventLoop]:
@@ -9,3 +14,81 @@ def get_event_loop() -> typing.Optional[asyncio.AbstractEventLoop]:
         return None
 
     return loop
+
+
+async def run_in_thread(
+    executor: concurrent.futures.Executor,
+    func: typing.Callable[..., types.T],
+) -> types.T:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(executor, func)
+
+
+class _CountingSemaphore:
+    def __init__(self, initial_value: int = 1) -> None:
+        self.counter: int = initial_value
+        self.waiters: list[asyncio.Future[bool]] = []
+
+    async def acquire(self) -> bool:
+        if self.counter > 0:
+            self.counter -= 1
+            return True
+
+        # No resources available, create a future and wait
+        future: asyncio.Future[bool] = asyncio.Future()
+        self.waiters.append(future)
+        await future
+        return True
+
+    def release(self) -> None:
+        self.counter += 1
+
+        # If there are waiters, wake one up.
+        if self.waiters and self.counter > 0:
+            waiter: asyncio.Future[bool] = self.waiters.pop(0)
+            if not waiter.done():
+                self.counter -= 1
+                waiter.set_result(True)
+
+    async def __aenter__(self) -> _CountingSemaphore:
+        await self.acquire()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: typing.Optional[type],
+        exc_val: typing.Optional[Exception],
+        exc_tb: typing.Optional[object],
+    ) -> None:
+        self.release()
+
+
+class ThreadPool:
+    """
+    A thread pool that runs non-async functions in a non-blocking way. It's a
+    thin wrapper around ThreadPoolExecutor, including a counting semaphore to
+    keep the number of threads below the max workers. Without this protection,
+    exceeding max workers blocks the thread.
+    """
+
+    _loop: typing.Optional[asyncio.AbstractEventLoop] = None
+
+    @property
+    def max_workers(self) -> int:
+        return self._executor._max_workers
+
+    def __init__(self, max_workers: typing.Optional[int]) -> None:
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=max_workers
+        )
+        self._semaphore = _CountingSemaphore(self._executor._max_workers)
+
+    async def run_in_thread(
+        self,
+        func: typing.Callable[[], types.T],
+    ) -> types.T:
+        if self._loop is None:
+            self._loop = asyncio.get_running_loop()
+
+        async with self._semaphore:
+            return await self._loop.run_in_executor(self._executor, func)

--- a/pkg/inngest/inngest/_internal/async_lib_test.py
+++ b/pkg/inngest/inngest/_internal/async_lib_test.py
@@ -1,0 +1,38 @@
+import asyncio
+import time
+import unittest
+
+from . import async_lib
+
+
+class TestThreadPool(unittest.IsolatedAsyncioTestCase):
+    async def test_exceed_max_workers(self) -> None:
+        pool = async_lib.ThreadPool(1)
+
+        counter = 0
+
+        async def increment() -> None:
+            nonlocal counter
+
+            while True:
+                await asyncio.sleep(0.1)
+                counter += 1
+
+        task = asyncio.create_task(increment())
+        self.addCleanup(task.cancel)
+
+        def block() -> None:
+            time.sleep(2)
+
+        start = time.time()
+        await pool.run_in_thread(block)
+        await pool.run_in_thread(block)
+
+        # Sync functions run sequentially.
+        assert round(time.time() - start, 1) == 4
+
+        # Assert that the increment function was called every 0.1 seconds. We'll
+        # do that by checking that the counter was incremented roughly 10 times
+        # per second.
+        assert counter >= 39
+        assert counter <= 41

--- a/pkg/inngest/inngest/_internal/comm_lib/handler.py
+++ b/pkg/inngest/inngest/_internal/comm_lib/handler.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
 import http
 import os
 import typing
@@ -10,6 +9,7 @@ import urllib.parse
 import httpx
 
 from inngest._internal import (
+    async_lib,
     client_lib,
     const,
     env_lib,
@@ -77,8 +77,10 @@ class CommHandler:
             # We don't need the thread pool when CommHandler is called from a
             # non-async context because we can assume that the HTTP framework
             # (e.g.  Flask) created a thread for the request.
-            self._thread_pool = concurrent.futures.ThreadPoolExecutor(
-                max_workers=thread_pool_max_workers,
+            self._thread_pool = async_lib.ThreadPool(thread_pool_max_workers)
+
+            self._client.logger.debug(
+                f"Created thread pool with {self._thread_pool.max_workers} max workers",
             )
 
         signing_key = client.signing_key

--- a/pkg/inngest/inngest/_internal/function.py
+++ b/pkg/inngest/inngest/_internal/function.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import concurrent.futures
 import dataclasses
 import inspect
 import typing
@@ -9,6 +8,7 @@ import urllib.parse
 import pydantic
 
 from inngest._internal import (
+    async_lib,
     client_lib,
     errors,
     execution_lib,
@@ -138,9 +138,7 @@ class Function:
         request: server_lib.ServerRequest,
         steps: step_lib.StepMemos,
         target_hashed_id: typing.Optional[str],
-        thread_pool: typing.Optional[
-            concurrent.futures.ThreadPoolExecutor
-        ] = None,
+        thread_pool: typing.Optional[async_lib.ThreadPool] = None,
     ) -> execution_lib.CallResult:
         middleware = middleware_lib.MiddlewareManager.from_manager(middleware)
         for m in self._middleware:

--- a/pkg/inngest/pyproject.toml
+++ b/pkg/inngest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.4.22a1"
+version = "0.4.22a2"
 authors = [{ name = "Inngest Inc.", email = "hello@inngest.com" }]
 description = "Python SDK for Inngest"
 readme = "README.md"


### PR DESCRIPTION
## Description

Fix the main thread blocking when the number of pending thread pool jobs exceeds that max thread pool workers. This can only happen in either of the following situations:
1. Connect + a non-async Inngest function.
2. Async `serve` (e.g. FastAPI) + non-async Inngest function.

The solution is to put a counting semaphore in front of the thread pool, ensuring that the thread pool's job count never exceeds its max workers.