### PR TITLE
Fixed AI adapter URLs and added smoke test for all adapters

### DIFF
--- a/pkg/inngest/inngest/experimental/ai/deepseek.py
+++ b/pkg/inngest/inngest/experimental/ai/deepseek.py
@@ -5,7 +5,7 @@ from .base import BaseAdapter
 
 class Adapter(BaseAdapter):
     """
-    Anthropic adapter
+    DeepSeek adapter
     """
 
     def __init__(

--- a/pkg/inngest/inngest/experimental/ai/gemini.py
+++ b/pkg/inngest/inngest/experimental/ai/gemini.py
@@ -5,7 +5,7 @@ from .base import BaseAdapter
 
 class Adapter(BaseAdapter):
     """
-    Anthropic adapter
+    Gemini adapter
     """
 
     def __init__(
@@ -63,7 +63,7 @@ class Adapter(BaseAdapter):
 
     def url_infer(self) -> str:
         """
-        Return the URL for generating text.
+        Return the URL for generating text with the model included in the path.
         """
 
-        return self._url.rstrip("/") + f":generateContent?key={self._auth_key}"
+        return self._url.rstrip("/") + f"/models/{self._model}:generateContent?key={self._auth_key}"

--- a/pkg/inngest/inngest/experimental/ai/grok.py
+++ b/pkg/inngest/inngest/experimental/ai/grok.py
@@ -5,7 +5,7 @@ from .base import BaseAdapter
 
 class Adapter(BaseAdapter):
     """
-    OpenAI adapter
+    Grok adapter
     """
 
     def __init__(
@@ -28,7 +28,7 @@ class Adapter(BaseAdapter):
         self._auth_key = auth_key
         self._headers = headers or {}
         self._model = model
-        self._url = base_url or "https://api.x.ai/v1"
+        self._url = base_url or "https://api.x.ai/v1/chat/completions"
 
     def auth_key(self) -> str:
         """

--- a/pkg/inngest/pyproject.toml
+++ b/pkg/inngest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.5.0a1"
+version = "0.5.0a2"
 authors = [{ name = "Inngest Inc.", email = "hello@inngest.com" }]
 description = "Python SDK for Inngest"
 readme = "README.md"

--- a/tests/smoke_tests/model_adapters/Makefile
+++ b/tests/smoke_tests/model_adapters/Makefile
@@ -1,0 +1,8 @@
+check-venv:
+	@if [ -z "$$VIRTUAL_ENV" ]; then \
+		echo "virtual environment is not activated"; \
+		exit 1; \
+	fi
+
+dev: check-venv
+	@export INNGEST_DEV=1 && ./scripts/start.sh

--- a/tests/smoke_tests/model_adapters/README.md
+++ b/tests/smoke_tests/model_adapters/README.md
@@ -1,0 +1,76 @@
+# AI Model Adapters Smoke Test
+
+This smoke test validates that all AI model adapters work correctly with their respective APIs.
+
+## What it tests
+
+This test calls multiple AI providers to answer a simple question. The purpose of this is to ensure that we:
+
+- Make successful API calls
+- Handle provider-specific request formats
+- Parse responses correctly
+
+### Models tested:
+
+- **OpenAI** (o4 Mini)
+- **Anthropic** (Claude 3 Sonnet)
+- **Google Gemini** (Gemini 2.5 Pro)
+- **xAI Grok** (Grok 3)
+- **DeepSeek** (DeepSeek Chat)
+
+## Setup
+
+1. **Environment Variables**: Copy the example environment variables into a `.env` file located in the root of the inngest-py project and fill in your API keys. Your `.env` file should look like this:
+
+   ```
+   INNGEST_BASE_URL=http://localhost:8288
+   OPENAI_API_KEY=your_openai_api_key_here
+   ANTHROPIC_API_KEY=your_anthropic_api_key_here
+   GEMINI_API_KEY=your_gemini_api_key_here
+   GROK_API_KEY=your_grok_api_key_here
+   DEEPSEEK_API_KEY=your_deepseek_api_key_here
+   ```
+
+2. **Virtual Environment**: Make sure you have activated your virtual environment:
+
+   ```bash
+   source .venv/bin/activate
+   ```
+
+3. **Install Dependencies**: Make sure all dependencies are installed:
+   ```bash
+   make install
+   ```
+
+## Running the test
+
+Navigate to the smoke test directory and run:
+
+```bash
+cd tests/smoke_tests/model_adapters
+make dev
+```
+
+This will:
+
+- Start a FastAPI server on port 8000
+- Load your environment variables from the project root `.env` file
+- Expose the Inngest function
+
+## Triggering the test
+
+Once the server is running, you can trigger the smoke test by sending an event via the Inngest dev server
+
+## Expected behavior
+
+The test should:
+
+- Successfully call all 5 AI providers
+- Return responses from each provider
+- Handle any API errors gracefully (displaying error messages instead of crashing)
+
+## Troubleshooting
+
+- **Missing or Invalid API keys**: Make sure all required API keys are set in your `.env` file and are valid
+- **Rate Limits**: Some providers may have rate limits; wait a moment and try again
+- **API Credits**: Most providers require that you purchase credits. After purchasing, you may need to wait some time for the credits to register on their system.

--- a/tests/smoke_tests/model_adapters/app.py
+++ b/tests/smoke_tests/model_adapters/app.py
@@ -1,0 +1,138 @@
+import fastapi
+import inngest
+import inngest.fast_api
+from inngest.experimental.ai.openai import Adapter as OpenAIAdapter
+from inngest.experimental.ai.anthropic import Adapter as AnthropicAdapter
+from inngest.experimental.ai.gemini import Adapter as GeminiAdapter
+from inngest.experimental.ai.grok import Adapter as GrokAdapter
+from inngest.experimental.ai.deepseek import Adapter as DeepSeekAdapter
+import os
+
+
+inngest_client = inngest.Inngest(app_id="smoke-test-model-adapters-app")
+
+# Create AI adapters
+openai_adapter = OpenAIAdapter(
+    auth_key=os.getenv("OPENAI_API_KEY"),
+    model="o4-mini-2025-04-16",
+)
+
+anthropic_adapter = AnthropicAdapter(
+    auth_key=os.getenv("ANTHROPIC_API_KEY"),
+    model="claude-3-5-sonnet-latest",
+)
+
+gemini_adapter = GeminiAdapter(
+    auth_key=os.getenv("GEMINI_API_KEY"),
+    model="gemini-2.5-pro",
+)
+
+grok_adapter = GrokAdapter(
+    auth_key=os.getenv("GROK_API_KEY"),
+    model="grok-3-latest",
+)
+
+deepseek_adapter = DeepSeekAdapter(
+    auth_key=os.getenv("DEEPSEEK_API_KEY"),
+    model="deepseek-chat",
+)
+
+@inngest_client.create_function(
+    fn_id="model-adapter-test",
+    trigger=inngest.TriggerEvent(event="test-adapters"),
+)
+async def test_adapters(ctx: inngest.Context) -> dict:
+    adapters = {
+        "openai": openai_adapter,
+        "anthropic": anthropic_adapter,
+        "gemini": gemini_adapter,
+        "grok": grok_adapter,
+        "deepseek": deepseek_adapter,
+    }
+
+    # Different state capital questions for each provider
+    questions = {
+        "openai": "What is the capital of California?",
+        "anthropic": "What is the capital of Texas?",
+        "gemini": "What is the capital of New York?",
+        "grok": "What is the capital of Florida?",
+        "deepseek": "What is the capital of Illinois?",
+    }
+
+    responses = {}
+
+    for provider_name, adapter in adapters.items():
+        try:
+            question = questions[provider_name]
+            
+            # Prepare the request body based on provider
+            if provider_name == "gemini":
+                # Gemini uses a different format and model should be in URL, not body
+                body = {
+                    "contents": [
+                        {
+                            "parts": [
+                                {
+                                    "text": question
+                                }
+                            ]
+                        }
+                    ]
+                }
+            else:
+                # Standard OpenAI-style format for other providers
+                body = {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": question
+                        }
+                    ]
+                }
+
+            # Add max_tokens for Anthropic (required parameter)
+            if provider_name == "anthropic":
+                body["max_tokens"] = 1024
+
+            print(f"Calling {provider_name} with question: {question}")
+
+            ai_response = await ctx.step.ai.infer(
+                step_id=f"ai-call-{provider_name}",
+                adapter=adapter,
+                body=body
+            )
+
+            print(f"{provider_name} response: {ai_response}")
+
+            # Extract the text content from the AI response
+            # Different providers may have different response formats
+            if "choices" in ai_response and len(ai_response["choices"]) > 0:
+                # OpenAI/DeepSeek/Grok format
+                responses[provider_name] = ai_response["choices"][0]["message"]["content"]
+            elif "content" in ai_response and isinstance(ai_response["content"], list):
+                # Anthropic format
+                responses[provider_name] = ai_response["content"][0]["text"]
+            elif "candidates" in ai_response and len(ai_response["candidates"]) > 0:
+                # Gemini format
+                candidate = ai_response["candidates"][0]
+                if "content" in candidate and "parts" in candidate["content"]:
+                    responses[provider_name] = candidate["content"]["parts"][0]["text"]
+                else:
+                    responses[provider_name] = str(candidate)
+            else:
+                # Fallback for unknown format
+                responses[provider_name] = str(ai_response)
+
+        except Exception as e:
+            print(f"Error with {provider_name}: {str(e)}")
+            responses[provider_name] = f"Error: {str(e)}"
+
+    return responses
+
+app = fastapi.FastAPI()
+
+inngest.fast_api.serve(
+    app,
+    inngest_client,
+    [test_adapters],
+)

--- a/tests/smoke_tests/model_adapters/env.example
+++ b/tests/smoke_tests/model_adapters/env.example
@@ -1,0 +1,18 @@
+# API Keys needed to test all supported models
+# 1. Copy these variables to the .env in your projects root directory
+# 2. Replace placeholders with actual API keys
+
+# OpenAI API Key
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Anthropic API Key  
+ANTHROPIC_API_KEY=your_anthropic_api_key_here
+
+# Google Gemini API Key
+GEMINI_API_KEY=your_gemini_api_key_here
+
+# xAI Grok API Key
+GROK_API_KEY=your_grok_api_key_here
+
+# DeepSeek API Key
+DEEPSEEK_API_KEY=your_deepseek_api_key_here 

--- a/tests/smoke_tests/model_adapters/scripts/start.sh
+++ b/tests/smoke_tests/model_adapters/scripts/start.sh
@@ -1,0 +1,11 @@
+set -e
+
+export PYTHONPATH=${PYTHONPATH}:../../..
+
+# Load env vars from .env file in repo root.
+ENV_VARS=$(cat ../../../.env | grep -v ^#)
+if [ -n "${ENV_VARS}" ]; then
+    export $(echo ${ENV_VARS} | xargs)
+fi
+
+uvicorn app:app --reload 


### PR DESCRIPTION
## Fixed AI Adapter URLs & Added Smoke Tests
This PR fixes critical URL formatting issues with Grok and Gemini adapters that were preventing successful API calls, corrects some documentation and adds a smoke test to validate that all AI adapters work correctly.

### 🔧 **Fixes**

#### **Grok Adapter URL Fix** 
- Fixed the base URL for the Grok adapter to include the full endpoint path (`/chat/completions`)
- Changed from `https://api.x.ai/v1` to `https://api.x.ai/v1/chat/completions`

#### **Gemini Adapter URL Structure**
- Updated Gemini adapter to correctly include the model in the URL path
- Modified `url_infer()` method to use `/models/{model}:generateContent` format
- Added clarifying comment about model inclusion in the URL path

### ✨ **Additional Changes**

#### **AI Model Adapters Smoke Test Suite**
- Added model adapter smoke tests in `tests/smoke_tests/model_adapters/`
- Tests all 5 supported AI providers: OpenAI, Anthropic, Gemini, Grok, and DeepSeek
- Validates successful API calls, provider-specific request formats, and response parsing
- Includes documentation and setup instructions
- Features provider-specific question handling and error management

**Test Suite Components:**
- `app.py` - FastAPI application with test function for all providers
- `README.md` - Detailed setup and usage documentation
- `Makefile` - Development workflow commands
- `env.example` - Environment variables template
- `scripts/start.sh` - Automated startup script with environment loading

### 🔄 **Other Changes**
- Version bump: `0.5.0a1` → `0.5.0a2`

### 🧪 **Testing**
The new smoke test can be run with:
```bash
cd tests/smoke_tests/model_adapters
make dev
```

### 📋 **Requirements**
- API keys for all providers must be configured in `.env` file
- Virtual environment must be activated
- All dependencies installed via `make install`