### PR TITLE
Add idempotent retries when sending events

### DIFF
--- a/pkg/inngest/inngest/_internal/client_lib/client.py
+++ b/pkg/inngest/inngest/_internal/client_lib/client.py
@@ -33,7 +33,7 @@ if typing.TYPE_CHECKING:
 # Dummy value
 _DEV_SERVER_EVENT_KEY = "NO_EVENT_KEY_SET"
 
-MAX_RETRY_ATTEMPTS = 5
+MAX_SEND_ATTEMPTS = 5
 RETRY_BASE_DELAY = 0.1  # 100ms in seconds
 
 
@@ -473,7 +473,7 @@ class Inngest:
             raise req
 
         resp = None
-        for attempt in range(MAX_RETRY_ATTEMPTS):
+        for attempt in range(MAX_SEND_ATTEMPTS):
             resp = await net.fetch_with_thready_safety(
                 self._http_client,
                 self._http_client_sync,

--- a/pkg/inngest/inngest/_internal/client_lib/client.py
+++ b/pkg/inngest/inngest/_internal/client_lib/client.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import logging
 import os
 import random
+import secrets
 import time
 import typing
 import urllib.parse
@@ -165,6 +167,7 @@ class Inngest:
             framework=framework,
             server_kind=server_kind,
         )
+        headers[server_lib.HeaderKey.EVENT_ID_SEED.value] = _seed()
 
         body = []
         for event in events:
@@ -607,3 +610,17 @@ def _get_mode(
         f"Cloud mode enabled. Set {const.EnvKey.DEV.value} to enable development mode"
     )
     return server_lib.ServerKind.CLOUD
+
+
+def _seed() -> str:
+    """
+    Create the event ID seed header value. This is used to seed a
+    deterministic event ID in the Inngest Server.
+
+    Returns:
+        str: A string in the format "{millis},{entropy_base64}"
+    """
+    current_time_millis = int(time.time() * 1000)
+    entropy = secrets.token_bytes(10)
+    entropy_base64 = base64.b64encode(entropy).decode("utf-8")
+    return f"{current_time_millis},{entropy_base64}"

--- a/pkg/inngest/inngest/_internal/client_lib/client.py
+++ b/pkg/inngest/inngest/_internal/client_lib/client.py
@@ -480,7 +480,7 @@ class Inngest:
                     self._http_client_sync,
                     req,
                 )
-            except httpx.ReadTimeout:
+            except httpx.RequestError:
                 pass  # we will retry with delay
 
             # Don't retry if the request was successful or if there was a 4xx

--- a/pkg/inngest/inngest/_internal/client_lib/client.py
+++ b/pkg/inngest/inngest/_internal/client_lib/client.py
@@ -489,13 +489,7 @@ class Inngest:
             if resp is not None and resp.status_code < 500:
                 break
 
-            # Jitter between 0 and the base delay
-            jitter = random.random() * RETRY_BASE_DELAY  # noqa:S311
-
-            # Exponential backoff with jitter
-            delay = RETRY_BASE_DELAY * (2**attempt) + jitter
-
-            await asyncio.sleep(delay)
+            await asyncio.sleep(_compute_backoff_delay(attempt))
 
         if resp is None:
             raise errors.SendEventsError(
@@ -561,13 +555,7 @@ class Inngest:
             if resp is not None and resp.status_code < 500:
                 break
 
-            # Jitter between 0 and the base delay
-            jitter = random.random() * RETRY_BASE_DELAY  # noqa:S311
-
-            # Exponential backoff with jitter
-            delay = RETRY_BASE_DELAY * (2**attempt) + jitter
-
-            time.sleep(delay)
+            time.sleep(_compute_backoff_delay(attempt))
 
         if resp is None:
             raise errors.SendEventsError(
@@ -652,3 +640,12 @@ def _seed() -> str:
     entropy = secrets.token_bytes(10)
     entropy_base64 = base64.b64encode(entropy).decode("utf-8")
     return f"{current_time_millis},{entropy_base64}"
+
+
+def _compute_backoff_delay(attempt: int) -> float:
+    # Jitter between 0 and the base delay
+    jitter = random.random() * RETRY_BASE_DELAY  # noqa:S311
+
+    # Exponential backoff with jitter
+    delay: float = RETRY_BASE_DELAY * (2**attempt) + jitter
+    return delay

--- a/pkg/inngest/inngest/_internal/server_lib/consts.py
+++ b/pkg/inngest/inngest/_internal/server_lib/consts.py
@@ -51,6 +51,7 @@ class HeaderKey(enum.Enum):
     AUTHORIZATION = "authorization"
     CONTENT_TYPE = "content-type"
     ENV = "x-inngest-env"
+    EVENT_ID_SEED = "x-inngest-event-id-seed"
     EXPECTED_SERVER_KIND = "x-inngest-expected-server-kind"
     FRAMEWORK = "x-inngest-framework"
     NO_RETRY = "x-inngest-no-retry"

--- a/tests/test_inngest/test_client/test_send.py
+++ b/tests/test_inngest/test_client/test_send.py
@@ -137,92 +137,64 @@ class TestSend(unittest.IsolatedAsyncioTestCase):
         Ensure that the client retries on error when sending to event API, and
         that retries use the same idempotency key header.
         """
-
-        proxy_request_count = 0
-
-        # Create a proxy that mimics a request reaching the Dev Server but the
-        # client receives a 500 on the first attempt. This ensures that the Dev
-        # Server's event processing logic properly handles the idempotency key
-        # header.
-        def on_request(
-            body: typing.Optional[bytes],
-            headers: dict[str, list[str]],
-            method: str,
-            path: str,
-        ) -> http_proxy.Response:
-            nonlocal proxy_request_count
-            proxy_request_count += 1
-
-            # Always forward request to real dev server
-            resp = httpx.request(
-                method=method,
-                url=f"{dev_server.server.origin}{path}",
-                headers={k: v[0] for k, v in headers.items()},
-                content=body,
-            )
-
-            # But make client think we failed with synthetic 500 response on first try
-            if proxy_request_count == 1:
-                return http_proxy.Response(
-                    body=b"{}",
-                    headers={},
-                    status_code=500,
-                )
-            else:
-                # forward subsequent dev server responses
-                return http_proxy.Response(
-                    body=resp.content,
-                    headers=dict(resp.headers),
-                    status_code=resp.status_code,
+        for proxy_request_handler_factory in [
+            create_first_request_500_handler,
+            create_first_request_timeout_handler,
+        ]:
+            with self.subTest(proxy_request_handler_factory):
+                on_request, get_proxy_request_counter = (
+                    proxy_request_handler_factory()
                 )
 
-        proxy = http_proxy.Proxy(on_request)
-        proxy.start()
-        self.addCleanup(proxy.stop)
+                proxy = http_proxy.Proxy(on_request)
+                proxy.start()
+                self.addCleanup(proxy.stop)
 
-        client = inngest.Inngest(
-            event_api_base_url=proxy.origin,
-            app_id=random_suffix("my-app"),
-            is_production=False,
-        )
+                client = inngest.Inngest(
+                    event_api_base_url=proxy.origin,
+                    app_id=random_suffix("my-app"),
+                    is_production=False,
+                )
 
-        # Send two events in one request with the same idempotency key header
-        # The returned IDs are unique.
-        event_name = random_suffix("foo")
-        send_ids = await client.send(
-            [
-                inngest.Event(name=event_name),
-                inngest.Event(name=event_name),
-            ]
-        )
-        assert len(send_ids) == 2
-        assert send_ids[0] != send_ids[1]
+                # Send two events in one request with the same idempotency key header
+                # The returned IDs are unique.
+                event_name = random_suffix("foo")
+                send_ids = await client.send(
+                    [
+                        inngest.Event(name=event_name),
+                        inngest.Event(name=event_name),
+                    ]
+                )
+                assert len(send_ids) == 2
+                assert send_ids[0] != send_ids[1]
 
-        # Sleep long enough for the Dev Server to process the events.
-        time.sleep(5)
+                # Sleep long enough for the Dev Server to process the events.
+                time.sleep(5)
 
-        assert proxy_request_count == 2
+                assert get_proxy_request_counter() == 2
 
-        list_events_resp = httpx.get(
-            f"{dev_server.server.origin}/v1/events", params={"name": event_name}
-        )
+                list_events_resp = httpx.get(
+                    f"{dev_server.server.origin}/v1/events",
+                    params={"name": event_name},
+                )
 
-        # 4 events were stored: 2 from the first attempt and 2 from the second
-        # attempt. This isn't ideal but it's the best we can do until we add
-        # first-class event idempotency (it's currently enforced when scheduling
-        # runs).
-        event_ids = [
-            event["internal_id"] for event in list_events_resp.json()["data"]
-        ]
-        assert len(event_ids) == 4
+                # 4 events were stored: 2 from the first attempt and 2 from the second
+                # attempt. This isn't ideal but it's the best we can do until we add
+                # first-class event idempotency (it's currently enforced when scheduling
+                # runs).
+                event_ids = [
+                    event["internal_id"]
+                    for event in list_events_resp.json()["data"]
+                ]
+                assert len(event_ids) == 4
 
-        # Only 2 unique IDs (despite 4 events) because their internal IDs are
-        # deterministically generated from the same seed.
-        unique_event_ids = set(event_ids)
-        assert len(unique_event_ids) == 2
+                # Only 2 unique IDs (despite 4 events) because their internal IDs are
+                # deterministically generated from the same seed.
+                unique_event_ids = set(event_ids)
+                assert len(unique_event_ids) == 2
 
-        # The send IDs match the IDs returned by the REST API.
-        assert unique_event_ids == set(send_ids)
+                # The send IDs match the IDs returned by the REST API.
+                assert unique_event_ids == set(send_ids)
 
     async def test_client_does_not_retry_on_400(self) -> None:
         """
@@ -267,6 +239,103 @@ class TestSend(unittest.IsolatedAsyncioTestCase):
 
         # client didn't retry request
         assert proxy_request_count == 1
+
+
+CountGetter = typing.Callable[[], int]
+
+
+# Create a proxy that mimics a request reaching the Dev Server but the
+# client receives a 500 on the first attempt. This ensures that the Dev
+# Server's event processing logic properly handles the idempotency key
+# header.
+def create_first_request_500_handler() -> typing.Tuple[
+    http_proxy.OnRequest, CountGetter
+]:
+    proxy_request_count = 0
+
+    def on_request(
+        body: typing.Optional[bytes],
+        headers: dict[str, list[str]],
+        method: str,
+        path: str,
+    ) -> http_proxy.Response:
+        nonlocal proxy_request_count
+        proxy_request_count += 1
+
+        # Always forward request to real dev server
+        resp = httpx.request(
+            method=method,
+            url=f"{dev_server.server.origin}{path}",
+            headers={k: v[0] for k, v in headers.items()},
+            content=body,
+        )
+
+        # But make client think we failed with synthetic 500 response on first try
+        if proxy_request_count == 1:
+            return http_proxy.Response(
+                body=b"{}",
+                headers={},
+                status_code=500,
+            )
+        else:
+            # forward subsequent dev server responses
+            return http_proxy.Response(
+                body=resp.content,
+                headers=dict(resp.headers),
+                status_code=resp.status_code,
+            )
+
+    def get_count() -> int:
+        return proxy_request_count
+
+    return on_request, get_count
+
+
+# Create a proxy that mimics a request reaching the Dev Server but the
+# client times out on the first attempt.
+def create_first_request_timeout_handler() -> typing.Tuple[
+    http_proxy.OnRequest, CountGetter
+]:
+    proxy_request_count = 0
+
+    def on_request(
+        body: typing.Optional[bytes],
+        headers: dict[str, list[str]],
+        method: str,
+        path: str,
+    ) -> http_proxy.Response:
+        nonlocal proxy_request_count
+        proxy_request_count += 1
+
+        # Always forward request to real dev server
+        resp = httpx.request(
+            method=method,
+            url=f"{dev_server.server.origin}{path}",
+            headers={k: v[0] for k, v in headers.items()},
+            content=body,
+        )
+
+        # But make client think we timed out
+        if proxy_request_count == 1:
+            time.sleep(35)
+            # dummy response only used for type checking, client will never receive it
+            return http_proxy.Response(
+                body=None,
+                headers={},
+                status_code=418,
+            )
+        else:
+            # forward subsequent dev server responses
+            return http_proxy.Response(
+                body=resp.content,
+                headers=dict(resp.headers),
+                status_code=resp.status_code,
+            )
+
+    def get_count() -> int:
+        return proxy_request_count
+
+    return on_request, get_count
 
 
 if __name__ == "__main__":

--- a/tests/test_inngest/test_client/test_send.py
+++ b/tests/test_inngest/test_client/test_send.py
@@ -1,14 +1,16 @@
 import asyncio
 import dataclasses
 import json
+import time
 import typing
 import unittest
 
+import httpx
 import inngest
 import inngest.flask
 from inngest._internal import const, errors
 from inngest.experimental import dev_server
-from test_core import http_proxy
+from test_core import http_proxy, net, random_suffix
 
 
 class TestSend(unittest.IsolatedAsyncioTestCase):
@@ -129,6 +131,142 @@ class TestSend(unittest.IsolatedAsyncioTestCase):
                 ]
             )
         assert len(ctx.exception.ids) == 1
+
+    async def test_client_send_retry(self) -> None:
+        """
+        Ensure that the client retries on error when sending to event API, and
+        that retries use the same idempotency key header.
+        """
+
+        proxy_request_count = 0
+
+        # Create a proxy that mimics a request reaching the Dev Server but the
+        # client receives a 500 on the first attempt. This ensures that the Dev
+        # Server's event processing logic properly handles the idempotency key
+        # header.
+        def on_request(
+            body: typing.Optional[bytes],
+            headers: dict[str, list[str]],
+            method: str,
+            path: str,
+        ) -> http_proxy.Response:
+            nonlocal proxy_request_count
+            proxy_request_count += 1
+
+            # Always forward request to real dev server
+            resp = httpx.request(
+                method=method,
+                url=f"{dev_server.server.origin}{path}",
+                headers={k: v[0] for k, v in headers.items()},
+                content=body,
+            )
+
+            # But make client think we failed with synthetic 500 response on first try
+            if proxy_request_count == 1:
+                return http_proxy.Response(
+                    body=b"{}",
+                    headers={},
+                    status_code=500,
+                )
+            else:
+                # forward subsequent dev server responses
+                return http_proxy.Response(
+                    body=resp.content,
+                    headers=dict(resp.headers),
+                    status_code=resp.status_code,
+                )
+
+        proxy = http_proxy.Proxy(on_request)
+        proxy.start()
+        self.addCleanup(proxy.stop)
+
+        client = inngest.Inngest(
+            event_api_base_url=proxy.origin,
+            app_id=random_suffix("my-app"),
+            is_production=False,
+        )
+
+        # Send two events in one request with the same idempotency key header
+        # The returned IDs are unique.
+        event_name = random_suffix("foo")
+        send_ids = await client.send(
+            [
+                inngest.Event(name=event_name),
+                inngest.Event(name=event_name),
+            ]
+        )
+        assert len(send_ids) == 2
+        assert send_ids[0] != send_ids[1]
+
+        # Sleep long enough for the Dev Server to process the events.
+        time.sleep(5)
+
+        assert proxy_request_count == 2
+
+        list_events_resp = httpx.get(
+            f"{dev_server.server.origin}/v1/events", params={"name": event_name}
+        )
+
+        # 4 events were stored: 2 from the first attempt and 2 from the second
+        # attempt. This isn't ideal but it's the best we can do until we add
+        # first-class event idempotency (it's currently enforced when scheduling
+        # runs).
+        event_ids = [
+            event["internal_id"] for event in list_events_resp.json()["data"]
+        ]
+        assert len(event_ids) == 4
+
+        # Only 2 unique IDs (despite 4 events) because their internal IDs are
+        # deterministically generated from the same seed.
+        unique_event_ids = set(event_ids)
+        assert len(unique_event_ids) == 2
+
+        # The send IDs match the IDs returned by the REST API.
+        assert unique_event_ids == set(send_ids)
+
+    async def test_client_does_not_retry_on_400(self) -> None:
+        """
+        Ensure that the client does not retry on 400 errors when sending to event API.
+        """
+
+        proxy_request_count = 0
+
+        # Create a proxy that returns a 400
+        def on_request(
+            body: typing.Optional[bytes],
+            headers: dict[str, list[str]],
+            method: str,
+            path: str,
+        ) -> http_proxy.Response:
+            nonlocal proxy_request_count
+            proxy_request_count += 1
+
+            return http_proxy.Response(
+                body=b"{}",
+                headers={},
+                status_code=400,
+            )
+
+        proxy = http_proxy.Proxy(on_request)
+        proxy.start()
+        self.addCleanup(proxy.stop)
+
+        client = inngest.Inngest(
+            event_api_base_url=proxy.origin,
+            app_id=random_suffix("my-app"),
+            is_production=False,
+        )
+
+        event_name = random_suffix("foo")
+        await client.send(
+            [
+                inngest.Event(name=event_name),
+                inngest.Event(name=event_name),
+            ]
+        )
+
+        # client didn't retry request
+        assert proxy_request_count == 1
 
 
 if __name__ == "__main__":

--- a/tests/test_inngest/test_client/test_send.py
+++ b/tests/test_inngest/test_client/test_send.py
@@ -13,6 +13,9 @@ from inngest.experimental import dev_server
 from test_core import http_proxy, net, random_suffix
 
 
+TEST_HTTPX_TIMEOUT = 1  # timeout in seconds
+
+
 class TestSend(unittest.IsolatedAsyncioTestCase):
     async def test_send_event_to_cloud_branch_env(self) -> None:
         """
@@ -166,6 +169,7 @@ class TestSend(unittest.IsolatedAsyncioTestCase):
                     event_api_base_url=proxy.origin,
                     app_id=random_suffix("my-app"),
                     is_production=False,
+                    request_timeout=TEST_HTTPX_TIMEOUT * 1000,
                 )
 
                 # Send two events in one request with the same idempotency key header
@@ -335,7 +339,7 @@ def create_first_request_timeout_handler() -> typing.Tuple[
 
         # But make client think we timed out
         if proxy_request_count == 1:
-            time.sleep(35)
+            time.sleep(TEST_HTTPX_TIMEOUT + 1)
             # dummy response only used for type checking, client will never receive it
             return http_proxy.Response(
                 body=None,


### PR DESCRIPTION
Python port of https://github.com/inngest/inngestgo/pull/134

- **Add failing test when there is an error reaching event API**
- **Add retry loop around event sending with exponential backoff and jitter**
- **Generate seed and send in `x-inngest-event-id-seed` header**