### PR TITLE
Add public_path arg to serve

### DIFF
--- a/pkg/inngest/inngest/_internal/comm_lib/handler.py
+++ b/pkg/inngest/inngest/_internal/comm_lib/handler.py
@@ -490,6 +490,7 @@ class Syncer:
             return req_body
 
         app_url = net.create_serve_url(
+            public_path=req.public_path,
             request_url=req_body.url,
             serve_origin=req.serve_origin,
             serve_path=req.serve_path,
@@ -542,6 +543,7 @@ class Syncer:
         req: CommRequest,
     ) -> types.MaybeError[typing.Union[CommResponse, httpx.Request]]:
         app_url = net.create_serve_url(
+            public_path=req.public_path,
             request_url=req.request_url,
             serve_origin=req.serve_origin,
             serve_path=req.serve_path,

--- a/pkg/inngest/inngest/_internal/comm_lib/models.py
+++ b/pkg/inngest/inngest/_internal/comm_lib/models.py
@@ -23,6 +23,7 @@ class CommRequest(types.BaseModel):
     is_connect: bool = False
 
     query_params: typing.Union[dict[str, str], dict[str, list[str]]]
+    public_path: typing.Optional[str]
     raw_request: object
     request_url: str
     serve_origin: typing.Optional[str]

--- a/pkg/inngest/inngest/_internal/net.py
+++ b/pkg/inngest/inngest/_internal/net.py
@@ -74,6 +74,7 @@ def create_headers(
 
 def create_serve_url(
     *,
+    public_path: typing.Optional[str],
     request_url: str,
     serve_origin: typing.Optional[str],
     serve_path: typing.Optional[str],
@@ -84,6 +85,7 @@ def create_serve_url(
 
     Args:
     ----
+        public_path: User-specified override for the public path.
         request_url: The URL that the Executor is using to reach the SDK.
         serve_origin: User-specified override for the serve origin.
         serve_path: User-specified override for the serve path.
@@ -110,6 +112,13 @@ def create_serve_url(
 
     if serve_path is not None:
         new_path = serve_path
+
+    # public_path takes precedence over serve_path because it allows users to
+    # decouple their publicly-reachable path (that the Inngest server sends
+    # requests to) and the path that our SDK is hosted on. This is useful when
+    # the SDK is behind a proxy that rewrites the path
+    if public_path is not None:
+        new_path = public_path
 
     return urllib.parse.urlunparse(
         (new_scheme, new_netloc, new_path, "", "", "")

--- a/pkg/inngest/inngest/_internal/net_test.py
+++ b/pkg/inngest/inngest/_internal/net_test.py
@@ -23,6 +23,7 @@ class Test_create_serve_url(unittest.TestCase):
 
     def test_only_request_url(self) -> None:
         actual = net.create_serve_url(
+            public_path=None,
             request_url="https://foo.test/api/inngest",
             serve_origin=None,
             serve_path=None,
@@ -32,6 +33,7 @@ class Test_create_serve_url(unittest.TestCase):
 
     def test_serve_origin(self) -> None:
         actual = net.create_serve_url(
+            public_path=None,
             request_url="https://foo.test/api/inngest",
             serve_origin="https://bar.test",
             serve_path=None,
@@ -43,6 +45,7 @@ class Test_create_serve_url(unittest.TestCase):
         os.environ[const.EnvKey.SERVE_ORIGIN.value] = "https://bar-env.test"
 
         actual = net.create_serve_url(
+            public_path=None,
             request_url="https://foo.test/api/inngest",
             serve_origin="https://bar.test",
             serve_path=None,
@@ -52,6 +55,7 @@ class Test_create_serve_url(unittest.TestCase):
 
     def test_serve_origin_missing_scheme(self) -> None:
         actual = net.create_serve_url(
+            public_path=None,
             request_url="https://foo.test/api/inngest",
             serve_origin="bar.test",
             serve_path=None,
@@ -61,6 +65,7 @@ class Test_create_serve_url(unittest.TestCase):
 
     def test_serve_origin_port(self) -> None:
         actual = net.create_serve_url(
+            public_path=None,
             request_url="https://foo.test/api/inngest",
             serve_origin="https://bar.test:8080",
             serve_path=None,
@@ -70,6 +75,7 @@ class Test_create_serve_url(unittest.TestCase):
 
     def test_serve_path(self) -> None:
         actual = net.create_serve_url(
+            public_path=None,
             request_url="https://foo.test/api/inngest",
             serve_origin=None,
             serve_path="/custom/path",
@@ -81,6 +87,7 @@ class Test_create_serve_url(unittest.TestCase):
         os.environ[const.EnvKey.SERVE_PATH.value] = "/env/path"
 
         actual = net.create_serve_url(
+            public_path=None,
             request_url="https://foo.test/api/inngest",
             serve_origin=None,
             serve_path="/custom/path",
@@ -90,11 +97,22 @@ class Test_create_serve_url(unittest.TestCase):
 
     def test_serve_origin_and_path(self) -> None:
         actual = net.create_serve_url(
+            public_path=None,
             request_url="https://foo.test/api/inngest",
             serve_origin="https://bar.test",
             serve_path="/custom/path",
         )
         expected = "https://bar.test/custom/path"
+        assert actual == expected
+
+    def test_public_path(self) -> None:
+        actual = net.create_serve_url(
+            public_path="/public/path",
+            request_url="https://foo.test/api/inngest",
+            serve_origin=None,
+            serve_path="/serve/path",
+        )
+        expected = "https://foo.test/public/path"
         assert actual == expected
 
 

--- a/pkg/inngest/inngest/digital_ocean.py
+++ b/pkg/inngest/inngest/digital_ocean.py
@@ -25,6 +25,7 @@ def serve(
     client: client_lib.Inngest,
     functions: list[function.Function],
     *,
+    public_path: typing.Optional[str] = None,
     serve_origin: typing.Optional[str] = None,
     serve_path: typing.Optional[str] = None,
 ) -> typing.Callable[[dict[str, object], _Context], _Response]:
@@ -35,9 +36,9 @@ def serve(
     ----
         client: Inngest client.
         functions: List of functions to serve.
-
-        serve_origin: Origin to serve the functions from.
-        serve_path: The entire function path (e.g. /api/v1/web/fn-b094417f/sample/hello).
+        public_path: Path that the Inngest server sends requests to. This is only necessary if the SDK is behind a proxy that rewrites the path.
+        serve_origin: Origin for serving Inngest functions.
+        serve_path: Path for hosting Inngest functions.
     """
 
     handler = comm_lib.CommHandler(
@@ -82,6 +83,7 @@ def serve(
             comm_req = comm_lib.CommRequest(
                 body=_to_body_bytes(http.body),
                 headers=http.headers,
+                public_path=public_path,
                 query_params=query_params,
                 raw_request={
                     "context": context,

--- a/pkg/inngest/inngest/digital_ocean.py
+++ b/pkg/inngest/inngest/digital_ocean.py
@@ -37,8 +37,8 @@ def serve(
         client: Inngest client.
         functions: List of functions to serve.
         public_path: Path that the Inngest server sends requests to. This is only necessary if the SDK is behind a proxy that rewrites the path.
-        serve_origin: Origin for serving Inngest functions.
-        serve_path: Path for hosting Inngest functions.
+        serve_origin: Origin for serving Inngest functions. This is typically only useful during Docker-based development.
+        serve_path: Path for serving Inngest functions. This is only useful if you don't want serve Inngest at the /api/inngest path.
     """
 
     handler = comm_lib.CommHandler(

--- a/pkg/inngest/inngest/django.py
+++ b/pkg/inngest/inngest/django.py
@@ -40,8 +40,8 @@ def serve(
         client: Inngest client.
         functions: List of functions to serve.
         public_path: Path that the Inngest server sends requests to. This is only necessary if the SDK is behind a proxy that rewrites the path.
-        serve_origin: Origin for serving Inngest functions.
-        serve_path: Path for hosting Inngest functions.
+        serve_origin: Origin for serving Inngest functions. This is typically only useful during Docker-based development.
+        serve_path: Path for serving Inngest functions. This is only useful if you don't want serve Inngest at the /api/inngest path.
     """
 
     handler = comm_lib.CommHandler(

--- a/pkg/inngest/inngest/django.py
+++ b/pkg/inngest/inngest/django.py
@@ -28,6 +28,7 @@ def serve(
     client: client_lib.Inngest,
     functions: list[function.Function],
     *,
+    public_path: typing.Optional[str] = None,
     serve_origin: typing.Optional[str] = None,
     serve_path: typing.Optional[str] = None,
 ) -> django.urls.URLPattern:
@@ -38,10 +39,9 @@ def serve(
     ----
         client: Inngest client.
         functions: List of functions to serve.
-
-        async_mode: [DEPRECATED] Whether to serve functions asynchronously.
-        serve_origin: Origin to serve Inngest from.
-        serve_path: Path to serve Inngest from.
+        public_path: Path that the Inngest server sends requests to. This is only necessary if the SDK is behind a proxy that rewrites the path.
+        serve_origin: Origin for serving Inngest functions.
+        serve_path: Path for hosting Inngest functions.
     """
 
     handler = comm_lib.CommHandler(
@@ -60,6 +60,7 @@ def serve(
         return _create_handler_async(
             client,
             handler,
+            public_path=public_path,
             serve_origin=serve_origin,
             serve_path=serve_path,
         )
@@ -67,6 +68,7 @@ def serve(
         return _create_handler_sync(
             client,
             handler,
+            public_path=public_path,
             serve_origin=serve_origin,
             serve_path=serve_path,
         )
@@ -76,6 +78,7 @@ def _create_handler_sync(
     client: client_lib.Inngest,
     handler: comm_lib.CommHandler,
     *,
+    public_path: typing.Optional[str],
     serve_origin: typing.Optional[str],
     serve_path: typing.Optional[str],
 ) -> django.urls.URLPattern:
@@ -85,6 +88,7 @@ def _create_handler_sync(
         comm_req = comm_lib.CommRequest(
             body=request.body,
             headers=dict(request.headers.items()),
+            public_path=public_path,
             query_params=dict(request.GET.items()),
             raw_request=request,
             request_url=request.build_absolute_uri(),
@@ -127,6 +131,7 @@ def _create_handler_async(
     client: client_lib.Inngest,
     handler: comm_lib.CommHandler,
     *,
+    public_path: typing.Optional[str],
     serve_origin: typing.Optional[str],
     serve_path: typing.Optional[str],
 ) -> django.urls.URLPattern:
@@ -146,6 +151,7 @@ def _create_handler_async(
         comm_req = comm_lib.CommRequest(
             body=request.body,
             headers=dict(request.headers.items()),
+            public_path=public_path,
             query_params=dict(request.GET.items()),
             raw_request=request,
             request_url=request.build_absolute_uri(),

--- a/pkg/inngest/inngest/experimental/connect/execution_handler.py
+++ b/pkg/inngest/inngest/experimental/connect/execution_handler.py
@@ -118,6 +118,7 @@ class _ExecutionHandler(_BaseHandler):
                         body=req_data.request_payload,
                         headers={},
                         is_connect=True,
+                        public_path=None,
                         query_params={
                             server_lib.QueryParamKey.FUNCTION_ID.value: req_data.function_slug,
                         },

--- a/pkg/inngest/inngest/fast_api.py
+++ b/pkg/inngest/inngest/fast_api.py
@@ -23,6 +23,7 @@ def serve(
     client: client_lib.Inngest,
     functions: list[function.Function],
     *,
+    public_path: typing.Optional[str] = None,
     serve_origin: typing.Optional[str] = None,
     serve_path: typing.Optional[str] = None,
     streaming: typing.Optional[const.Streaming] = None,
@@ -35,11 +36,10 @@ def serve(
         app: FastAPI app.
         client: Inngest client.
         functions: List of functions to serve.
-
-        serve_origin: Origin to serve the functions from.
-        serve_path: Path to serve the functions from.
-        streaming: Controls whether to send keepalive bytes until the response is
-            complete.
+        public_path: Path that the Inngest server sends requests to. This is only necessary if the SDK is behind a proxy that rewrites the path.
+        serve_origin: Origin for serving Inngest functions.
+        serve_path: Path for hosting Inngest functions.
+        streaming: Controls whether to send keepalive bytes until the response is complete.
     """
 
     handler = comm_lib.CommHandler(
@@ -59,6 +59,7 @@ def serve(
                 comm_lib.CommRequest(
                     body=await request.body(),
                     headers=dict(request.headers.items()),
+                    public_path=public_path,
                     query_params=dict(request.query_params.items()),
                     raw_request=request,
                     request_url=str(request.url),
@@ -78,6 +79,7 @@ def serve(
                 comm_lib.CommRequest(
                     body=await request.body(),
                     headers=dict(request.headers.items()),
+                    public_path=public_path,
                     query_params=dict(request.query_params.items()),
                     raw_request=request,
                     request_url=str(request.url),
@@ -97,6 +99,7 @@ def serve(
                 comm_lib.CommRequest(
                     body=await request.body(),
                     headers=dict(request.headers.items()),
+                    public_path=public_path,
                     query_params=dict(request.query_params.items()),
                     raw_request=request,
                     request_url=str(request.url),

--- a/pkg/inngest/inngest/fast_api.py
+++ b/pkg/inngest/inngest/fast_api.py
@@ -37,8 +37,8 @@ def serve(
         client: Inngest client.
         functions: List of functions to serve.
         public_path: Path that the Inngest server sends requests to. This is only necessary if the SDK is behind a proxy that rewrites the path.
-        serve_origin: Origin for serving Inngest functions.
-        serve_path: Path for hosting Inngest functions.
+        serve_origin: Origin for serving Inngest functions. This is typically only useful during Docker-based development.
+        serve_path: Path for serving Inngest functions. This is only useful if you don't want serve Inngest at the /api/inngest path.
         streaming: Controls whether to send keepalive bytes until the response is complete.
     """
 

--- a/pkg/inngest/inngest/flask.py
+++ b/pkg/inngest/inngest/flask.py
@@ -35,8 +35,8 @@ def serve(
         client: Inngest client.
         functions: List of functions to serve.
         public_path: Path that the Inngest server sends requests to. This is only necessary if the SDK is behind a proxy that rewrites the path.
-        serve_origin: Origin for serving Inngest functions.
-        serve_path: Path for hosting Inngest functions.
+        serve_origin: Origin for serving Inngest functions. This is typically only useful during Docker-based development.
+        serve_path: Path for serving Inngest functions. This is only useful if you don't want serve Inngest at the /api/inngest path.
     """
 
     handler = comm_lib.CommHandler(

--- a/pkg/inngest/inngest/flask.py
+++ b/pkg/inngest/inngest/flask.py
@@ -22,6 +22,7 @@ def serve(
     client: client_lib.Inngest,
     functions: list[function.Function],
     *,
+    public_path: typing.Optional[str] = None,
     serve_origin: typing.Optional[str] = None,
     serve_path: typing.Optional[str] = None,
 ) -> None:
@@ -33,9 +34,9 @@ def serve(
         app: Flask app.
         client: Inngest client.
         functions: List of functions to serve.
-
-        serve_origin: Origin to serve the functions from.
-        serve_path: Path to serve the functions from.
+        public_path: Path that the Inngest server sends requests to. This is only necessary if the SDK is behind a proxy that rewrites the path.
+        serve_origin: Origin for serving Inngest functions.
+        serve_path: Path for hosting Inngest functions.
     """
 
     handler = comm_lib.CommHandler(
@@ -54,6 +55,7 @@ def serve(
             app,
             client,
             handler,
+            public_path=public_path,
             serve_origin=serve_origin,
             serve_path=serve_path,
         )
@@ -62,6 +64,7 @@ def serve(
             app,
             client,
             handler,
+            public_path=public_path,
             serve_origin=serve_origin,
             serve_path=serve_path,
         )
@@ -72,6 +75,7 @@ def _create_handler_async(
     client: client_lib.Inngest,
     handler: comm_lib.CommHandler,
     *,
+    public_path: typing.Optional[str],
     serve_origin: typing.Optional[str],
     serve_path: typing.Optional[str],
 ) -> None:
@@ -83,6 +87,7 @@ def _create_handler_async(
         comm_req = comm_lib.CommRequest(
             body=_get_body_bytes(),
             headers=dict(flask.request.headers.items()),
+            public_path=public_path,
             query_params=flask.request.args,
             raw_request=flask.request,
             request_url=flask.request.url,
@@ -117,6 +122,7 @@ def _create_handler_sync(
     client: client_lib.Inngest,
     handler: comm_lib.CommHandler,
     *,
+    public_path: typing.Optional[str],
     serve_origin: typing.Optional[str],
     serve_path: typing.Optional[str],
 ) -> None:
@@ -128,6 +134,7 @@ def _create_handler_sync(
         comm_req = comm_lib.CommRequest(
             body=_get_body_bytes(),
             headers=dict(flask.request.headers.items()),
+            public_path=public_path,
             query_params=flask.request.args,
             raw_request=flask.request,
             request_url=flask.request.url,

--- a/pkg/inngest/inngest/tornado.py
+++ b/pkg/inngest/inngest/tornado.py
@@ -36,8 +36,8 @@ def serve(
         client: Inngest client.
         functions: List of functions to serve.
         public_path: Path that the Inngest server sends requests to. This is only necessary if the SDK is behind a proxy that rewrites the path.
-        serve_origin: Origin for serving Inngest functions.
-        serve_path: Path for hosting Inngest functions.
+        serve_origin: Origin for serving Inngest functions. This is typically only useful during Docker-based development.
+        serve_path: Path for serving Inngest functions. This is only useful if you don't want serve Inngest at the /api/inngest path.
     """
 
     handler = comm_lib.CommHandler(

--- a/pkg/inngest/inngest/tornado.py
+++ b/pkg/inngest/inngest/tornado.py
@@ -23,6 +23,7 @@ def serve(
     client: client_lib.Inngest,
     functions: list[function.Function],
     *,
+    public_path: typing.Optional[str] = None,
     serve_origin: typing.Optional[str] = None,
     serve_path: typing.Optional[str] = None,
 ) -> None:
@@ -34,9 +35,9 @@ def serve(
         app: Tornado app.
         client: Inngest client.
         functions: List of functions to serve.
-
-        serve_origin: Origin to serve the functions from.
-        serve_path: Path to serve the functions from.
+        public_path: Path that the Inngest server sends requests to. This is only necessary if the SDK is behind a proxy that rewrites the path.
+        serve_origin: Origin for serving Inngest functions.
+        serve_path: Path for hosting Inngest functions.
     """
 
     handler = comm_lib.CommHandler(
@@ -57,6 +58,7 @@ def serve(
                 comm_lib.CommRequest(
                     body=self.request.body,
                     headers=dict(self.request.headers.items()),
+                    public_path=public_path,
                     query_params=_parse_query_params(
                         self.request.query_arguments
                     ),
@@ -74,6 +76,7 @@ def serve(
                 comm_lib.CommRequest(
                     body=self.request.body,
                     headers=dict(self.request.headers.items()),
+                    public_path=public_path,
                     query_params=_parse_query_params(
                         self.request.query_arguments
                     ),
@@ -91,6 +94,7 @@ def serve(
                 comm_lib.CommRequest(
                     body=self.request.body,
                     headers=dict(self.request.headers.items()),
+                    public_path=public_path,
                     query_params=_parse_query_params(
                         self.request.query_arguments
                     ),

--- a/pkg/inngest/pyproject.toml
+++ b/pkg/inngest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.4.23a0"
+version = "0.4.23a1"
 authors = [{ name = "Inngest Inc.", email = "hello@inngest.com" }]
 description = "Python SDK for Inngest"
 readme = "README.md"

--- a/tests/test_inngest/test_registration/test_flask.py
+++ b/tests/test_inngest/test_registration/test_flask.py
@@ -24,12 +24,13 @@ class TestRegistration(base.TestCase):
         *,
         body: typing.Union[dict[str, object], bytes],
         headers: typing.Optional[dict[str, str]] = None,
+        path: str = "/api/inngest",
     ) -> base.RegistrationResponse:
         if headers is None:
             headers = {}
 
         res = self.app_client.put(
-            "/api/inngest",
+            path,
             data=body,
             headers=headers,
         )

--- a/tests/test_inngest/test_serve/test_flask.py
+++ b/tests/test_inngest/test_serve/test_flask.py
@@ -36,28 +36,6 @@ class TestServe(unittest.TestCase):
             inngest.flask.serve(app, client, [fn])
         assert isinstance(err.value, errors.SigningKeyMissingError)
 
-    def test_handler_path(self) -> None:
-        """
-        When a handler path is provided, it should be used to serve the functions.
-        """
-
-        os.environ["INNGEST_HANDLER_PATH"] = "/my/handler/path"
-        self.addCleanup(os.environ.pop, "INNGEST_HANDLER_PATH")
-
-        app = flask.Flask(__name__)
-        client = inngest.Inngest(app_id=_app_id)
-
-        @client.create_function(
-            fn_id="fn",
-            trigger=inngest.TriggerEvent(event="event"),
-        )
-        def fn(ctx: inngest.Context, step: inngest.StepSync) -> None:
-            pass
-
-        inngest.flask.serve(app, client, [fn], serve_path="/my/serve/path")
-
-        res = requests.put("http://localhost:5000/my/handler/path")
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add `public_path` arg to `serve`, which lets users specify their public path separately from the `serve_path` arg.

This is necessary for SDKs behind proxy path rewrites