### PR TITLE
Fix streaming task

### DIFF
--- a/pkg/inngest/inngest/_internal/comm_lib/handler.py
+++ b/pkg/inngest/inngest/_internal/comm_lib/handler.py
@@ -160,23 +160,25 @@ class CommHandler:
             return Exception("events not in request")
 
         # Don't await because we might need to stream the response.
-        call_res = asyncio.create_task(fn.call(
-            self._client,
-            execution_lib.Context(
-                attempt=request.ctx.attempt,
-                event=request.event,
-                events=events,
-                group=step_lib.Group(),
-                logger=self._client.logger,
-                run_id=request.ctx.run_id,
-            ),
-            params.fn_id,
-            middleware,
-            request,
-            step_lib.StepMemos.from_raw(steps),
-            params.step_id,
-            self._thread_pool,
-        ))
+        call_res = asyncio.create_task(
+            fn.call(
+                self._client,
+                execution_lib.Context(
+                    attempt=request.ctx.attempt,
+                    event=request.event,
+                    events=events,
+                    group=step_lib.Group(),
+                    logger=self._client.logger,
+                    run_id=request.ctx.run_id,
+                ),
+                params.fn_id,
+                middleware,
+                request,
+                step_lib.StepMemos.from_raw(steps),
+                params.step_id,
+                self._thread_pool,
+            )
+        )
 
         if self._streaming is const.Streaming.FORCE:
             return CommResponse.create_streaming(

--- a/pkg/inngest/inngest/_internal/comm_lib/models.py
+++ b/pkg/inngest/inngest/_internal/comm_lib/models.py
@@ -75,9 +75,6 @@ class CommResponse:
     def create_streaming(
         cls,
         logger: types.Logger,
-        # coro: typing.Coroutine[
-        #     typing.Any, typing.Any, execution_lib.CallResult
-        # ],
         task: asyncio.Task[execution_lib.CallResult],
         env: typing.Optional[str],
         framework: server_lib.Framework,
@@ -92,9 +89,6 @@ class CommResponse:
             """
             Sends keepalive bytes until the response is complete.
             """
-
-            # Run the call coroutine in the background.
-            # task = asyncio.create_task(coro)
 
             # Send keepalives until task completes.
             while not task.done():

--- a/pkg/inngest/inngest/_internal/comm_lib/models.py
+++ b/pkg/inngest/inngest/_internal/comm_lib/models.py
@@ -75,9 +75,10 @@ class CommResponse:
     def create_streaming(
         cls,
         logger: types.Logger,
-        coro: typing.Coroutine[
-            typing.Any, typing.Any, execution_lib.CallResult
-        ],
+        # coro: typing.Coroutine[
+        #     typing.Any, typing.Any, execution_lib.CallResult
+        # ],
+        task: asyncio.Task[execution_lib.CallResult],
         env: typing.Optional[str],
         framework: server_lib.Framework,
         server_kind: typing.Optional[server_lib.ServerKind],
@@ -93,7 +94,7 @@ class CommResponse:
             """
 
             # Run the call coroutine in the background.
-            task = asyncio.create_task(coro)
+            # task = asyncio.create_task(coro)
 
             # Send keepalives until task completes.
             while not task.done():

--- a/pkg/inngest/pyproject.toml
+++ b/pkg/inngest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.4.23a1"
+version = "0.4.23a2"
 authors = [{ name = "Inngest Inc.", email = "hello@inngest.com" }]
 description = "Python SDK for Inngest"
 readme = "README.md"


### PR DESCRIPTION
# Description
Immediately create a task instead of calling an async function without awaiting

# Motivation
A user ran into this error:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/anyio/streams/memory.py", line 98, in receive
    return self.receive_nowait()
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/anyio/streams/memory.py", line 93, in receive_nowait
    raise WouldBlock
anyio.WouldBlock

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 78, in call_next
    message = await recv_stream.receive()
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/anyio/streams/memory.py", line 118, in receive
    raise EndOfStream
anyio.EndOfStream
```