### PR TITLE
Disallow mixed async-ness for on_failure

### DIFF
--- a/pkg/inngest/inngest/_internal/function.py
+++ b/pkg/inngest/inngest/_internal/function.py
@@ -128,14 +128,14 @@ class Function:
                 and self.is_on_failure_handler_async is False
             ):
                 raise errors.Error(
-                    "an async function cannot have a non-async on_failure handler"
+                    f"an async function cannot have a non-async on_failure handler (function {opts.local_id})"
                 )
             if (
                 self.is_handler_async is False
                 and self.is_on_failure_handler_async is True
             ):
                 raise errors.Error(
-                    "a non-async function cannot have an async on_failure handler"
+                    f"a non-async function cannot have an async on_failure handler (function {opts.local_id})"
                 )
 
             self._on_failure_fn_id = f"{opts.fully_qualified_id}-failure"

--- a/pkg/inngest/inngest/_internal/function.py
+++ b/pkg/inngest/inngest/_internal/function.py
@@ -123,6 +123,21 @@ class Function:
         self._triggers = trigger if isinstance(trigger, list) else [trigger]
 
         if opts.on_failure is not None:
+            if (
+                self.is_handler_async
+                and self.is_on_failure_handler_async is False
+            ):
+                raise errors.Error(
+                    "an async function cannot have a non-async on_failure handler"
+                )
+            if (
+                self.is_handler_async is False
+                and self.is_on_failure_handler_async is True
+            ):
+                raise errors.Error(
+                    "a non-async function cannot have an async on_failure handler"
+                )
+
             self._on_failure_fn_id = f"{opts.fully_qualified_id}-failure"
 
     async def call(

--- a/pkg/inngest/inngest/_internal/function_test.py
+++ b/pkg/inngest/inngest/_internal/function_test.py
@@ -14,7 +14,7 @@ def test_sync_fn_with_async_on_failure() -> None:
     async def on_failure(ctx: inngest.Context) -> None:
         pass
 
-    with pytest.raises(errors.Error):
+    with pytest.raises(errors.Error) as e:
 
         @client.create_function(
             fn_id="foo",
@@ -23,6 +23,11 @@ def test_sync_fn_with_async_on_failure() -> None:
         )
         def fn(ctx: inngest.ContextSync) -> None:
             pass
+
+    assert (
+        str(e.value)
+        == "a non-async function cannot have an async on_failure handler (function foo)"
+    )
 
 
 def test_async_fn_with_sync_on_failure() -> None:
@@ -35,7 +40,7 @@ def test_async_fn_with_sync_on_failure() -> None:
     def on_failure(ctx: inngest.ContextSync) -> None:
         pass
 
-    with pytest.raises(errors.Error):
+    with pytest.raises(errors.Error) as e:
 
         @client.create_function(
             fn_id="foo",
@@ -44,3 +49,8 @@ def test_async_fn_with_sync_on_failure() -> None:
         )
         async def fn(ctx: inngest.Context) -> None:
             pass
+
+    assert (
+        str(e.value)
+        == "an async function cannot have a non-async on_failure handler (function foo)"
+    )

--- a/pkg/inngest/inngest/_internal/function_test.py
+++ b/pkg/inngest/inngest/_internal/function_test.py
@@ -1,0 +1,46 @@
+import pytest
+
+import inngest
+from inngest._internal import errors
+
+
+def test_sync_fn_with_async_on_failure() -> None:
+    """
+    Test that a sync function can not have an async on_failure handler.
+    """
+
+    client = inngest.Inngest(app_id="test", is_production=False)
+
+    async def on_failure(ctx: inngest.Context) -> None:
+        pass
+
+    with pytest.raises(errors.Error):
+
+        @client.create_function(
+            fn_id="foo",
+            trigger=inngest.TriggerEvent(event="foo"),
+            on_failure=on_failure,
+        )
+        def fn(ctx: inngest.ContextSync) -> None:
+            pass
+
+
+def test_async_fn_with_sync_on_failure() -> None:
+    """
+    Test that an async function can not have a sync on_failure handler.
+    """
+
+    client = inngest.Inngest(app_id="test", is_production=False)
+
+    def on_failure(ctx: inngest.ContextSync) -> None:
+        pass
+
+    with pytest.raises(errors.Error):
+
+        @client.create_function(
+            fn_id="foo",
+            trigger=inngest.TriggerEvent(event="foo"),
+            on_failure=on_failure,
+        )
+        async def fn(ctx: inngest.Context) -> None:
+            pass


### PR DESCRIPTION
If an Inngest function is async, its `on_failure` must also be async. And vice-versa