### PR TITLE
Use new GQL resolvers for tests

### DIFF
--- a/pkg/test_core/test_core/helper.py
+++ b/pkg/test_core/test_core/helper.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import enum
-import json
 import time
 import typing
 
 import inngest
-import pydantic
 from inngest._internal import types
 from inngest.experimental import dev_server
 


### PR DESCRIPTION
Use new GQL resolvers for tests, since that's what our dashboard uses.

We should eventually use REST, but right now its cache makes tests way slower