### PR TITLE
Reverse 'after' middleware hooks; delete memoization hooks

### DIFF
--- a/pkg/inngest/inngest/_internal/middleware_lib/manager.py
+++ b/pkg/inngest/inngest/_internal/middleware_lib/manager.py
@@ -82,6 +82,7 @@ class MiddlewareManager:
 
     async def after_execution(self) -> types.MaybeError[None]:
         try:
+            # Reverse order because this is an "after" hook.
             for m in reversed(self._middleware):
                 await transforms.maybe_await(m.after_execution())
             return None
@@ -90,6 +91,7 @@ class MiddlewareManager:
 
     def after_execution_sync(self) -> types.MaybeError[None]:
         try:
+            # Reverse order because this is an "after" hook.
             for m in reversed(self._middleware):
                 if inspect.iscoroutinefunction(m.after_execution):
                     return _mismatched_sync
@@ -103,6 +105,7 @@ class MiddlewareManager:
         result: client_lib.SendEventsResult,
     ) -> types.MaybeError[None]:
         try:
+            # Reverse order because this is an "after" hook.
             for m in reversed(self._middleware):
                 await transforms.maybe_await(m.after_send_events(result))
             return None
@@ -114,6 +117,7 @@ class MiddlewareManager:
         result: client_lib.SendEventsResult,
     ) -> types.MaybeError[None]:
         try:
+            # Reverse order because this is an "after" hook.
             for m in reversed(self._middleware):
                 if inspect.iscoroutinefunction(m.after_execution):
                     return _mismatched_sync
@@ -260,6 +264,7 @@ class MiddlewareManager:
             )
 
         try:
+            # Reverse order because this is an "after" hook.
             for m in reversed(self._middleware):
                 await transforms.maybe_await(m.transform_output(result))
 
@@ -301,6 +306,7 @@ class MiddlewareManager:
             )
 
         try:
+            # Reverse order because this is an "after" hook.
             for m in reversed(self._middleware):
                 if isinstance(m, Middleware):
                     return _mismatched_sync

--- a/pkg/inngest/inngest/_internal/middleware_lib/middleware.py
+++ b/pkg/inngest/inngest/_internal/middleware_lib/middleware.py
@@ -34,13 +34,6 @@ class Middleware:
         """
         return None
 
-    async def after_memoization(self) -> None:
-        """
-        After exhausting memoized step data. Always called immediately before
-        before_execution.
-        """
-        return None
-
     async def after_send_events(
         self,
         result: client_lib.SendEventsResult,
@@ -54,13 +47,6 @@ class Middleware:
         """
         Before executing new code. Called multiple times per run when using
         steps.
-        """
-        return None
-
-    async def before_memoization(self) -> None:
-        """
-        Before checking memoized step data. Always called immediately after
-        transform_input.
         """
         return None
 
@@ -121,13 +107,6 @@ class MiddlewareSync:
         """
         return None
 
-    def after_memoization(self) -> None:
-        """
-        After exhausting memoized step data. Always called immediately before
-        before_execution.
-        """
-        return None
-
     def after_send_events(
         self,
         result: client_lib.SendEventsResult,
@@ -141,13 +120,6 @@ class MiddlewareSync:
         """
         Before executing new code. Called multiple times per run when using
         steps.
-        """
-        return None
-
-    def before_memoization(self) -> None:
-        """
-        Before checking memoized step data. Always called immediately after
-        transform_input.
         """
         return None
 

--- a/tests/test_inngest/test_client/test_client_middleware.py
+++ b/tests/test_inngest/test_client/test_client_middleware.py
@@ -45,16 +45,12 @@ class TestClientMiddleware(unittest.IsolatedAsyncioTestCase):
             "after_send_events",
             # Entry 1
             "transform_input",
-            "before_memoization",
-            "after_memoization",
             "before_execution",
             "after_execution",
             "transform_output",
             "before_response",
             # Entry 2
             "transform_input",
-            "before_memoization",
-            "after_memoization",
             "before_execution",
             "before_send_events",
             "after_send_events",
@@ -63,8 +59,6 @@ class TestClientMiddleware(unittest.IsolatedAsyncioTestCase):
             "before_response",
             # Entry 3
             "transform_input",
-            "before_memoization",
-            "after_memoization",
             "before_execution",
             "after_execution",
             "transform_output",
@@ -110,9 +104,6 @@ class TestClientMiddleware(unittest.IsolatedAsyncioTestCase):
             async def after_execution(self) -> None:
                 state.hook_list.append("after_execution")
 
-            async def after_memoization(self) -> None:
-                state.hook_list.append("after_memoization")
-
             async def after_send_events(
                 self,
                 result: inngest.SendEventsResult,
@@ -121,9 +112,6 @@ class TestClientMiddleware(unittest.IsolatedAsyncioTestCase):
 
             async def before_execution(self) -> None:
                 state.hook_list.append("before_execution")
-
-            async def before_memoization(self) -> None:
-                state.hook_list.append("before_memoization")
 
             async def before_response(self) -> None:
                 state.hook_list.append("before_response")
@@ -211,9 +199,6 @@ class TestClientMiddleware(unittest.IsolatedAsyncioTestCase):
             def after_execution(self) -> None:
                 state.hook_list.append("after_execution")
 
-            def after_memoization(self) -> None:
-                state.hook_list.append("after_memoization")
-
             def after_send_events(
                 self,
                 result: inngest.SendEventsResult,
@@ -222,9 +207,6 @@ class TestClientMiddleware(unittest.IsolatedAsyncioTestCase):
 
             def before_execution(self) -> None:
                 state.hook_list.append("before_execution")
-
-            def before_memoization(self) -> None:
-                state.hook_list.append("before_memoization")
 
             def before_response(self) -> None:
                 state.hook_list.append("before_response")

--- a/tests/test_inngest/test_function/cases/function_middleware.py
+++ b/tests/test_inngest/test_function/cases/function_middleware.py
@@ -39,9 +39,6 @@ def create(
         def after_execution(self) -> None:
             state.messages.append("hook:after_execution")
 
-        def after_memoization(self) -> None:
-            state.messages.append("hook:after_memoization")
-
         def after_send_events(
             self,
             result: inngest.SendEventsResult,
@@ -50,9 +47,6 @@ def create(
 
         def before_execution(self) -> None:
             state.messages.append("hook:before_execution")
-
-        def before_memoization(self) -> None:
-            state.messages.append("hook:before_memoization")
 
         def before_response(self) -> None:
             state.messages.append("hook:before_response")
@@ -88,9 +82,6 @@ def create(
         async def after_execution(self) -> None:
             state.messages.append("hook:after_execution")
 
-        async def after_memoization(self) -> None:
-            state.messages.append("hook:after_memoization")
-
         async def after_send_events(
             self,
             result: inngest.SendEventsResult,
@@ -99,9 +90,6 @@ def create(
 
         async def before_execution(self) -> None:
             state.messages.append("hook:before_execution")
-
-        async def before_memoization(self) -> None:
-            state.messages.append("hook:before_memoization")
 
         async def before_response(self) -> None:
             state.messages.append("hook:before_response")
@@ -199,8 +187,6 @@ def create(
         assert state.messages == [
             # Entry 1
             "hook:transform_input",
-            "hook:before_memoization",
-            "hook:after_memoization",
             "hook:before_execution",
             "fn_logic: before step_1",
             "hook:after_execution",
@@ -208,9 +194,7 @@ def create(
             "hook:before_response",
             # Entry 2
             "hook:transform_input",
-            "hook:before_memoization",
             "fn_logic: before step_1",
-            "hook:after_memoization",
             "hook:before_execution",
             "fn_logic: after step_1",
             "hook:before_send_events",
@@ -220,10 +204,8 @@ def create(
             "hook:before_response",
             # Entry 3
             "hook:transform_input",
-            "hook:before_memoization",
             "fn_logic: before step_1",
             "fn_logic: after step_1",
-            "hook:after_memoization",
             "hook:before_execution",
             "fn_logic: after send",
             "hook:after_execution",

--- a/tests/test_inngest/test_function/cases/middleware_order.py
+++ b/tests/test_inngest/test_function/cases/middleware_order.py
@@ -87,34 +87,26 @@ def create(
             [
                 "1.transform_input",
                 "2.transform_input",
-                "1.before_memoization",
-                "2.before_memoization",
-                "1.after_memoization",
-                "2.after_memoization",
                 "1.before_execution",
                 "2.before_execution",
                 "1.before_send_events",
                 "2.before_send_events",
-                "1.after_send_events",
                 "2.after_send_events",
-                "1.after_execution",
+                "1.after_send_events",
                 "2.after_execution",
-                "1.transform_output",
+                "1.after_execution",
                 "2.transform_output",
+                "1.transform_output",
                 "1.before_response",
                 "2.before_response",
                 "1.transform_input",
                 "2.transform_input",
-                "1.before_memoization",
-                "2.before_memoization",
-                "1.after_memoization",
-                "2.after_memoization",
                 "1.before_execution",
                 "2.before_execution",
-                "1.after_execution",
                 "2.after_execution",
-                "1.transform_output",
+                "1.after_execution",
                 "2.transform_output",
+                "1.transform_output",
                 "1.before_response",
                 "2.before_response",
             ],
@@ -149,9 +141,6 @@ class _MwSyncBase(inngest.MiddlewareSync):
     def after_execution(self) -> None:
         self.append_message(_get_method_name())
 
-    def after_memoization(self) -> None:
-        self.append_message(_get_method_name())
-
     def after_send_events(
         self,
         result: inngest.SendEventsResult,
@@ -159,9 +148,6 @@ class _MwSyncBase(inngest.MiddlewareSync):
         self.append_message(_get_method_name())
 
     def before_execution(self) -> None:
-        self.append_message(_get_method_name())
-
-    def before_memoization(self) -> None:
         self.append_message(_get_method_name())
 
     def before_response(self) -> None:
@@ -192,9 +178,6 @@ class _MwAsyncBase(inngest.Middleware):
     async def after_execution(self) -> None:
         self.append_message(_get_method_name())
 
-    async def after_memoization(self) -> None:
-        self.append_message(_get_method_name())
-
     async def after_send_events(
         self,
         result: inngest.SendEventsResult,
@@ -202,9 +185,6 @@ class _MwAsyncBase(inngest.Middleware):
         self.append_message(_get_method_name())
 
     async def before_execution(self) -> None:
-        self.append_message(_get_method_name())
-
-    async def before_memoization(self) -> None:
         self.append_message(_get_method_name())
 
     async def before_response(self) -> None:


### PR DESCRIPTION
> ⚠️ This is a breaking change. It will be release in `v0.5.0`.

Reverse the "after" middleware hooks. This is necessary for encryption middleware to work properly with other middleware.

Delete the "memoization" middleware hooks since they never proved valuable.