### PR TITLE
Run pyright against integration tests

### DIFF
--- a/.github/workflows/inngest.yml
+++ b/.github/workflows/inngest.yml
@@ -16,6 +16,8 @@ on:
       - "**/pyproject.toml"
       - ".github/**"
       - "Makefile"
+      - "mypy.ini"
+      - "pyrightconfig.json"
       - "pytest.ini"
       - "ruff.toml"
       - "uv.lock"

--- a/.github/workflows/inngest_encryption.yml
+++ b/.github/workflows/inngest_encryption.yml
@@ -13,6 +13,8 @@ on:
       - "**/Makefile"
       - "**/pyproject.toml"
       - ".github/**"
+      - "mypy.ini"
+      - "pyrightconfig.json"
       - "pytest.ini"
       - "ruff.toml"
       - "uv.lock"

--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -11,7 +11,9 @@ on:
       - "**/*.py"
       - ".github/**"
       - "Makefile"
+      - "mypy.ini"
       - "pyproject.toml"
+      - "pyrightconfig.json"
       - "pytest.ini"
       - "ruff.toml"
       - "uv.lock"
@@ -58,3 +60,17 @@ jobs:
         run: "make install"
       - name: "Type check"
         run: "make type-check"
+
+  type-check-pyright:
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.13"]
+    steps:
+      - uses: "actions/checkout@v4"
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v4
+      - name: "Install"
+        run: "make install"
+      - name: "Type check"
+        run: "make type-check-pyright"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,7 @@
     "pkg/inngest_encryption",
     "pkg/test_core"
   ],
-  "python.analysis.typeCheckingMode": "basic",
+  "python.analysis.typeCheckingMode": "strict",
   "python.languageServer": "Pylance",
   "ruff.fixAll": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,7 @@
     "pkg/inngest_encryption",
     "pkg/test_core"
   ],
-  "python.analysis.typeCheckingMode": "strict",
+  "python.analysis.typeCheckingMode": "basic",
   "python.languageServer": "Pylance",
   "ruff.fixAll": true
 }

--- a/Makefile
+++ b/Makefile
@@ -18,13 +18,17 @@ lint:
 	@cd pkg/inngest && make lint
 	@cd pkg/inngest_encryption && make lint
 	@cd pkg/test_core && make lint
+	@cd tests && make lint
 
 type-check:
 	@cd examples && make type-check
 	@cd pkg/inngest && make type-check
 	@cd pkg/inngest_encryption && make type-check
 	@cd pkg/test_core && make type-check
-	@uv run mypy --config-file=mypy.ini tests
+	@cd tests && make type-check
+
+type-check-pyright:
+	@cd tests && make type-check-pyright
 
 utest:
 	@cd pkg/inngest && make utest

--- a/pkg/inngest/inngest/_internal/types.py
+++ b/pkg/inngest/inngest/_internal/types.py
@@ -87,3 +87,11 @@ class BaseModel(pydantic.BaseModel):
 BaseModelT = typing.TypeVar("BaseModelT", bound=BaseModel)
 
 MaybeError: typing_extensions.TypeAlias = typing.Union[T, Exception]
+
+
+def is_dict(v: object) -> typing.TypeGuard[dict[object, object]]:
+    return isinstance(v, dict)
+
+
+def is_list(v: object) -> typing.TypeGuard[list[object]]:
+    return isinstance(v, list)

--- a/pkg/inngest/inngest/_internal/types.py
+++ b/pkg/inngest/inngest/_internal/types.py
@@ -89,9 +89,31 @@ BaseModelT = typing.TypeVar("BaseModelT", bound=BaseModel)
 MaybeError: typing_extensions.TypeAlias = typing.Union[T, Exception]
 
 
-def is_dict(v: object) -> typing.TypeGuard[dict[object, object]]:
-    return isinstance(v, dict)
+def is_dict(
+    v: object,
+    key_type: type[T] = object,  # type: ignore[assignment]
+) -> typing.TypeGuard[dict[T, object]]:
+    if not isinstance(v, dict):
+        return False
+
+    if key_type is not object:
+        for k in typing.cast(dict[object, object], v).keys():
+            if not isinstance(k, key_type):
+                return False
+
+    return True
 
 
-def is_list(v: object) -> typing.TypeGuard[list[object]]:
-    return isinstance(v, list)
+def is_list(
+    v: object,
+    item_type: type[T] = object,
+) -> typing.TypeGuard[list[T]]:
+    if not isinstance(v, list):
+        return False
+
+    if item_type is not object:
+        for i in typing.cast(list[object], v):
+            if not isinstance(i, item_type):
+                return False
+
+    return True

--- a/pkg/inngest/inngest/_internal/types.py
+++ b/pkg/inngest/inngest/_internal/types.py
@@ -89,9 +89,13 @@ BaseModelT = typing.TypeVar("BaseModelT", bound=BaseModel)
 MaybeError: typing_extensions.TypeAlias = typing.Union[T, Exception]
 
 
-def is_dict(
+def is_dict(v: object) -> typing.TypeGuard[dict[object, object]]:
+    return isinstance(v, dict)
+
+
+def is_dict_keys(
     v: object,
-    key_type: type[T] = object,  # type: ignore[assignment]
+    key_type: type[T],
 ) -> typing.TypeGuard[dict[T, object]]:
     if not isinstance(v, dict):
         return False
@@ -104,9 +108,13 @@ def is_dict(
     return True
 
 
-def is_list(
+def is_list(v: object) -> typing.TypeGuard[list[object]]:
+    return isinstance(v, list)
+
+
+def is_list_items(
     v: object,
-    item_type: type[T] = object,
+    item_type: type[T],
 ) -> typing.TypeGuard[list[T]]:
     if not isinstance(v, list):
         return False

--- a/pkg/inngest/inngest/_internal/types_test.py
+++ b/pkg/inngest/inngest/_internal/types_test.py
@@ -19,12 +19,12 @@ class Test_is_dict:
 
 
 class Test_is_dict_keys:
-    def test_dict_with_key_type(self) -> None:
+    def test_key_type(self) -> None:
         v: dict[object, object] = {"a": 1}
         assert types.is_dict_keys(v, str)
         assert_type(v, dict[str, object])
 
-    def test_dict_with_key_type_invalid(self) -> None:
+    def test_key_type_invalid(self) -> None:
         v: dict[object, object] = {1: "a"}
         assert types.is_dict_keys(v, str) is False
 
@@ -45,12 +45,12 @@ class Test_is_list:
 
 
 class Test_is_list_items:
-    def test_list_with_item_type_primitive(self) -> None:
+    def test_item_type_primitive(self) -> None:
         v: list[object] = ["a"]
         assert types.is_list_items(v, str)
         assert_type(v, list[str])
 
-    def test_list_with_item_type_object(self) -> None:
+    def test_item_type_object(self) -> None:
         class Foo:
             pass
 
@@ -58,6 +58,6 @@ class Test_is_list_items:
         assert types.is_list_items(v, Foo)
         assert_type(v, list[Foo])
 
-    def test_list_with_item_type_invalid(self) -> None:
+    def test_item_type_invalid(self) -> None:
         v: list[object] = [1]
         assert types.is_list_items(v, str) is False

--- a/pkg/inngest/inngest/_internal/types_test.py
+++ b/pkg/inngest/inngest/_internal/types_test.py
@@ -9,15 +9,6 @@ class Test_is_dict:
         assert types.is_dict(v)
         assert_type(v, dict[object, object])
 
-    def test_dict_with_key_type(self) -> None:
-        v: dict[object, object] = {"a": 1}
-        assert types.is_dict(v, str)
-        assert_type(v, dict[str, object])
-
-    def test_dict_with_key_type_invalid(self) -> None:
-        v: dict[object, object] = {1: "a"}
-        assert types.is_dict(v, str) is False
-
     def test_non_dicts(self) -> None:
         assert types.is_dict([]) is False
         assert types.is_dict("string") is False
@@ -27,28 +18,22 @@ class Test_is_dict:
         assert types.is_dict(tuple[str]()) is False
 
 
+class Test_is_dict_keys:
+    def test_dict_with_key_type(self) -> None:
+        v: dict[object, object] = {"a": 1}
+        assert types.is_dict_keys(v, str)
+        assert_type(v, dict[str, object])
+
+    def test_dict_with_key_type_invalid(self) -> None:
+        v: dict[object, object] = {1: "a"}
+        assert types.is_dict_keys(v, str) is False
+
+
 class Test_is_list:
     def test_list(self) -> None:
         v: list[object] = []
         assert types.is_list(v)
         assert_type(v, list[object])
-
-    def test_list_with_item_type_primitive(self) -> None:
-        v: list[object] = ["a"]
-        assert types.is_list(v, str)
-        assert_type(v, list[str])
-
-    def test_list_with_item_type_object(self) -> None:
-        class Foo:
-            pass
-
-        v: list[Foo] = []
-        assert types.is_list(v, Foo)
-        assert_type(v, list[Foo])
-
-    def test_list_with_item_type_invalid(self) -> None:
-        v: list[object] = [1]
-        assert types.is_list(v, str) is False
 
     def test_non_lists(self) -> None:
         assert types.is_list({}) is False
@@ -57,3 +42,22 @@ class Test_is_list:
         assert types.is_list(None) is False
         assert types.is_list(set[str]()) is False
         assert types.is_list(tuple[str]()) is False
+
+
+class Test_is_list_items:
+    def test_list_with_item_type_primitive(self) -> None:
+        v: list[object] = ["a"]
+        assert types.is_list_items(v, str)
+        assert_type(v, list[str])
+
+    def test_list_with_item_type_object(self) -> None:
+        class Foo:
+            pass
+
+        v: list[Foo] = []
+        assert types.is_list_items(v, Foo)
+        assert_type(v, list[Foo])
+
+    def test_list_with_item_type_invalid(self) -> None:
+        v: list[object] = [1]
+        assert types.is_list_items(v, str) is False

--- a/pkg/inngest/inngest/_internal/types_test.py
+++ b/pkg/inngest/inngest/_internal/types_test.py
@@ -1,0 +1,59 @@
+from typing_extensions import assert_type
+
+from . import types
+
+
+class Test_is_dict:
+    def test_dict(self) -> None:
+        v: dict[object, object] = {}
+        assert types.is_dict(v)
+        assert_type(v, dict[object, object])
+
+    def test_dict_with_key_type(self) -> None:
+        v: dict[object, object] = {"a": 1}
+        assert types.is_dict(v, str)
+        assert_type(v, dict[str, object])
+
+    def test_dict_with_key_type_invalid(self) -> None:
+        v: dict[object, object] = {1: "a"}
+        assert types.is_dict(v, str) is False
+
+    def test_non_dicts(self) -> None:
+        assert types.is_dict([]) is False
+        assert types.is_dict("string") is False
+        assert types.is_dict(123) is False
+        assert types.is_dict(None) is False
+        assert types.is_dict(set[str]()) is False
+        assert types.is_dict(tuple[str]()) is False
+
+
+class Test_is_list:
+    def test_list(self) -> None:
+        v: list[object] = []
+        assert types.is_list(v)
+        assert_type(v, list[object])
+
+    def test_list_with_item_type_primitive(self) -> None:
+        v: list[object] = ["a"]
+        assert types.is_list(v, str)
+        assert_type(v, list[str])
+
+    def test_list_with_item_type_object(self) -> None:
+        class Foo:
+            pass
+
+        v: list[Foo] = []
+        assert types.is_list(v, Foo)
+        assert_type(v, list[Foo])
+
+    def test_list_with_item_type_invalid(self) -> None:
+        v: list[object] = [1]
+        assert types.is_list(v, str) is False
+
+    def test_non_lists(self) -> None:
+        assert types.is_list({}) is False
+        assert types.is_list("string") is False
+        assert types.is_list(123) is False
+        assert types.is_list(None) is False
+        assert types.is_list(set[str]()) is False
+        assert types.is_list(tuple[str]()) is False

--- a/pkg/test_core/test_core/__init__.py
+++ b/pkg/test_core/test_core/__init__.py
@@ -1,4 +1,5 @@
 from .base import BaseState, wait_for, wait_for_len, wait_for_truthy
+from .dicts import get_nested
 from .helper import RunStatus, client
 from .string import random_suffix
 
@@ -6,6 +7,7 @@ __all__ = [
     "BaseState",
     "RunStatus",
     "client",
+    "get_nested",
     "random_suffix",
     "wait_for",
     "wait_for_len",

--- a/pkg/test_core/test_core/dicts.py
+++ b/pkg/test_core/test_core/dicts.py
@@ -1,0 +1,18 @@
+from inngest._internal import types
+
+
+def get_nested(d: dict[object, object], key: str) -> object:
+    # Get a nested value using a dot-separated key
+    keys = key.split(".")
+    for i, k in enumerate(keys):
+        value = d[k]
+
+        if i == len(keys) - 1:
+            return value
+
+        if not types.is_dict(value):
+            raise TypeError(f"expected dict, got {type(value)}")
+
+        d = value
+
+    raise Exception("unreachable")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "moto[s3,server]==5.0.18",
     "mypy==1.10.0",
     "pynacl==1.5.0",
+    "pyright==1.1.402",
     "pytest==8.3.4",
     "pytest-django==4.7.0",
     "pytest-timeout==2.3.1",

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+  "typeCheckingMode": "strict",
+  "reportUnusedFunction": false
+}

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,4 +1,3 @@
 {
-  "typeCheckingMode": "strict",
-  "reportUnusedFunction": false
+  "typeCheckingMode": "strict"
 }

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,16 +1,13 @@
 export MYPYPATH=../pkg/inngest:../pkg/inngest_encryption:../pkg/test_core
 
-.PHONY: check-venv
-check-venv:
-	@if [ -z "$${CI}" ] && [ -z "$${VIRTUAL_ENV}" ]; then \
-		echo "virtual environment is not activated"; \
-		exit 1; \
-	fi
-
 .PHONY: lint
-lint: check-venv
-	@ruff check .
+lint:
+	@uv run ruff check .
 
 .PHONY: type-check
-type-check: check-venv
-	@mypy --config-file=../mypy.ini .
+type-check:
+	@uv run mypy --config-file=../mypy.ini .
+
+.PHONY: type-check-pyright
+type-check-pyright:
+	@uv run pyright --project=../pyrightconfig.json .

--- a/tests/test_inngest/test_client/test_client_middleware.py
+++ b/tests/test_inngest/test_client/test_client_middleware.py
@@ -12,8 +12,6 @@ import unittest
 import fastapi
 import fastapi.testclient
 import flask
-import flask.logging
-import flask.testing
 import inngest
 import inngest.fast_api
 import inngest.flask

--- a/tests/test_inngest/test_connect/base.py
+++ b/tests/test_inngest/test_connect/base.py
@@ -13,7 +13,7 @@ from inngest.connect import ConnectionState
 from inngest.connect._internal import connect_pb2
 from inngest.connect._internal.connection import (
     WorkerConnection,
-    _WebSocketWorkerConnection,
+    _WebSocketWorkerConnection,  # pyright: ignore[reportPrivateUsage]
 )
 from inngest.experimental.dev_server import dev_server
 
@@ -93,6 +93,6 @@ class BaseTest(unittest.IsolatedAsyncioTestCase):
 def collect_states(conn: WorkerConnection) -> list[ConnectionState]:
     states: list[ConnectionState] = []
     if isinstance(conn, _WebSocketWorkerConnection):
-        conn._state.conn_state.on_change(lambda _, state: states.append(state))
+        conn._state.conn_state.on_change(lambda _, state: states.append(state))  # pyright: ignore[reportPrivateUsage]
     states.append(conn.get_state())
     return states

--- a/tests/test_inngest/test_connect/test_init_handshake.py
+++ b/tests/test_inngest/test_connect/test_init_handshake.py
@@ -8,8 +8,6 @@ import inngest
 import pytest
 import test_core
 import test_core.http_proxy
-import test_core.net
-import test_core.ws_proxy
 from inngest.connect import connect
 
 from .base import BaseTest

--- a/tests/test_inngest/test_connect/test_signals.py
+++ b/tests/test_inngest/test_connect/test_signals.py
@@ -10,6 +10,7 @@ import httpx
 import inngest
 import pytest
 import test_core
+from inngest._internal import types
 
 from .base import BaseTest
 
@@ -206,15 +207,15 @@ async def _wait_for_app(app_id: str, should_exist: bool) -> None:
                 raise Exception(f"unexpected status code: {res.status_code}")
 
             body = res.json()
-            if not isinstance(body, dict):
+            if not types.is_dict(body):
                 raise Exception("unexpected response")
             data = body["data"]
-            if not isinstance(data, list):
+            if not types.is_list(data):
                 raise Exception("unexpected response")
 
             exists = False
             for app in data:
-                if not isinstance(app, dict):
+                if not types.is_dict(app):
                     raise Exception("unexpected response")
 
                 exists = app["instance_id"] == app_id

--- a/tests/test_inngest/test_execution/test_flask.py
+++ b/tests/test_inngest/test_execution/test_flask.py
@@ -2,7 +2,6 @@ import http
 import unittest
 
 import flask
-import flask.logging
 import flask.testing
 import inngest
 import inngest.flask

--- a/tests/test_inngest/test_experimental/test_remote_state_middleware/cases/__init__.py
+++ b/tests/test_inngest/test_experimental/test_remote_state_middleware/cases/__init__.py
@@ -23,10 +23,10 @@ def create_sync_cases(
     client: inngest.Inngest,
     framework: server_lib.Framework,
 ) -> list[base.Case]:
-    cases = []
+    cases: list[base.Case] = []
     for module in _modules:
         case = module.create(client, framework, is_sync=True)
-        if isinstance(case.fn, list) and len(case.fn) == 0:
+        if not isinstance(case.fn, inngest.Function) and len(case.fn) == 0:
             continue
         cases.append(case)
 

--- a/tests/test_inngest/test_experimental/test_remote_state_middleware/cases/step_failed.py
+++ b/tests/test_inngest/test_experimental/test_remote_state_middleware/cases/step_failed.py
@@ -6,7 +6,7 @@ import json
 
 import inngest
 import test_core.helper
-from inngest._internal import server_lib
+from inngest._internal import server_lib, types
 from inngest.experimental import remote_state_middleware
 
 from . import base
@@ -88,13 +88,13 @@ def create(
                 step_id="step_1",
             )
         )
-        assert isinstance(output, dict)
+        assert types.is_dict(output)
         assert output.get("data") is None
         error = output.get("error")
-        assert isinstance(error, dict)
+        assert types.is_dict(error)
 
         # Ensure that the error data was not remotely stored.
-        assert driver._marker not in error
+        assert driver._marker not in error  # pyright: ignore[reportPrivateUsage]
         assert error.get("message") == "oh no"
 
         assert run.output is not None

--- a/tests/test_inngest/test_experimental/test_remote_state_middleware/cases/step_output_aws.py
+++ b/tests/test_inngest/test_experimental/test_remote_state_middleware/cases/step_output_aws.py
@@ -10,7 +10,7 @@ import inngest
 import moto
 import moto.server
 import test_core.helper
-from inngest._internal import server_lib
+from inngest._internal import server_lib, types
 from inngest.experimental import remote_state_middleware
 from test_core import net
 
@@ -39,7 +39,7 @@ def create(
     aws_region = "us-east-1"
     s3_bucket = "inngest"
 
-    s3_client = boto3.client(
+    s3_client = boto3.client(  # pyright: ignore[reportUnknownMemberType]
         "s3",
         endpoint_url=aws_url,
         region_name=aws_region,
@@ -138,12 +138,12 @@ def create(
             )
         )
 
-        assert isinstance(output, dict)
+        assert types.is_dict(output)
         data = output.get("data")
-        assert isinstance(data, dict)
+        assert types.is_dict(data)
 
         # Ensure the step output is remotely stored.
-        assert driver._marker in data
+        assert driver._marker in data  # pyright: ignore[reportPrivateUsage]
 
         output = json.loads(
             await test_core.helper.client.get_step_output(
@@ -151,12 +151,12 @@ def create(
                 step_id="step_2",
             )
         )
-        assert isinstance(output, dict)
+        assert types.is_dict(output)
         data = output.get("data")
-        assert isinstance(data, dict)
+        assert types.is_dict(data)
 
         # Ensure the step output is remotely stored.
-        assert driver._marker in data
+        assert driver._marker in data  # pyright: ignore[reportPrivateUsage]
 
         assert run.output is not None
         assert json.loads(run.output) == "function output"

--- a/tests/test_inngest/test_experimental/test_remote_state_middleware/cases/step_output_in_memory.py
+++ b/tests/test_inngest/test_experimental/test_remote_state_middleware/cases/step_output_in_memory.py
@@ -7,7 +7,7 @@ import json
 
 import inngest
 import test_core.helper
-from inngest._internal import server_lib
+from inngest._internal import server_lib, types
 from inngest.experimental import remote_state_middleware
 
 from . import base
@@ -111,9 +111,9 @@ def create(
                 step_id="step_1",
             )
         )
-        assert isinstance(output, dict)
+        assert types.is_dict(output)
         data = output.get("data")
-        assert isinstance(data, dict)
+        assert types.is_dict(data)
 
         # Ensure that step_2 output is encrypted and its value is correct
         output = json.loads(
@@ -122,9 +122,9 @@ def create(
                 step_id="step_2",
             )
         )
-        assert isinstance(output, dict)
+        assert types.is_dict(output)
         data = output.get("data")
-        assert isinstance(data, dict)
+        assert types.is_dict(data)
 
         assert run.output is not None
         assert json.loads(run.output) == "function output"

--- a/tests/test_inngest/test_experimental/test_remote_state_middleware/test_fast_api.py
+++ b/tests/test_inngest/test_experimental/test_remote_state_middleware/test_fast_api.py
@@ -3,7 +3,6 @@ import typing
 import unittest
 
 import fastapi
-import fastapi.testclient
 import inngest
 import inngest.fast_api
 import uvicorn
@@ -49,7 +48,7 @@ class TestRemoteStateMiddleware(unittest.IsolatedAsyncioTestCase):
                 _client,
                 _fns,
             )
-            uvicorn.run(app, host="0.0.0.0", port=port, log_level="warning")
+            uvicorn.run(app, host="0.0.0.0", port=port, log_level="warning")  # pyright: ignore[reportUnknownMemberType]
 
         # Start FastAPI in a thread instead of using their test client, since
         # their test client doesn't seem to actually run requests in parallel

--- a/tests/test_inngest/test_experimental/test_remote_state_middleware/test_flask.py
+++ b/tests/test_inngest/test_experimental/test_remote_state_middleware/test_flask.py
@@ -2,7 +2,6 @@ import typing
 import unittest
 
 import flask
-import flask.logging
 import flask.testing
 import inngest
 import inngest.flask

--- a/tests/test_inngest/test_function/cases/__init__.py
+++ b/tests/test_inngest/test_function/cases/__init__.py
@@ -112,10 +112,10 @@ def create_sync_cases(
     client: inngest.Inngest,
     framework: server_lib.Framework,
 ) -> list[Case]:
-    cases = []
+    cases: list[Case] = []
     for module in _modules:
         case = module.create(client, framework, is_sync=True)
-        if isinstance(case.fn, list) and len(case.fn) == 0:
+        if not isinstance(case.fn, inngest.Function) and len(case.fn) == 0:
             continue
         cases.append(case)
 

--- a/tests/test_inngest/test_function/cases/batch_that_needs_api.py
+++ b/tests/test_inngest/test_function/cases/batch_that_needs_api.py
@@ -60,7 +60,7 @@ def create(
     async def run_test(self: base.TestClass) -> None:
         # Send a large (in terms of bytes, not event count) enough batch to
         # ensure that the SDK needs to fetch the batch from the API
-        events = []
+        events: list[inngest.Event] = []
         for _ in range(8):
             events.append(
                 inngest.Event(

--- a/tests/test_inngest/test_function/cases/middleware_parallel_steps.py
+++ b/tests/test_inngest/test_function/cases/middleware_parallel_steps.py
@@ -8,7 +8,6 @@ flakiness should be fixed when we finish parallelism improvements.
 import typing
 
 import inngest
-import pytest
 import test_core.helper
 from inngest._internal import middleware_lib, server_lib
 

--- a/tests/test_inngest/test_function/cases/parallel_group_of_sequential_steps.py
+++ b/tests/test_inngest/test_function/cases/parallel_group_of_sequential_steps.py
@@ -61,7 +61,7 @@ def create(
                 state.step_1b_counter += 1
                 return "1b"
 
-            out = []
+            out: list[str] = []
             out.append(ctx.step.run("1a", _step_1a))
             out.append(ctx.step.run("1b", _step_1b))
             return out
@@ -80,7 +80,7 @@ def create(
                 state.step_2c_counter += 1
                 return "2c"
 
-            out = []
+            out: list[str] = []
             out.append(ctx.step.run("2a", _step_2a))
             out.append(ctx.step.run("2b", _step_2b))
             out.append(ctx.step.run("2c", _step_2c))
@@ -132,7 +132,7 @@ def create(
                 state.step_1b_counter += 1
                 return "1b"
 
-            out = []
+            out: list[str] = []
             out.append(await ctx.step.run("1a", _step_1a))
             out.append(await ctx.step.run("1b", _step_1b))
             return out
@@ -151,7 +151,7 @@ def create(
                 state.step_2c_counter += 1
                 return "2c"
 
-            out = []
+            out: list[str] = []
             out.append(await ctx.step.run("2a", _step_2a))
             out.append(await ctx.step.run("2b", _step_2b))
             out.append(await ctx.step.run("2c", _step_2c))

--- a/tests/test_inngest/test_function/cases/pydantic_event.py
+++ b/tests/test_inngest/test_function/cases/pydantic_event.py
@@ -14,11 +14,12 @@ from typing_extensions import assert_type
 
 from . import base
 
-TEvent = typing.TypeVar("TEvent", bound="BaseEvent")
+TEvent = typing.TypeVar("TEvent", bound="BaseEvent[typing.Any]")
+TData = typing.TypeVar("TData", bound=pydantic.BaseModel)
 
 
-class BaseEvent(pydantic.BaseModel):
-    data: pydantic.BaseModel
+class BaseEvent(pydantic.BaseModel, typing.Generic[TData]):
+    data: TData
     id: str = ""
     name: typing.ClassVar[str]
     ts: int = 0
@@ -47,8 +48,7 @@ def create(
 ) -> base.Case:
     test_name = base.create_test_name(__file__)
 
-    class MyEvent(BaseEvent):
-        data: MyEventData
+    class MyEvent(BaseEvent[MyEventData]):
         name = base.create_event_name(framework, test_name)
 
     fn_id = base.create_fn_id(test_name)

--- a/tests/test_inngest/test_function/cases/singleton_cancel.py
+++ b/tests/test_inngest/test_function/cases/singleton_cancel.py
@@ -18,7 +18,7 @@ def create(
     state = base.BaseState()
 
     # Used to know how many runs started.
-    run_ids = set()
+    run_ids = set[str]()
 
     @client.create_function(
         fn_id=fn_id,

--- a/tests/test_inngest/test_function/cases/singleton_skip.py
+++ b/tests/test_inngest/test_function/cases/singleton_skip.py
@@ -18,7 +18,7 @@ def create(
     state = base.BaseState()
 
     # Used to know how many runs started.
-    run_ids = set()
+    run_ids: set[str] = set()
 
     @client.create_function(
         fn_id=fn_id,

--- a/tests/test_inngest/test_function/cases/unexpected_step_during_targeting.py
+++ b/tests/test_inngest/test_function/cases/unexpected_step_during_targeting.py
@@ -48,7 +48,7 @@ def create(
         def unexpected() -> None:
             state.step_unexpected_counter += 1
 
-        is_targeting_enabled = ctx.step._target_hashed_id is not None
+        is_targeting_enabled = ctx.step._target_hashed_id is not None  # pyright: ignore[reportPrivateUsage]
         if is_targeting_enabled:
             ctx.step.run("unexpected", unexpected)
 
@@ -77,7 +77,7 @@ def create(
         async def unexpected() -> None:
             state.step_unexpected_counter += 1
 
-        is_targeting_enabled = ctx.step._target_hashed_id is not None
+        is_targeting_enabled = ctx.step._target_hashed_id is not None  # pyright: ignore[reportPrivateUsage]
         if is_targeting_enabled:
             await ctx.step.run("unexpected", unexpected)
 

--- a/tests/test_inngest/test_function/test_digital_ocean.py
+++ b/tests/test_inngest/test_function/test_digital_ocean.py
@@ -5,7 +5,6 @@ import flask
 import flask.testing
 import inngest
 import inngest.digital_ocean
-import inngest.fast_api
 from inngest._internal import server_lib
 from inngest.experimental import dev_server, digital_ocean_simulator
 from test_core import base, http_proxy

--- a/tests/test_inngest/test_function/test_fast_api.py
+++ b/tests/test_inngest/test_function/test_fast_api.py
@@ -3,7 +3,6 @@ import typing
 import unittest
 
 import fastapi
-import fastapi.testclient
 import inngest
 import inngest.fast_api
 import uvicorn
@@ -49,7 +48,7 @@ class TestFunctions(unittest.IsolatedAsyncioTestCase):
                 _client,
                 _fns,
             )
-            uvicorn.run(app, host="0.0.0.0", port=port, log_level="warning")
+            uvicorn.run(app, host="0.0.0.0", port=port, log_level="warning")  # pyright: ignore[reportUnknownMemberType]
 
         # Start FastAPI in a thread instead of using their test client, since
         # their test client doesn't seem to actually run requests in parallel

--- a/tests/test_inngest/test_function/test_flask.py
+++ b/tests/test_inngest/test_function/test_flask.py
@@ -2,7 +2,6 @@ import typing
 import unittest
 
 import flask
-import flask.logging
 import flask.testing
 import inngest
 import inngest.flask

--- a/tests/test_inngest/test_introspection/test_digital_ocean.py
+++ b/tests/test_inngest/test_introspection/test_digital_ocean.py
@@ -4,7 +4,6 @@ import flask
 import flask.testing
 import inngest
 import inngest.digital_ocean
-import inngest.fast_api
 from inngest._internal import net, server_lib
 from inngest.experimental import digital_ocean_simulator
 from test_core import base

--- a/tests/test_inngest/test_introspection/test_flask.py
+++ b/tests/test_inngest/test_introspection/test_flask.py
@@ -2,7 +2,6 @@ import typing
 import unittest
 
 import flask
-import flask.logging
 import flask.testing
 import inngest
 import inngest.flask

--- a/tests/test_inngest/test_probes/test_flask.py
+++ b/tests/test_inngest/test_probes/test_flask.py
@@ -1,7 +1,6 @@
 import unittest
 
 import flask
-import flask.logging
 import flask.testing
 import inngest
 import inngest.flask

--- a/tests/test_inngest/test_registration/cases/cloud_branch_env.py
+++ b/tests/test_inngest/test_registration/cases/cloud_branch_env.py
@@ -1,7 +1,6 @@
 import json
 
 import inngest
-import inngest.fast_api
 from inngest._internal import const, net, server_lib
 
 from . import base

--- a/tests/test_inngest/test_registration/cases/disallow_in_band.py
+++ b/tests/test_inngest/test_registration/cases/disallow_in_band.py
@@ -4,7 +4,6 @@ import os
 import typing
 
 import inngest
-import inngest.fast_api
 from inngest._internal import const, net, server_lib
 from test_core import http_proxy
 
@@ -107,6 +106,8 @@ def create(framework: server_lib.Framework) -> base.Case:
             host = "http://testserver"
         elif framework == server_lib.Framework.FLASK:
             host = "http://localhost"
+        else:
+            raise ValueError(f"unknown framework: {framework}")
 
         assert state.body is not None
         assert json.loads(state.body.decode("utf-8")) == {

--- a/tests/test_inngest/test_registration/cases/in_band_invalid_sig.py
+++ b/tests/test_inngest/test_registration/cases/in_band_invalid_sig.py
@@ -1,7 +1,6 @@
 import json
 
 import inngest
-import inngest.fast_api
 from inngest._internal import net, server_lib
 
 from . import base

--- a/tests/test_inngest/test_registration/cases/in_band_missing_sig.py
+++ b/tests/test_inngest/test_registration/cases/in_band_missing_sig.py
@@ -1,7 +1,6 @@
 import json
 
 import inngest
-import inngest.fast_api
 from inngest._internal import server_lib
 
 from . import base

--- a/tests/test_inngest/test_registration/cases/missing_sync_kind_header.py
+++ b/tests/test_inngest/test_registration/cases/missing_sync_kind_header.py
@@ -3,7 +3,6 @@ import json
 import typing
 
 import inngest
-import inngest.fast_api
 from inngest._internal import const, server_lib
 from test_core import http_proxy
 
@@ -82,6 +81,8 @@ def create(framework: server_lib.Framework) -> base.Case:
             host = "http://testserver"
         elif framework == server_lib.Framework.FLASK:
             host = "http://localhost"
+        else:
+            raise ValueError(f"unknown framework: {framework}")
 
         assert state.body is not None
         assert json.loads(state.body.decode("utf-8")) == {

--- a/tests/test_inngest/test_registration/cases/server_kind_mismatch.py
+++ b/tests/test_inngest/test_registration/cases/server_kind_mismatch.py
@@ -1,7 +1,6 @@
 import json
 
 import inngest
-import inngest.fast_api
 from inngest._internal import server_lib
 
 from . import base

--- a/tests/test_inngest/test_registration/test_flask.py
+++ b/tests/test_inngest/test_registration/test_flask.py
@@ -2,8 +2,6 @@ import typing
 import unittest
 
 import flask
-import flask.logging
-import flask.testing
 import inngest
 import inngest.flask
 from inngest._internal import server_lib

--- a/tests/test_inngest/test_serialization/test_fast_api.py
+++ b/tests/test_inngest/test_serialization/test_fast_api.py
@@ -29,7 +29,7 @@ class _TestBase(unittest.IsolatedAsyncioTestCase):
         def start_app() -> None:
             app = fastapi.FastAPI()
             serve(app)
-            uvicorn.run(app, host="0.0.0.0", port=port, log_level="warning")
+            uvicorn.run(app, host="0.0.0.0", port=port, log_level="warning")  # pyright: ignore[reportUnknownMemberType]
 
         app_thread = threading.Thread(daemon=True, target=start_app)
         app_thread.start()

--- a/tests/test_inngest/test_serve/test_flask.py
+++ b/tests/test_inngest/test_serve/test_flask.py
@@ -1,8 +1,6 @@
 import unittest
 
 import flask
-import flask.logging
-import flask.testing
 import inngest
 import inngest.flask
 import pytest

--- a/tests/test_inngest/test_serve/test_streaming.py
+++ b/tests/test_inngest/test_serve/test_streaming.py
@@ -10,6 +10,7 @@ import inngest
 import inngest.fast_api
 import test_core
 import uvicorn
+from inngest._internal import types
 from test_core import base, http_proxy, net
 
 
@@ -86,7 +87,7 @@ class TestStreaming(unittest.IsolatedAsyncioTestCase):
                 serve_origin=proxy.origin,
                 streaming=inngest.Streaming.FORCE,
             )
-            uvicorn.run(app, host="0.0.0.0", port=sdk_port, log_level="warning")
+            uvicorn.run(app, host="0.0.0.0", port=sdk_port, log_level="warning")  # pyright: ignore[reportUnknownMemberType]
 
         app_thread = threading.Thread(daemon=True, target=start_app)
         app_thread.start()
@@ -110,7 +111,7 @@ class TestStreaming(unittest.IsolatedAsyncioTestCase):
 
         # The final chunk is the wrapped response.
         wrapped_resp = json.loads(res_chunks[len(res_chunks) - 1])
-        assert isinstance(wrapped_resp, dict)
+        assert types.is_dict(wrapped_resp)
 
         # Body we would've gotten if we weren't streaming.
         assert wrapped_resp["body"] == '"Hi"'
@@ -119,7 +120,9 @@ class TestStreaming(unittest.IsolatedAsyncioTestCase):
         assert wrapped_resp["status"] == 200
 
         # Headers we would've gotten if we weren't streaming.
-        assert wrapped_resp["headers"].get("x-inngest-sdk") is not None
+        headers = wrapped_resp["headers"]
+        assert types.is_dict(headers)
+        assert headers.get("x-inngest-sdk") is not None
 
     async def test_streaming_disabled(self) -> None:
         """
@@ -191,7 +194,7 @@ class TestStreaming(unittest.IsolatedAsyncioTestCase):
                 [fn],
                 serve_origin=proxy.origin,
             )
-            uvicorn.run(app, host="0.0.0.0", port=sdk_port, log_level="warning")
+            uvicorn.run(app, host="0.0.0.0", port=sdk_port, log_level="warning")  # pyright: ignore[reportUnknownMemberType]
 
         app_thread = threading.Thread(daemon=True, target=start_app)
         app_thread.start()

--- a/tests/test_inngest/test_types.py
+++ b/tests/test_inngest/test_types.py
@@ -12,32 +12,6 @@ from typing_extensions import assert_type
 client = inngest.Inngest(app_id="foo", is_production=False)
 
 
-# def sync_fn_with_sync_step() -> None:
-#     """
-#     Test that a sync function cannot use an async step type
-#     """
-
-#     @client.create_function(  # type: ignore[arg-type]
-#         fn_id="foo",
-#         trigger=inngest.TriggerEvent(event="foo"),
-#     )
-#     def fn(ctx: inngest.ContextSync) -> None:
-#         pass
-
-
-# def async_fn_with_sync_step() -> None:
-#     """
-#     Test that an async function cannot use a sync step type
-#     """
-
-#     @client.create_function(  # type: ignore[arg-type]
-#         fn_id="foo",
-#         trigger=inngest.TriggerEvent(event="foo"),
-#     )
-#     async def fn(ctx: inngest.ContextSync) -> None:
-#         pass
-
-
 def event_data_dict() -> None:
     """
     Test that event data can be a dict. This is exists to prevent a regression
@@ -207,7 +181,7 @@ def parallel() -> None:
         trigger=inngest.TriggerEvent(event="foo"),
     )
     async def async_fn(ctx: inngest.Context) -> None:
-        output = await ctx.group.parallel(
+        await ctx.group.parallel(
             (
                 functools.partial(ctx.step.run, "step-1", fn_1_async),
                 functools.partial(
@@ -219,16 +193,12 @@ def parallel() -> None:
             )
         )
 
-        # Type is wrong because of a mypy limitation around inferring union
-        # types from tuples
-        assert_type(output, tuple[None, ...])
-
     @client.create_function(
         fn_id="foo",
         trigger=inngest.TriggerEvent(event="foo"),
     )
     def sync_fn(ctx: inngest.ContextSync) -> None:
-        output = ctx.group.parallel(
+        ctx.group.parallel(
             (
                 functools.partial(ctx.step.run, "step-1", fn_1_sync),
                 functools.partial(
@@ -239,10 +209,6 @@ def parallel() -> None:
                 functools.partial(ctx.step.sleep, "sleep", 1),
             )
         )
-
-        # Type is wrong because of a mypy limitation around inferring union
-        # types from tuples
-        assert_type(output, tuple[None, ...])
 
 
 def parallel_iterator() -> None:
@@ -303,9 +269,6 @@ def step_return_types() -> None:
     """
     Test that a sync function cannot use an async step type
     """
-
-    class MyTypedDict(typing.TypedDict):
-        foo: str
 
     @client.create_function(
         fn_id="foo",

--- a/tests/test_inngest/test_types.py
+++ b/tests/test_inngest/test_types.py
@@ -1,3 +1,5 @@
+# pyright: reportUnusedFunction=false
+
 """
 Even though this file has test functions, they don't actually need to run. This
 file is purely for static type analysis

--- a/tests/test_inngest_encryption/cases/__init__.py
+++ b/tests/test_inngest_encryption/cases/__init__.py
@@ -42,11 +42,12 @@ def create_sync_cases(
     client: inngest.Inngest,
     framework: server_lib.Framework,
 ) -> list[base.Case]:
-    cases = []
+    cases: list[base.Case] = []
     for module in _modules:
         case = module.create(client, framework, is_sync=True)
-        if isinstance(case.fn, list) and len(case.fn) == 0:
+        if not isinstance(case.fn, inngest.Function) and len(case.fn) == 0:
             continue
+
         cases.append(case)
 
     return cases

--- a/tests/test_inngest_encryption/cases/decrypt_event.py
+++ b/tests/test_inngest_encryption/cases/decrypt_event.py
@@ -3,10 +3,8 @@ Ensure events are decrypted
 """
 
 import inngest
-import nacl.encoding
 import nacl.hash
 import nacl.secret
-import nacl.utils
 import test_core.helper
 from inngest._internal import server_lib
 from inngest_encryption import EncryptionMiddleware

--- a/tests/test_inngest_encryption/cases/decrypt_only.py
+++ b/tests/test_inngest_encryption/cases/decrypt_only.py
@@ -6,12 +6,10 @@ anything
 import json
 
 import inngest
-import nacl.encoding
 import nacl.hash
 import nacl.secret
-import nacl.utils
 import test_core.helper
-from inngest._internal import server_lib
+from inngest._internal import server_lib, types
 from inngest_encryption import EncryptionMiddleware
 
 from . import base
@@ -135,7 +133,7 @@ def create(
                 step_id="step_1",
             )
         )
-        assert isinstance(output, dict)
+        assert types.is_dict(output)
         assert output.get("data") == "test string"
 
         # Ensure that step_2 output is encrypted and its value is correct
@@ -145,7 +143,7 @@ def create(
                 step_id="step_2",
             )
         )
-        assert isinstance(output, dict)
+        assert types.is_dict(output)
         assert output.get("data") == [{"a": {"b": 1}}]
 
         assert run.output is not None

--- a/tests/test_inngest_encryption/cases/decrypt_unexpected_encryption_field.py
+++ b/tests/test_inngest_encryption/cases/decrypt_unexpected_encryption_field.py
@@ -4,10 +4,8 @@ unexpected. Event producers may specify a non-default field to encrypt
 """
 
 import inngest
-import nacl.encoding
 import nacl.hash
 import nacl.secret
-import nacl.utils
 import test_core.helper
 from inngest._internal import server_lib
 from inngest_encryption import EncryptionMiddleware

--- a/tests/test_inngest_encryption/cases/encrypt_overridden_encryption_field.py
+++ b/tests/test_inngest_encryption/cases/encrypt_overridden_encryption_field.py
@@ -4,10 +4,8 @@ field is overridden
 """
 
 import inngest
-import nacl.encoding
 import nacl.hash
 import nacl.secret
-import nacl.utils
 import test_core.helper
 from inngest._internal import server_lib
 from inngest.experimental import dev_server

--- a/tests/test_inngest_encryption/cases/fallback_decryption_key.py
+++ b/tests/test_inngest_encryption/cases/fallback_decryption_key.py
@@ -4,10 +4,8 @@ decryption key. The primary key is intentionally wrong
 """
 
 import inngest
-import nacl.encoding
 import nacl.hash
 import nacl.secret
-import nacl.utils
 import test_core.helper
 from inngest._internal import server_lib
 from inngest_encryption import EncryptionMiddleware

--- a/tests/test_inngest_encryption/cases/invoke.py
+++ b/tests/test_inngest_encryption/cases/invoke.py
@@ -6,10 +6,8 @@ decrypted data.
 import typing
 
 import inngest
-import nacl.encoding
 import nacl.hash
 import nacl.secret
-import nacl.utils
 import test_core
 from inngest._internal import server_lib
 from inngest_encryption import EncryptionMiddleware

--- a/tests/test_inngest_encryption/cases/invoke_custom_encryption_field.py
+++ b/tests/test_inngest_encryption/cases/invoke_custom_encryption_field.py
@@ -6,10 +6,8 @@ specified. The triggered function receives decrypted data.
 import typing
 
 import inngest
-import nacl.encoding
 import nacl.hash
 import nacl.secret
-import nacl.utils
 import test_core
 from inngest._internal import server_lib
 from inngest_encryption import EncryptionMiddleware

--- a/tests/test_inngest_encryption/cases/send_event.py
+++ b/tests/test_inngest_encryption/cases/send_event.py
@@ -6,10 +6,8 @@ receives decrypted data.
 import typing
 
 import inngest
-import nacl.encoding
 import nacl.hash
 import nacl.secret
-import nacl.utils
 import test_core
 from inngest._internal import server_lib
 from inngest_encryption import EncryptionMiddleware

--- a/tests/test_inngest_encryption/cases/send_event_custom_encryption_field.py
+++ b/tests/test_inngest_encryption/cases/send_event_custom_encryption_field.py
@@ -6,10 +6,8 @@ specified. The triggered function receives decrypted data.
 import typing
 
 import inngest
-import nacl.encoding
 import nacl.hash
 import nacl.secret
-import nacl.utils
 import test_core
 from inngest._internal import server_lib
 from inngest_encryption import EncryptionMiddleware

--- a/tests/test_inngest_encryption/test_fast_api.py
+++ b/tests/test_inngest_encryption/test_fast_api.py
@@ -48,7 +48,7 @@ class TestEncryptionMiddleware(unittest.IsolatedAsyncioTestCase):
                 _client,
                 _fns,
             )
-            uvicorn.run(app, host="0.0.0.0", port=port, log_level="warning")
+            uvicorn.run(app, host="0.0.0.0", port=port, log_level="warning")  # pyright: ignore[reportUnknownMemberType]
 
         # Start FastAPI in a thread instead of using their test client, since
         # their test client doesn't seem to actually run requests in parallel

--- a/tests/test_inngest_encryption/test_flask.py
+++ b/tests/test_inngest_encryption/test_flask.py
@@ -2,7 +2,6 @@ import typing
 import unittest
 
 import flask
-import flask.logging
 import flask.testing
 import inngest
 import inngest.flask

--- a/uv.lock
+++ b/uv.lock
@@ -59,14 +59,14 @@ wheels = [
 
 [[package]]
 name = "asgiref"
-version = "3.8.1"
+version = "3.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/29/38/b3395cc9ad1b56d2ddac9970bc8f4141312dbaec28bc7c218b0dfafd0f42/asgiref-3.8.1.tar.gz", hash = "sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590", size = 35186 }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/68/fb4fb78c9eac59d5e819108a57664737f855c5a8e9b76aec1738bb137f9e/asgiref-3.9.0.tar.gz", hash = "sha256:3dd2556d0f08c4fab8a010d9ab05ef8c34565f6bf32381d17505f7ca5b273767", size = 36772 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/e3/893e8757be2612e6c266d9bb58ad2e3651524b5b40cf56761e985a28b13e/asgiref-3.8.1-py3-none-any.whl", hash = "sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47", size = 23828 },
+    { url = "https://files.pythonhosted.org/packages/3d/f9/76c9f4d4985b5a642926162e2d41fe6019b1fa929cfa58abb7d2dc9041e5/asgiref-3.9.0-py3-none-any.whl", hash = "sha256:06a41250a0114d2b6f6a2cb3ab962147d355b53d1de15eebc34a9d04a7b79981", size = 23788 },
 ]
 
 [[package]]
@@ -626,6 +626,7 @@ dev = [
     { name = "moto", extra = ["s3", "server"] },
     { name = "mypy" },
     { name = "pynacl" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-django" },
     { name = "pytest-timeout" },
@@ -658,6 +659,7 @@ requires-dist = [
     { name = "moto", extras = ["s3", "server"], marker = "extra == 'dev'", specifier = "==5.0.18" },
     { name = "mypy", marker = "extra == 'dev'", specifier = "==1.10.0" },
     { name = "pynacl", marker = "extra == 'dev'", specifier = "==1.5.0" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = "==1.1.402" },
     { name = "pytest", marker = "extra == 'dev'", specifier = "==8.3.4" },
     { name = "pytest-django", marker = "extra == 'dev'", specifier = "==4.7.0" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = "==2.3.1" },
@@ -1002,6 +1004,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
 name = "openapi-schema-validator"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1251,6 +1262,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216 },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.402"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/04/ce0c132d00e20f2d2fb3b3e7c125264ca8b909e693841210534b1ea1752f/pyright-1.1.402.tar.gz", hash = "sha256:85a33c2d40cd4439c66aa946fd4ce71ab2f3f5b8c22ce36a623f59ac22937683", size = 3888207 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/37/1a1c62d955e82adae588be8e374c7f77b165b6cb4203f7d581269959abbc/pyright-1.1.402-py3-none-any.whl", hash = "sha256:2c721f11869baac1884e846232800fe021c33f1b4acb3929cff321f7ea4e2982", size = 5624004 },
 ]
 
 [[package]]


### PR DESCRIPTION
Run `pyright` against integration tests. This is valuable because many of our users use `pyright` and our integration tests resemble real world usage.

All of the changes in this PR are about fixing `pyright` errors. None of these errors are issues with our prod code. Instead, they're issues with our test logic. The logic _works_ properly, but `pyright` is stricter than `mypy`