### PR TITLE
Bump to 0.5.5

### DIFF
--- a/pkg/inngest/pyproject.toml
+++ b/pkg/inngest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.5.5rc0"
+version = "0.5.5"
 authors = [{ name = "Inngest Inc.", email = "hello@inngest.com" }]
 description = "Python SDK for Inngest"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -564,7 +564,7 @@ wheels = [
 
 [[package]]
 name = "inngest"
-version = "0.5.5rc0"
+version = "0.5.5"
 source = { editable = "pkg/inngest" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Features
- Add `parallel_mode` kwarg to `group.parallel`. Setting it to `ParallelMode.RACE` will allow sequential steps in a parallel group to execute independent of other parallel groups at the expense of more requests to your app.

# Fixes
- Fix Connect heartbeater dying on error.