### PR TITLE
Connect: add support for message flushing

### DIFF
--- a/pkg/inngest/inngest/experimental/connect/buffer.py
+++ b/pkg/inngest/inngest/experimental/connect/buffer.py
@@ -1,0 +1,102 @@
+import collections
+import dataclasses
+import time
+
+
+@dataclasses.dataclass
+class _BufferItem:
+    data: bytes
+    id: str
+    timestamp: float
+
+
+class _SizeConstrainedBuffer:
+    def __init__(self, max_size_bytes: int):
+        """
+        A size-constrained buffer. The total size of all items' data never
+        exceeds the max size.
+        """
+
+        self._current_size = 0
+        self._items: collections.OrderedDict[str, _BufferItem] = (
+            collections.OrderedDict()
+        )
+
+        self._max_size_bytes = max_size_bytes
+        if self._max_size_bytes <= 0:
+            raise ValueError("max_size_bytes must be greater than 0")
+
+    def add(self, item_id: str, data: bytes) -> bool:
+        """
+        Add item to buffer. If adding would exceed size limit, evicts oldest
+        items until there is enough space. Returns True if item was added
+        successfully. If the item is larger than the max size, it is not added
+        to the buffer.
+        """
+
+        item_size = len(data)
+
+        if item_size > self._max_size_bytes:
+            return False
+
+        # Remove existing item with same ID if it exists.
+        if item_id in self._items:
+            self._current_size -= len(self._items[item_id].data)
+            del self._items[item_id]
+
+        # If adding would exceed limit, evict oldest items until there's enough
+        # space.
+        while (
+            self._current_size + item_size > self._max_size_bytes
+            and self._items
+        ):
+            # Remove oldest item.
+            _, oldest_item = self._items.popitem(last=False)
+            self._current_size -= len(oldest_item.data)
+
+        # Add new item.
+        item = _BufferItem(
+            data=data,
+            id=item_id,
+            timestamp=time.time(),
+        )
+        self._items[item_id] = item
+        self._current_size += item_size
+        return True
+
+    def get(self, item_id: str) -> bytes | None:
+        """
+        Get item by ID without removing it.
+        """
+
+        item = self._items.get(item_id)
+        if item is None:
+            return None
+        return item.data
+
+    def delete(self, item_id: str) -> bool:
+        """
+        Delete item by ID. Returns True if item was found and deleted.
+        """
+
+        if item_id not in self._items:
+            return False
+
+        item = self._items[item_id]
+        self._current_size -= len(item.data)
+        del self._items[item_id]
+        return True
+
+    def get_older_than(self, seconds: float) -> list[tuple[str, bytes]]:
+        """
+        Get all items that were inserted at least `seconds` ago.
+        """
+
+        cutoff_time = time.time() - seconds
+        result = []
+
+        for item in self._items.values():
+            if item.timestamp <= cutoff_time:
+                result.append((item.id, item.data))
+
+        return result

--- a/pkg/inngest/inngest/experimental/connect/buffer_test.py
+++ b/pkg/inngest/inngest/experimental/connect/buffer_test.py
@@ -1,0 +1,42 @@
+from .buffer import _SizeConstrainedBuffer
+
+
+def test_evict_oldest_items() -> None:
+    """
+    When eviction is necessary to make room for a new item, the oldest items
+    are evicted.
+    """
+
+    buffer = _SizeConstrainedBuffer(3)
+
+    # Fill the buffer with 3 items (each is 1 byte).
+    assert buffer.add("1", b"A") is True
+    assert buffer.get("1") is not None
+    assert buffer.add("2", b"A") is True
+    assert buffer.get("2") is not None
+    assert buffer.add("3", b"A") is True
+    assert buffer.get("3") is not None
+
+    # Add a 2-byte item, which necessitates eviction.
+    assert buffer.add("4", b"A" * 2) is True
+
+    # The oldest 2 pre-existing items were evicted.
+    assert buffer.get("1") is None
+    assert buffer.get("2") is None
+
+    # The most recent pre-existing item wasn't evicted.
+    assert buffer.get("3") is not None
+
+    # The new item was added.
+    assert buffer.get("4") is not None
+
+
+def test_item_larger_than_max_size() -> None:
+    """
+    If an item is larger than the max size, it is not added to the buffer.
+    """
+
+    buffer = _SizeConstrainedBuffer(1)
+
+    assert buffer.add("1", b"A" * 2) is False
+    assert buffer.get("1") is None

--- a/pkg/inngest/inngest/experimental/connect/connection.py
+++ b/pkg/inngest/inngest/experimental/connect/connection.py
@@ -199,9 +199,14 @@ class _WebSocketWorkerConnection(WorkerConnection):
                 self._instance_id,
             ),
             _ExecutionHandler(
-                self._logger,
-                self._state,
-                self._comm_handlers,
+                api_origin=self._api_origin,
+                comm_handlers=self._comm_handlers,
+                http_client=self._http_client,
+                http_client_sync=self._http_client_sync,
+                logger=self._logger,
+                state=self._state,
+                signing_key=self._signing_key,
+                signing_key_fallback=self._fallback_signing_key,
             ),
             _DrainHandler(self._logger, self._state),
         ]

--- a/pkg/inngest/inngest/experimental/connect/execution_handler.py
+++ b/pkg/inngest/inngest/experimental/connect/execution_handler.py
@@ -1,11 +1,18 @@
 import asyncio
 import typing
+import urllib.parse
 
-from inngest._internal import comm_lib, server_lib, types
+import httpx
+
+from inngest._internal import comm_lib, net, server_lib, types
 
 from . import connect_pb2
 from .base_handler import _BaseHandler
+from .buffer import _SizeConstrainedBuffer
 from .models import _State
+
+# TODO: Make this configurable.
+_default_max_buffer_size_bytes = 1024 * 1024 * 500  # 500MB
 
 
 class _ExecutionHandler(_BaseHandler):
@@ -14,15 +21,27 @@ class _ExecutionHandler(_BaseHandler):
     """
 
     _leaser_extender_task: typing.Optional[asyncio.Task[None]] = None
+    _unacked_msg_flush_poller_task: typing.Optional[asyncio.Task[None]] = None
 
     def __init__(
         self,
-        logger: types.Logger,
-        state: _State,
+        api_origin: str,
         comm_handlers: dict[str, comm_lib.CommHandler],
+        http_client: net.ThreadAwareAsyncHTTPClient,
+        http_client_sync: httpx.Client,
+        logger: types.Logger,
+        signing_key: typing.Optional[str],
+        signing_key_fallback: typing.Optional[str],
+        state: _State,
     ) -> None:
+        self._api_origin = api_origin
+        self._buffer = _SizeConstrainedBuffer(_default_max_buffer_size_bytes)
         self._comm_handlers = comm_handlers
+        self._http_client = http_client
+        self._http_client_sync = http_client_sync
         self._logger = logger
+        self._signing_key = signing_key
+        self._signing_key_fallback = signing_key_fallback
         self._state = state
 
         # Keep track of pending tasks to support graceful shutdown and lease
@@ -42,6 +61,11 @@ class _ExecutionHandler(_BaseHandler):
                 self._leaser_extender()
             )
 
+        if self._unacked_msg_flush_poller_task is None:
+            self._unacked_msg_flush_poller_task = asyncio.create_task(
+                self._unacked_msg_flush_poller()
+            )
+
         return None
 
     def close(self) -> None:
@@ -49,6 +73,9 @@ class _ExecutionHandler(_BaseHandler):
 
         if self._leaser_extender_task is not None:
             self._leaser_extender_task.cancel()
+
+        if self._unacked_msg_flush_poller_task is not None:
+            self._unacked_msg_flush_poller_task.cancel()
 
     async def closed(self) -> None:
         await super().closed()
@@ -58,6 +85,14 @@ class _ExecutionHandler(_BaseHandler):
         if self._leaser_extender_task is not None:
             try:
                 await self._leaser_extender_task
+            except asyncio.CancelledError:
+                # This is expected since the task is likely calling
+                # `asyncio.sleep` after cancellation.
+                pass
+
+        if self._unacked_msg_flush_poller_task is not None:
+            try:
+                await self._unacked_msg_flush_poller_task
             except asyncio.CancelledError:
                 # This is expected since the task is likely calling
                 # `asyncio.sleep` after cancellation.
@@ -153,24 +188,29 @@ class _ExecutionHandler(_BaseHandler):
                     extra={"status_code": comm_res.status_code},
                 )
 
+            reply_payload = connect_pb2.SDKResponse(
+                account_id=req_data.account_id,
+                app_id=req_data.app_id,
+                body=body,
+                env_id=req_data.env_id,
+                no_retry=comm_res.no_retry,
+                request_id=req_data.request_id,
+                request_version=comm_res.request_version,
+                retry_after=comm_res.retry_after,
+                sdk_version=comm_res.sdk_version,
+                status=status,
+                system_trace_ctx=req_data.system_trace_ctx,
+                user_trace_ctx=req_data.user_trace_ctx,
+            ).SerializeToString()
+
+            # Add the reply to the buffer in case we need to flush it later.
+            self._buffer.add(req_data.request_id, reply_payload)
+
             self._logger.debug("Sending execution reply")
             await ws.send(
                 connect_pb2.ConnectMessage(
                     kind=connect_pb2.GatewayMessageType.WORKER_REPLY,
-                    payload=connect_pb2.SDKResponse(
-                        account_id=req_data.account_id,
-                        app_id=req_data.app_id,
-                        body=body,
-                        env_id=req_data.env_id,
-                        no_retry=comm_res.no_retry,
-                        request_id=req_data.request_id,
-                        request_version=comm_res.request_version,
-                        retry_after=comm_res.retry_after,
-                        sdk_version=comm_res.sdk_version,
-                        status=status,
-                        system_trace_ctx=req_data.system_trace_ctx,
-                        user_trace_ctx=req_data.user_trace_ctx,
-                    ).SerializeToString(),
+                    payload=reply_payload,
                 ).SerializeToString()
             )
 
@@ -201,6 +241,24 @@ class _ExecutionHandler(_BaseHandler):
         # Each lease extension ack includes a new lease ID. If we don't use the
         # new lease ID the next time we extend, we'll have a bad time.
         pending_req[0].lease_id = req_data.new_lease_id
+
+    def _handle_worker_reply_ack(
+        self,
+        msg: connect_pb2.ConnectMessage,
+    ) -> None:
+        """
+        Handles a worker reply ack, which indicates that the Inngest Server
+        received the execution reply.
+        """
+
+        req_data = connect_pb2.WorkerReplyAckData()
+        req_data.ParseFromString(msg.payload)
+
+        self._logger.debug(
+            "Received worker reply ack",
+            extra={"request_id": req_data.request_id},
+        )
+        self._buffer.delete(req_data.request_id)
 
     async def _leaser_extender(self) -> None:
         while self.closed_event.is_set() is False:
@@ -240,3 +298,61 @@ class _ExecutionHandler(_BaseHandler):
                     self._logger.error(
                         "Failed to extend lease", extra={"error": str(e)}
                     )
+
+    async def _unacked_msg_flush_poller(self) -> None:
+        """
+        Responsible for flushing unacked messages via HTTP. Checks for flushable
+        messages on an interval.
+        """
+
+        # How long a message should exist before being flushed. We picked the
+        # lease interval, but there may be a better value.
+        flush_ttl = await self._state.extend_lease_interval.wait_for_not_none()
+
+        while self.closed_event.is_set() is False:
+            for request_id, reply_msg in self._buffer.get_older_than(flush_ttl):
+                try:
+                    err = await self._flush_message(reply_msg)
+                    if err is not None:
+                        self._logger.error(
+                            "Failed to flush message", extra={"error": str(err)}
+                        )
+                finally:
+                    # We only attempt to flush once, so we can delete the
+                    # message.
+                    self._buffer.delete(request_id)
+
+            await asyncio.sleep(1)
+
+    async def _flush_message(self, msg: bytes) -> types.MaybeError[None]:
+        """
+        Flush a single message via HTTP.
+        """
+
+        url = urllib.parse.urljoin(self._api_origin, "/v0/connect/flush")
+
+        res = await net.fetch_with_auth_fallback(
+            self._http_client,
+            self._http_client_sync,
+            httpx.Request(
+                content=msg,
+                extensions={
+                    "timeout": httpx.Timeout(5).as_dict(),
+                },
+                headers={
+                    "content-type": "application/protobuf",
+                },
+                method="POST",
+                url=url,
+            ),
+            signing_key=self._signing_key,
+            signing_key_fallback=self._signing_key_fallback,
+        )
+        if isinstance(res, Exception):
+            return res
+        if res.status_code == 401 or res.status_code == 403:
+            return Exception("unauthorized")
+        if res.status_code < 200 or res.status_code >= 300:
+            return Exception(f"unexpected status code: {res.status_code}")
+
+        return None

--- a/pkg/inngest/inngest/experimental/connect/execution_handler.py
+++ b/pkg/inngest/inngest/experimental/connect/execution_handler.py
@@ -111,6 +111,8 @@ class _ExecutionHandler(_BaseHandler):
             == connect_pb2.GatewayMessageType.WORKER_REQUEST_EXTEND_LEASE_ACK
         ):
             self._handle_lease_extend_ack(msg)
+        elif msg.kind == connect_pb2.GatewayMessageType.WORKER_REPLY_ACK:
+            self._handle_worker_reply_ack(msg)
 
     def _handle_executor_request(
         self,

--- a/tests/test_inngest/test_connect/test_flush.py
+++ b/tests/test_inngest/test_connect/test_flush.py
@@ -1,0 +1,79 @@
+import asyncio
+import json
+
+import inngest
+import pytest
+import structlog
+import test_core
+from inngest.experimental.connect import ConnectionState, connect
+
+from .base import BaseTest
+
+
+class _State(test_core.BaseState):
+    ws_aborted: bool = False
+
+
+class TestFlush(BaseTest):
+    # Need to extend the timeout because messages are only flushed after their
+    # lease expires.
+    @pytest.mark.timeout(10, method="thread")
+    async def test(self) -> None:
+        """
+        An unexpected WebSocket disconnect (a.k.a. abort) should trigger a
+        reconnect. That reconnect should eventually succeed.
+        """
+
+        proxies = await self.create_proxies()
+
+        client = inngest.Inngest(
+            api_base_url=proxies.http_proxy.origin,
+            app_id="app",
+            is_production=False,
+            logger=structlog.get_logger(),
+        )
+        event_name = test_core.random_suffix("event")
+        state = _State()
+
+        @client.create_function(
+            fn_id="fn",
+            trigger=inngest.TriggerEvent(event=event_name),
+        )
+        async def fn(ctx: inngest.Context) -> str:
+            state.run_id = ctx.run_id
+
+            while not state.ws_aborted:  # noqa: ASYNC110
+                await asyncio.sleep(0.1)
+
+            return "hi"
+
+        # Startup.
+        conn = connect([(client, [fn])])
+        task = asyncio.create_task(conn.start())
+        self.addCleanup(conn.close, wait=True)
+        self.addCleanup(task.cancel)
+        await conn.wait_for_state(ConnectionState.ACTIVE)
+
+        # Trigger the function.
+        await client.send(inngest.Event(name=event_name))
+        run_id = await state.wait_for_run_id()
+
+        # Abort the WS conn.
+        await proxies.ws_proxy.abort_conns()
+        state.ws_aborted = True
+
+        # Wait for the run to complete.
+        run = await test_core.helper.client.wait_for_run_status(
+            run_id,
+            test_core.helper.RunStatus.COMPLETED,
+        )
+        assert run.output is not None
+        assert json.loads(run.output) == "hi"
+
+        # Ensure the flush API endpoint was called.
+        flush_request_exists = False
+        for req in proxies.requests:
+            if req.path == "/v0/connect/flush":
+                flush_request_exists = True
+                break
+        assert flush_request_exists

--- a/tests/test_inngest/test_connect/test_flush.py
+++ b/tests/test_inngest/test_connect/test_flush.py
@@ -18,9 +18,9 @@ class TestFlush(BaseTest):
     # Need to extend the timeout because messages are only flushed after their
     # lease expires.
     @pytest.mark.timeout(10, method="thread")
-    async def test(self) -> None:
+    async def test_connection_loss(self) -> None:
         """
-        An unexpected WebSocket disconnect (a.k.a. abort) should trigger a
+        An unexpected WebSocket disconnect (e.g. abort) should trigger a
         reconnect. That reconnect should eventually succeed.
         """
 
@@ -77,3 +77,62 @@ class TestFlush(BaseTest):
                 flush_request_exists = True
                 break
         assert flush_request_exists
+
+    # Need to extend the timeout because messages are only flushed after their
+    # lease expires.
+    @pytest.mark.timeout(10, method="thread")
+    async def test_acked_messages_are_not_flushed(self) -> None:
+        """
+        Acked messages are not flushed when the connection is lost. Internally,
+        this means that acked messages are removed from the buffer before
+        flushing.
+        """
+
+        proxies = await self.create_proxies()
+
+        client = inngest.Inngest(
+            api_base_url=proxies.http_proxy.origin,
+            app_id="app",
+            is_production=False,
+            logger=structlog.get_logger(),
+        )
+        event_name = test_core.random_suffix("event")
+        state = test_core.BaseState()
+
+        @client.create_function(
+            fn_id="fn",
+            trigger=inngest.TriggerEvent(event=event_name),
+        )
+        async def fn(ctx: inngest.Context) -> str:
+            state.run_id = ctx.run_id
+            return "hi"
+
+        # Startup.
+        conn = connect([(client, [fn])])
+        task = asyncio.create_task(conn.start())
+        self.addCleanup(conn.close, wait=True)
+        self.addCleanup(task.cancel)
+        await conn.wait_for_state(ConnectionState.ACTIVE)
+
+        # Trigger the function.
+        await client.send(inngest.Event(name=event_name))
+        run_id = await state.wait_for_run_id()
+
+        # Wait for the run to complete.
+        run = await test_core.helper.client.wait_for_run_status(
+            run_id,
+            test_core.helper.RunStatus.COMPLETED,
+        )
+        assert run.output is not None
+        assert json.loads(run.output) == "hi"
+
+        # Wait for the lease to expire. The lease expiration is 5 seconds.
+        await asyncio.sleep(6)
+
+        # Ensure the flush API endpoint was called.
+        flush_request_exists = False
+        for req in proxies.requests:
+            if req.path == "/v0/connect/flush":
+                flush_request_exists = True
+                break
+        assert flush_request_exists is False


### PR DESCRIPTION
When an execution reply message hasn't been acked within the lease TTL, that message is "flushed" by sending it to the Inngest Server via HTTP.

Note that the flusher is polling and does not respond to WebSocket connection loss. This means that messages may flush ~5 seconds after the connection is lost, but that seems OK