### PR TITLE
Static type error when passing non-async callback to async step.run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ type-check: check-venv
 	@cd pkg/inngest && make type-check
 	@cd pkg/inngest_encryption && make type-check
 	@cd pkg/test_core && make type-check
+	@mypy --config-file=mypy.ini tests
 
 utest: check-venv
 	@cd pkg/inngest && make utest

--- a/pkg/inngest/Makefile
+++ b/pkg/inngest/Makefile
@@ -22,7 +22,6 @@ lint: check-venv
 proto:
 	@protoc --proto_path=./inngest/experimental/connect/ --python_out=./inngest/experimental/connect/ ./inngest/experimental/connect/connect.proto --pyi_out=./inngest/experimental/connect/
 
-
 release:
 	@grep "version = \"$${VERSION}\"" pyproject.toml && git tag inngest@$${VERSION} && git push origin inngest@$${VERSION} || echo "pyproject.toml version does not match"
 

--- a/pkg/inngest/inngest/_internal/execution_lib/models.py
+++ b/pkg/inngest/inngest/_internal/execution_lib/models.py
@@ -84,7 +84,7 @@ class FunctionHandlerAsync(typing.Protocol):
     def __call__(
         self,
         ctx: Context,
-    ) -> typing.Awaitable[types.JSON]: ...
+    ) -> typing.Awaitable[typing.Any]: ...
 
 
 @typing.runtime_checkable
@@ -92,7 +92,7 @@ class FunctionHandlerSync(typing.Protocol):
     def __call__(
         self,
         ctx: ContextSync,
-    ) -> types.JSON: ...
+    ) -> typing.Any: ...
 
 
 # Context variable to detect nested steps.

--- a/pkg/inngest/inngest/_internal/step_lib/step_sync.py
+++ b/pkg/inngest/inngest/_internal/step_lib/step_sync.py
@@ -147,10 +147,10 @@ class StepSync(base.StepBase):
         step_id: str,
         handler: typing.Callable[
             [typing_extensions.Unpack[types.TTuple]],
-            types.JSONT,
+            types.T,
         ],
         *handler_args: typing_extensions.Unpack[types.TTuple],
-    ) -> types.JSONT:
+    ) -> types.T:
         """
         Run logic that should be retried on error and memoized after success.
 

--- a/pkg/inngest/inngest/_internal/types.py
+++ b/pkg/inngest/inngest/_internal/types.py
@@ -41,9 +41,6 @@ JSON = typing_extensions.TypeAliasType(
 )
 
 
-JSONT = typing.TypeVar("JSONT", bound=JSON)
-
-
 class BaseModel(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(strict=True)
 

--- a/pkg/inngest/inngest/experimental/mocked/trigger_test.py
+++ b/pkg/inngest/inngest/experimental/mocked/trigger_test.py
@@ -20,10 +20,13 @@ class TestTriggerAsync(unittest.TestCase):
             trigger=inngest.TriggerEvent(event="test"),
         )
         async def fn(ctx: inngest.Context) -> tuple[str, ...]:
+            async def foo(value: str) -> str:
+                return value
+
             return await ctx.group.parallel(
                 (
-                    lambda: ctx.step.run("a", lambda: "a"),
-                    lambda: ctx.step.run("b", lambda: "b"),
+                    lambda: ctx.step.run("a", foo, "a"),
+                    lambda: ctx.step.run("b", foo, "b"),
                 )
             )
 

--- a/tests/test_inngest/test_client/test_client_middleware.py
+++ b/tests/test_inngest/test_client/test_client_middleware.py
@@ -124,7 +124,7 @@ class TestClientMiddleware(unittest.IsolatedAsyncioTestCase):
 
             async def transform_input(
                 self,
-                ctx: inngest.Context,
+                ctx: inngest.Context | inngest.ContextSync,
                 function: inngest.Function,
                 steps: inngest.StepMemos,
             ) -> None:
@@ -216,7 +216,7 @@ class TestClientMiddleware(unittest.IsolatedAsyncioTestCase):
 
             def transform_input(
                 self,
-                ctx: inngest.Context,
+                ctx: inngest.Context | inngest.ContextSync,
                 function: inngest.Function,
                 steps: inngest.StepMemos,
             ) -> None:

--- a/tests/test_inngest/test_connect/test_function_run.py
+++ b/tests/test_inngest/test_connect/test_function_run.py
@@ -41,7 +41,7 @@ class TestFunctionRun(BaseTest):
         async def fn(ctx: inngest.Context) -> str:
             state.run_id = ctx.run_id
 
-            def step_a() -> str:
+            async def step_a() -> str:
                 state.step_counter += 1
                 return "Alice"
 
@@ -81,7 +81,7 @@ class TestFunctionRun(BaseTest):
         async def fn(ctx: inngest.Context) -> str:
             state.run_id = ctx.run_id
 
-            def step_a() -> str:
+            async def step_a() -> str:
                 state.step_counter += 1
                 return "Alice"
 

--- a/tests/test_inngest/test_connect/test_init_handshake.py
+++ b/tests/test_inngest/test_connect/test_init_handshake.py
@@ -249,7 +249,7 @@ class TestAPIRequestHeaders(BaseTest):
             fn_id="fn",
             trigger=inngest.TriggerEvent(event="event"),
         )
-        async def fn(ctx: inngest.Context, step: inngest.Step) -> None:
+        async def fn(ctx: inngest.Context) -> None:
             pass
 
         conn = connect(

--- a/tests/test_inngest/test_experimental/test_remote_state_middleware/cases/step_failed.py
+++ b/tests/test_inngest/test_experimental/test_remote_state_middleware/cases/step_failed.py
@@ -62,7 +62,7 @@ def create(
 
         state.run_id = ctx.run_id
 
-        def _step() -> str:
+        async def _step() -> str:
             raise Exception("oh no")
 
         try:

--- a/tests/test_inngest/test_experimental/test_remote_state_middleware/cases/step_output_aws.py
+++ b/tests/test_inngest/test_experimental/test_remote_state_middleware/cases/step_output_aws.py
@@ -96,13 +96,13 @@ def create(
     async def fn_async(ctx: inngest.Context) -> str:
         state.run_id = ctx.run_id
 
-        def _step_1() -> str:
+        async def _step_1() -> str:
             return "test string"
 
         step_1_output = await ctx.step.run("step_1", _step_1)
         assert step_1_output == "test string"
 
-        def _step_2() -> list[inngest.JSON]:
+        async def _step_2() -> list[inngest.JSON]:
             return [{"a": {"b": 1}}]
 
         step_2_output = await ctx.step.run("step_2", _step_2)

--- a/tests/test_inngest/test_experimental/test_remote_state_middleware/cases/step_output_in_memory.py
+++ b/tests/test_inngest/test_experimental/test_remote_state_middleware/cases/step_output_in_memory.py
@@ -73,13 +73,13 @@ def create(
     async def fn_async(ctx: inngest.Context) -> str:
         state.run_id = ctx.run_id
 
-        def _step_1() -> str:
+        async def _step_1() -> str:
             return "test string"
 
         step_1_output = await ctx.step.run("step_1", _step_1)
         assert step_1_output == "test string"
 
-        def _step_2() -> list[inngest.JSON]:
+        async def _step_2() -> list[inngest.JSON]:
             return [{"a": {"b": 1}}]
 
         step_2_output = await ctx.step.run("step_2", _step_2)

--- a/tests/test_inngest/test_function/cases/__init__.py
+++ b/tests/test_inngest/test_function/cases/__init__.py
@@ -2,6 +2,7 @@ import inngest
 from inngest._internal import server_lib
 
 from . import (
+    async_fn_with_sync_step_callback,
     batch_that_needs_api,
     cancel,
     change_step_error,
@@ -48,6 +49,7 @@ from . import (
 from .base import Case
 
 _modules = (
+    async_fn_with_sync_step_callback,
     batch_that_needs_api,
     cancel,
     change_step_error,

--- a/tests/test_inngest/test_function/cases/base.py
+++ b/tests/test_inngest/test_function/cases/base.py
@@ -47,7 +47,11 @@ T = typing.TypeVar("T")
 def asyncify(
     fn: typing.Callable[P, T],
 ) -> typing.Callable[P, typing.Awaitable[T]]:
+    """
+    Convert a sync function to an async function.
+    """
+
     async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-        return await fn(*args, **kwargs)  # type: ignore
+        return fn(*args, **kwargs)
 
     return wrapper

--- a/tests/test_inngest/test_function/cases/base.py
+++ b/tests/test_inngest/test_function/cases/base.py
@@ -38,3 +38,16 @@ def create_fn_id(test_name: str) -> str:
         suffix += f"-{worker_id}"
 
     return test_name + suffix
+
+
+P = typing.ParamSpec("P")
+T = typing.TypeVar("T")
+
+
+def asyncify(
+    fn: typing.Callable[P, T],
+) -> typing.Callable[P, typing.Awaitable[T]]:
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+        return await fn(*args, **kwargs)  # type: ignore
+
+    return wrapper

--- a/tests/test_inngest/test_function/cases/change_step_error.py
+++ b/tests/test_inngest/test_function/cases/change_step_error.py
@@ -50,7 +50,7 @@ def create(
     async def fn_async(ctx: inngest.Context) -> None:
         state.run_id = ctx.run_id
 
-        def foo() -> None:
+        async def foo() -> None:
             raise ValueError("foo")
 
         try:

--- a/tests/test_inngest/test_function/cases/crazy_ids.py
+++ b/tests/test_inngest/test_function/cases/crazy_ids.py
@@ -33,7 +33,7 @@ def create(
     )
     async def fn_async(ctx: inngest.Context) -> None:
         state.run_id = ctx.run_id
-        await ctx.step.run(_crazy, lambda: None)
+        await ctx.step.run(_crazy, base.asyncify(lambda: None))
 
     async def run_test(self: base.TestClass) -> None:
         self.client.send_sync(inngest.Event(name=event_name))

--- a/tests/test_inngest/test_function/cases/function_middleware.py
+++ b/tests/test_inngest/test_function/cases/function_middleware.py
@@ -56,7 +56,7 @@ def create(
 
         def transform_input(
             self,
-            ctx: inngest.Context,
+            ctx: inngest.Context | inngest.ContextSync,
             function: inngest.Function,
             steps: inngest.StepMemos,
         ) -> None:
@@ -102,7 +102,7 @@ def create(
 
         async def transform_input(
             self,
-            ctx: inngest.Context,
+            ctx: inngest.Context | inngest.ContextSync,
             function: inngest.Function,
             steps: inngest.StepMemos,
         ) -> None:

--- a/tests/test_inngest/test_function/cases/non_retriable_error.py
+++ b/tests/test_inngest/test_function/cases/non_retriable_error.py
@@ -45,7 +45,7 @@ def create(
         state.attempt = ctx.attempt
         state.run_id = ctx.run_id
 
-        def step_1() -> None:
+        async def step_1() -> None:
             raise inngest.NonRetriableError("foo", quiet=True)
 
         await ctx.step.run("step_1", step_1)

--- a/tests/test_inngest/test_function/cases/parallel_step_disappears.py
+++ b/tests/test_inngest/test_function/cases/parallel_step_disappears.py
@@ -82,15 +82,15 @@ def create(
         state.request_counter += 1
 
         steps: tuple[typing.Any, ...] = (
-            lambda: ctx.step.run("1a", lambda: None),
-            lambda: ctx.step.run("1b", lambda: None),
+            lambda: ctx.step.run("1a", base.asyncify(lambda: None)),
+            lambda: ctx.step.run("1b", base.asyncify(lambda: None)),
         )
 
         if state.request_counter == 1:
-            steps += (lambda: ctx.step.run("1c", lambda: None),)
+            steps += (lambda: ctx.step.run("1c", base.asyncify(lambda: None)),)
 
         await ctx.group.parallel(steps)
-        await ctx.step.run("after", lambda: None)
+        await ctx.step.run("after", base.asyncify(lambda: None))
 
     async def run_test(self: base.TestClass) -> None:
         self.client.send_sync(inngest.Event(name=event_name))

--- a/tests/test_inngest/test_function/cases/pydantic_output.py
+++ b/tests/test_inngest/test_function/cases/pydantic_output.py
@@ -40,7 +40,7 @@ def create(
         state.run_id = ctx.run_id
         state.step_output = ctx.step.run(
             "a",
-            lambda: _User(name="Alice"),  # type: ignore
+            lambda: _User(name="Alice"),
         )
 
     @client.create_function(
@@ -52,7 +52,7 @@ def create(
         state.run_id = ctx.run_id
         state.step_output = await ctx.step.run(
             "a",
-            lambda: _User(name="Alice"),  # type: ignore
+            base.asyncify(lambda: _User(name="Alice")),
         )
 
     async def run_test(self: base.TestClass) -> None:

--- a/tests/test_inngest/test_function/cases/step_callback_args.py
+++ b/tests/test_inngest/test_function/cases/step_callback_args.py
@@ -21,9 +21,6 @@ def create(
     fn_id = base.create_fn_id(test_name)
     state = _State()
 
-    def step_callback(a: int, b: str) -> None:
-        state.step_args = [a, b]
-
     @client.create_function(
         fn_id=fn_id,
         retries=0,
@@ -31,6 +28,10 @@ def create(
     )
     def fn_sync(ctx: inngest.ContextSync) -> None:
         state.run_id = ctx.run_id
+
+        def step_callback(a: int, b: str) -> None:
+            state.step_args = [a, b]
+
         ctx.step.run("step", step_callback, 1, "a")
 
     @client.create_function(
@@ -40,6 +41,10 @@ def create(
     )
     async def fn_async(ctx: inngest.Context) -> None:
         state.run_id = ctx.run_id
+
+        async def step_callback(a: int, b: str) -> None:
+            state.step_args = [a, b]
+
         await ctx.step.run("step", step_callback, 1, "a")
 
     async def run_test(self: base.TestClass) -> None:

--- a/tests/test_inngest/test_function/cases/step_callback_kwargs.py
+++ b/tests/test_inngest/test_function/cases/step_callback_kwargs.py
@@ -42,7 +42,10 @@ def create(
     )
     async def fn_async(ctx: inngest.Context) -> None:
         state.run_id = ctx.run_id
-        await ctx.step.run("step", functools.partial(step_callback, 1, b="a"))
+        await ctx.step.run(
+            "step",
+            base.asyncify(functools.partial(step_callback, 1, b="a")),
+        )
 
     async def run_test(self: base.TestClass) -> None:
         self.client.send_sync(inngest.Event(name=event_name))

--- a/tests/test_inngest/test_function/cases/steps_that_needs_api.py
+++ b/tests/test_inngest/test_function/cases/steps_that_needs_api.py
@@ -69,7 +69,10 @@ def create(
                 return "a" * 1024 * 1024
 
             step_id = f"step_{i}"
-            await ctx.step.run(step_id, functools.partial(fn, step_id))
+            await ctx.step.run(
+                step_id,
+                base.asyncify(functools.partial(fn, step_id)),
+            )
 
     async def run_test(self: base.TestClass) -> None:
         self.client.send_sync(inngest.Event(name=event_name))

--- a/tests/test_inngest/test_function/cases/unserializable_step_output.py
+++ b/tests/test_inngest/test_function/cases/unserializable_step_output.py
@@ -37,10 +37,7 @@ def create(
             return Foo()
 
         try:
-            ctx.step.run(
-                "step_1",
-                step_1,  # type: ignore[type-var]
-            )
+            ctx.step.run("step_1", step_1)
         except BaseException as err:
             state.error = err
             raise
@@ -59,10 +56,7 @@ def create(
         async def step_1() -> Foo:
             return Foo()
 
-        await ctx.step.run(  # type: ignore[call-arg]
-            "step_1",
-            step_1,  # type: ignore[type-var]
-        )
+        await ctx.step.run("step_1", step_1)
 
     async def run_test(self: base.TestClass) -> None:
         self.client.send_sync(inngest.Event(name=event_name))

--- a/tests/test_inngest/test_introspection/test_digital_ocean.py
+++ b/tests/test_inngest/test_introspection/test_digital_ocean.py
@@ -68,7 +68,7 @@ class TestIntrospection(base.BaseTestIntrospection):
         assert isinstance(
             net.validate_response_sig(
                 body=res.get_data(),
-                headers=res.headers,
+                headers=dict(res.headers),
                 mode=server_lib.ServerKind.CLOUD,
                 signing_key=self.signing_key,
             ),

--- a/tests/test_inngest/test_introspection/test_flask.py
+++ b/tests/test_inngest/test_introspection/test_flask.py
@@ -75,7 +75,7 @@ class TestIntrospection(base.BaseTestIntrospection):
         assert isinstance(
             net.validate_response_sig(
                 body=res.get_data(),
-                headers=res.headers,
+                headers=dict(res.headers),
                 mode=server_lib.ServerKind.CLOUD,
                 signing_key=self.signing_key,
             ),
@@ -114,7 +114,7 @@ class TestIntrospection(base.BaseTestIntrospection):
         assert isinstance(
             net.validate_response_sig(
                 body=res.get_data(),
-                headers=res.headers,
+                headers=dict(res.headers),
                 mode=server_lib.ServerKind.CLOUD,
                 signing_key=signing_key_fallback,
             ),

--- a/tests/test_inngest/test_probes/test_flask.py
+++ b/tests/test_inngest/test_probes/test_flask.py
@@ -45,7 +45,7 @@ class TestTrustProbe(base.BaseTest):
         assert isinstance(
             net.validate_response_sig(
                 body=res.get_data(),
-                headers=res.headers,
+                headers=dict(res.headers),
                 mode=server_lib.ServerKind.CLOUD,
                 signing_key=self.signing_key,
             ),

--- a/tests/test_inngest/test_types.py
+++ b/tests/test_inngest/test_types.py
@@ -12,30 +12,30 @@ from typing_extensions import assert_type
 client = inngest.Inngest(app_id="foo", is_production=False)
 
 
-def sync_fn_with_sync_step() -> None:
-    """
-    Test that a sync function cannot use an async step type
-    """
+# def sync_fn_with_sync_step() -> None:
+#     """
+#     Test that a sync function cannot use an async step type
+#     """
 
-    @client.create_function(  # type: ignore[arg-type]
-        fn_id="foo",
-        trigger=inngest.TriggerEvent(event="foo"),
-    )
-    def fn(ctx: inngest.ContextSync) -> None:
-        pass
+#     @client.create_function(  # type: ignore[arg-type]
+#         fn_id="foo",
+#         trigger=inngest.TriggerEvent(event="foo"),
+#     )
+#     def fn(ctx: inngest.ContextSync) -> None:
+#         pass
 
 
-def async_fn_with_sync_step() -> None:
-    """
-    Test that an async function cannot use a sync step type
-    """
+# def async_fn_with_sync_step() -> None:
+#     """
+#     Test that an async function cannot use a sync step type
+#     """
 
-    @client.create_function(  # type: ignore[arg-type]
-        fn_id="foo",
-        trigger=inngest.TriggerEvent(event="foo"),
-    )
-    async def fn(ctx: inngest.ContextSync) -> None:
-        pass
+#     @client.create_function(  # type: ignore[arg-type]
+#         fn_id="foo",
+#         trigger=inngest.TriggerEvent(event="foo"),
+#     )
+#     async def fn(ctx: inngest.ContextSync) -> None:
+#         pass
 
 
 def event_data_dict() -> None:
@@ -82,7 +82,7 @@ def step_callback_Args() -> None:
             step_callback_async,  # type: ignore[arg-type]
             "a",
             1,
-        )  # type: ignore[call-arg]
+        )
 
         output = await ctx.step.run("step", step_callback_async, 1, "a")
         assert_type(output, bool)
@@ -98,10 +98,7 @@ def step_callback_Args() -> None:
             step_callback_sync,  # type: ignore[arg-type]
             "a",
             1,
-        )  # type: ignore[call-arg]
-
-        output = await ctx.step.run("step", step_callback_sync, 1, "a")
-        assert_type(output, bool)
+        )
 
     @client.create_function(
         fn_id="foo",
@@ -142,7 +139,7 @@ def step_callback_kwargs() -> None:
             step_callback_async,  # type: ignore[arg-type]
             "a",
             1,
-        )  # type: ignore[call-arg]
+        )
 
         output = await ctx.step.run(
             "step",
@@ -161,13 +158,12 @@ def step_callback_kwargs() -> None:
             step_callback_sync,  # type: ignore[arg-type]
             "a",
             1,
-        )  # type: ignore[call-arg]
-
-        output = await ctx.step.run(
-            "step",
-            functools.partial(step_callback_sync, 1, b="a"),
         )
-        assert_type(output, bool)
+
+        await ctx.step.run(
+            "step",
+            functools.partial(step_callback_sync, 1, b="a"),  # type: ignore[arg-type]
+        )
 
     @client.create_function(
         fn_id="foo",
@@ -316,27 +312,27 @@ def step_return_types() -> None:
         trigger=inngest.TriggerEvent(event="foo"),
     )
     async def fn(ctx: inngest.Context) -> None:
-        def fn_bool() -> bool:
+        async def fn_bool() -> bool:
             return True
 
         assert_type(await ctx.step.run("fn_bool", fn_bool), bool)
 
-        def fn_int() -> int:
+        async def fn_int() -> int:
             return 1
 
         assert_type(await ctx.step.run("fn_int", fn_int), int)
 
-        def fn_float() -> float:
+        async def fn_float() -> float:
             return 1.0
 
         assert_type(await ctx.step.run("fn_float", fn_float), float)
 
-        def fn_str() -> str:
+        async def fn_str() -> str:
             return "foo"
 
         assert_type(await ctx.step.run("fn_str", fn_str), str)
 
-        def fn_dict() -> dict[str, int]:
+        async def fn_dict() -> dict[str, int]:
             return {"foo": 1}
 
         assert_type(await ctx.step.run("fn_dict", fn_dict), dict[str, int])
@@ -344,21 +340,69 @@ def step_return_types() -> None:
         class MyTypedDict(typing.TypedDict):
             foo: str
 
-        def fn_typed_dict() -> MyTypedDict:
+        async def fn_typed_dict() -> MyTypedDict:
             return {"foo": "bar"}
 
         assert_type(
             await ctx.step.run("fn_typed_dict", fn_typed_dict), MyTypedDict
         )
 
-        def fn_list() -> list[dict[str, int]]:
+        async def fn_list() -> list[dict[str, int]]:
             return [{"foo": 1}]
 
         assert_type(
             await ctx.step.run("fn_list", fn_list), list[dict[str, int]]
         )
 
-        def fn_none() -> None:
+        async def fn_none() -> None:
             return None
 
         assert_type(await ctx.step.run("fn_none", fn_none), None)
+
+    @client.create_function(
+        fn_id="foo",
+        trigger=inngest.TriggerEvent(event="foo"),
+    )
+    def fn_sync(ctx: inngest.ContextSync) -> None:
+        def fn_bool() -> bool:
+            return True
+
+        assert_type(ctx.step.run("fn_bool", fn_bool), bool)
+
+        def fn_int() -> int:
+            return 1
+
+        assert_type(ctx.step.run("fn_int", fn_int), int)
+
+        def fn_float() -> float:
+            return 1.0
+
+        assert_type(ctx.step.run("fn_float", fn_float), float)
+
+        def fn_str() -> str:
+            return "foo"
+
+        assert_type(ctx.step.run("fn_str", fn_str), str)
+
+        def fn_dict() -> dict[str, int]:
+            return {"foo": 1}
+
+        assert_type(ctx.step.run("fn_dict", fn_dict), dict[str, int])
+
+        class MyTypedDict(typing.TypedDict):
+            foo: str
+
+        def fn_typed_dict() -> MyTypedDict:
+            return {"foo": "bar"}
+
+        assert_type(ctx.step.run("fn_typed_dict", fn_typed_dict), MyTypedDict)
+
+        def fn_list() -> list[dict[str, int]]:
+            return [{"foo": 1}]
+
+        assert_type(ctx.step.run("fn_list", fn_list), list[dict[str, int]])
+
+        def fn_none() -> None:
+            return None
+
+        assert_type(ctx.step.run("fn_none", fn_none), None)

--- a/tests/test_inngest_encryption/cases/decrypt_only.py
+++ b/tests/test_inngest_encryption/cases/decrypt_only.py
@@ -82,13 +82,13 @@ def create(
         state.events = ctx.events
         state.run_id = ctx.run_id
 
-        def _step_1() -> str:
+        async def _step_1() -> str:
             return "test string"
 
         step_1_output = await ctx.step.run("step_1", _step_1)
         assert step_1_output == "test string"
 
-        def _step_2() -> list[inngest.JSON]:
+        async def _step_2() -> list[inngest.JSON]:
             return [{"a": {"b": 1}}]
 
         step_2_output = await ctx.step.run("step_2", _step_2)

--- a/tests/test_inngest_encryption/cases/step_and_fn_output.py
+++ b/tests/test_inngest_encryption/cases/step_and_fn_output.py
@@ -73,13 +73,13 @@ def create(
     async def fn_async(ctx: inngest.Context) -> str:
         state.run_id = ctx.run_id
 
-        def _step_1() -> str:
+        async def _step_1() -> str:
             return "test string"
 
         step_1_output = await ctx.step.run("step_1", _step_1)
         assert step_1_output == "test string"
 
-        def _step_2() -> list[inngest.JSON]:
+        async def _step_2() -> list[inngest.JSON]:
             return [{"a": {"b": 1}}]
 
         step_2_output = await ctx.step.run("step_2", _step_2)


### PR DESCRIPTION
# Description
Change async `step.run` to have a static type error when its callback is not async. We'll still support non-async callbacks in async `step.run` calls at runtime, but static type checkers will still scream.

# Motivation
We need to replace the `step.run` generic return type from `JSONT` with `T` for a couple reasons:
1. `JSONT` is too restrictive and users have found it annoying. It also isn't that valuable because it isn't recursive (which means some non-JSON-serializable return values can still be valid `JSONT`).
2. It makes it _much_ easier to add Pydantic support.

But using `T` means Python's type system can no longer differentiate async at non-async callbacks. This is because `typing.Awaitable[T]` is ineffectual when in a union with `T`. In other words, `T` works for both async and non-async.