### PR TITLE
Connect: fix auto-close on non-retryably start request fail

### DIFF
--- a/pkg/inngest/inngest/experimental/connect/conn_init_starter.py
+++ b/pkg/inngest/inngest/experimental/connect/conn_init_starter.py
@@ -35,7 +35,6 @@ class _ConnInitHandler(_BaseHandler):
     def __init__(
         self,
         api_origin: str,
-        close_all: typing.Callable[[], None],
         http_client: net.ThreadAwareAsyncHTTPClient,
         http_client_sync: httpx.Client,
         logger: types.Logger,
@@ -45,7 +44,6 @@ class _ConnInitHandler(_BaseHandler):
         state: _State,
     ):
         self._api_origin = api_origin
-        self._close_all = close_all
         self._http_client = http_client
         self._http_client_sync = http_client_sync
         self._logger = logger
@@ -108,7 +106,7 @@ class _ConnInitHandler(_BaseHandler):
             if err is not None:
                 # Close everything because we non-retryably failed to send the
                 # start request.
-                self._close_all()
+                self._state.fatal_error.value = err
                 return
 
             await self._state.conn_init.wait_for(None)

--- a/pkg/inngest/inngest/experimental/connect/connection.py
+++ b/pkg/inngest/inngest/experimental/connect/connection.py
@@ -181,6 +181,7 @@ class _WebSocketWorkerConnection(WorkerConnection):
         self._handlers: list[_BaseHandler] = [
             _ConnInitHandler(
                 api_origin=self._api_origin,
+                close_all=self._close,
                 http_client=self._http_client,
                 http_client_sync=self._http_client_sync,
                 logger=self._logger,

--- a/pkg/inngest/inngest/experimental/connect/models.py
+++ b/pkg/inngest/inngest/experimental/connect/models.py
@@ -18,6 +18,10 @@ class _State:
     draining: _ValueWatcher[bool]
     exclude_gateways: list[str]
     extend_lease_interval: _ValueWatcher[typing.Optional[int]]
+
+    # Error that should make Connect close and raise an exception.
+    fatal_error: _ValueWatcher[typing.Optional[Exception]]
+
     ws: _ValueWatcher[typing.Optional[websockets.ClientConnection]]
 
 

--- a/pkg/inngest/pyproject.toml
+++ b/pkg/inngest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.4.22a3"
+version = "0.4.22"
 authors = [{ name = "Inngest Inc.", email = "hello@inngest.com" }]
 description = "Python SDK for Inngest"
 readme = "README.md"

--- a/tests/test_inngest/test_connect/test_init_handshake.py
+++ b/tests/test_inngest/test_connect/test_init_handshake.py
@@ -5,6 +5,7 @@ import typing
 
 import httpx
 import inngest
+import pytest
 import test_core
 import test_core.http_proxy
 import test_core.net
@@ -213,7 +214,7 @@ class TestAPIRequestHeaders(BaseTest):
 
     async def test_start_request_non_retryable_failure(self) -> None:
         """
-        Closes when the start request fails non-retryably.
+        Raises an exception when the start request fails non-retryably.
         """
 
         @dataclasses.dataclass
@@ -258,4 +259,7 @@ class TestAPIRequestHeaders(BaseTest):
         task = asyncio.create_task(conn.start())
         self.addCleanup(task.cancel)
 
-        await conn.closed()
+        with pytest.raises(Exception) as e:
+            await task
+
+        assert str(e.value) == "unauthorized"


### PR DESCRIPTION
Fix Connect not closing itself when it non-retryably fails to send the start request.