### PR TITLE
Cancel and remove pending request when lease is nacked

### DIFF
--- a/pkg/inngest/inngest/connect/_internal/execution_handler.py
+++ b/pkg/inngest/inngest/connect/_internal/execution_handler.py
@@ -253,12 +253,9 @@ class _ExecutionHandler(_BaseHandler):
                 "Unable to extend lease",
                 extra={"request_id": req_data.request_id},
             )
-            pending_req = self._pending_requests.get(req_data.request_id, None)
-            if pending_req is not None:
-                _, task = pending_req
-                # Cancelling the task will also trigger the done callback to remove it from
-                # the pending requests.
-                task.cancel()
+            # Cancelling the task will trigger the done callback to remove it from
+            # the pending requests.
+            pending_req[1].cancel()
 
     def _handle_worker_reply_ack(
         self,

--- a/pkg/test_core/test_core/ws_proxy.py
+++ b/pkg/test_core/test_core/ws_proxy.py
@@ -21,6 +21,7 @@ class WebSocketProxy:
         self._server_uri = server_uri
         self._server: typing.Optional[websockets.Server] = None
         self._tasks = set[asyncio.Task[None]]()
+        self.forwarded_messages: list[bytes] = []
 
     @property
     def url(self) -> str:
@@ -96,6 +97,9 @@ class WebSocketProxy:
     ) -> None:
         async for message in source:
             try:
+                bmsg = message.encode() if isinstance(message, str) else message
+                self.forwarded_messages.append(bmsg)
+
                 await destination.send(message)
             except Exception as e:
                 print("error sending message", e)


### PR DESCRIPTION
Sometimes a worker’s event loop gets blocked long enough for it to lose the lease for a run. Another worker then acquires the lease and takes over the run, while the original worker continues processing the task, repeatedly failing to renew the lease and eventually crashing.