### PR TITLE
Fix Connect hearbeater using stale connection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,6 @@
 ## Setup
 
 ```sh
-python -m venv .venv && source .venv/bin/activate
 make install
 ```
 

--- a/pkg/inngest/CLAUDE.md
+++ b/pkg/inngest/CLAUDE.md
@@ -20,7 +20,6 @@ Its purpose is to add Inngest "worker" logic into users' apps. Users can run the
 **Prerequisites:**
 
 - Python 3.10+ (minimum supported version)
-- Must activate the virtual environment in the monorepo root (`source .venv/bin/activate`) before running any commands
 - Dependencies installed from monorepo root: `make install`
 
 **Package Structure:**

--- a/pkg/inngest/pyproject.toml
+++ b/pkg/inngest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.5.0"
+version = "0.5.1a1"
 authors = [{ name = "Inngest Inc.", email = "hello@inngest.com" }]
 description = "Python SDK for Inngest"
 readme = "README.md"

--- a/pkg/inngest_encryption/CLAUDE.md
+++ b/pkg/inngest_encryption/CLAUDE.md
@@ -17,7 +17,6 @@ This package provides encryption middleware for the Inngest Python SDK. It enabl
 **Prerequisites:**
 
 - Python 3.10+ (minimum supported version)
-- Must activate the virtual environment in the monorepo root (`source .venv/bin/activate`) before running any commands
 - Dependencies installed from monorepo root: `make install`
 
 **Package Structure:**

--- a/uv.lock
+++ b/uv.lock
@@ -564,7 +564,7 @@ wheels = [
 
 [[package]]
 name = "inngest"
-version = "0.5.1a0"
+version = "0.5.0"
 source = { editable = "pkg/inngest" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Fix a bug where the Connect heartbeater would use a stale WebSocket connection object after reconnect. After reconnect, the heartbeater would constantly error with `no close frame received or sent`