### PR TITLE
Add Server-Timing response header

### DIFF
--- a/pkg/inngest/inngest/_internal/client_lib/client.py
+++ b/pkg/inngest/inngest/_internal/client_lib/client.py
@@ -416,6 +416,7 @@ class Inngest:
             middleware = middleware_lib.MiddlewareManager.from_client(
                 self,
                 raw_request=None,
+                timings=None,
             )
             await middleware.before_send_events(events)
 
@@ -485,6 +486,7 @@ class Inngest:
             middleware = middleware_lib.MiddlewareManager.from_client(
                 self,
                 raw_request=None,
+                timings=None,
             )
             err = middleware.before_send_events_sync(events)
             if isinstance(err, Exception):

--- a/pkg/inngest/inngest/_internal/middleware_lib/manager.py
+++ b/pkg/inngest/inngest/_internal/middleware_lib/manager.py
@@ -7,6 +7,7 @@ from inngest._internal import (
     errors,
     execution_lib,
     function,
+    net,
     server_lib,
     step_lib,
     transforms,
@@ -37,23 +38,35 @@ class MiddlewareManager:
     def middleware(self) -> list[typing.Union[Middleware, MiddlewareSync]]:
         return [*self._middleware]
 
-    def __init__(self, client: client_lib.Inngest, raw_request: object) -> None:
+    def __init__(
+        self,
+        client: client_lib.Inngest,
+        raw_request: object,
+        timings: net.ServerTimings,
+    ) -> None:
         self.client = client
         self._disabled_hooks = set[str]()
         self._middleware = list[typing.Union[Middleware, MiddlewareSync]]()
         self._raw_request = raw_request
+        self._timings = timings
 
     @classmethod
     def from_client(
         cls,
         client: client_lib.Inngest,
         raw_request: object,
+        timings: net.ServerTimings | None,
     ) -> MiddlewareManager:
         """
         Create a new manager from an Inngest client, using the middleware on the
         client.
         """
-        mgr = cls(client, raw_request)
+
+        if timings is None:
+            # A dummy timings object to simplify logic
+            timings = net.ServerTimings()
+
+        mgr = cls(client, raw_request, timings)
 
         for m in DEFAULT_CLIENT_MIDDLEWARE:
             mgr.add(m)
@@ -69,7 +82,7 @@ class MiddlewareManager:
         Create a new manager from another manager, using the middleware on the
         passed manager. Effectively wraps a manager.
         """
-        new_mgr = cls(manager.client, manager._raw_request)
+        new_mgr = cls(manager.client, manager._raw_request, manager._timings)
         for m in manager.middleware:
             new_mgr._middleware = [*new_mgr._middleware, m]
         return new_mgr
@@ -208,15 +221,16 @@ class MiddlewareManager:
         function: function.Function[typing.Any],
         steps: step_lib.StepMemos,
     ) -> types.MaybeError[None]:
-        try:
-            for m in self._middleware:
-                await transforms.maybe_await(
-                    m.transform_input(ctx, function, steps),
-                )
-        except Exception as err:
-            return err
+        with self._timings.mw_transform_input:
+            try:
+                for m in self._middleware:
+                    await transforms.maybe_await(
+                        m.transform_input(ctx, function, steps),
+                    )
+            except Exception as err:
+                return err
 
-        return None
+            return None
 
     def transform_input_sync(
         self,
@@ -224,98 +238,101 @@ class MiddlewareManager:
         function: function.Function[typing.Any],
         steps: step_lib.StepMemos,
     ) -> types.MaybeError[None]:
-        try:
-            for m in self._middleware:
-                if inspect.iscoroutinefunction(m.transform_input):
-                    return _mismatched_sync
-                m.transform_input(ctx, function, steps)
-        except Exception as err:
-            return err
+        with self._timings.mw_transform_input:
+            try:
+                for m in self._middleware:
+                    if inspect.iscoroutinefunction(m.transform_input):
+                        return _mismatched_sync
+                    m.transform_input(ctx, function, steps)
+            except Exception as err:
+                return err
 
-        return None
+            return None
 
     async def transform_output(
         self,
         call_res: execution_lib.CallResult,
     ) -> types.MaybeError[None]:
-        # This should only happen when planning parallel steps
-        if call_res.multi is not None:
-            if len(call_res.multi) > 1:
+        with self._timings.mw_transform_output:
+            # This should only happen when planning parallel steps
+            if call_res.multi is not None:
+                if len(call_res.multi) > 1:
+                    return None
+                call_res = call_res.multi[0]
+
+            # Not sure how this can happen, but we should handle it
+            if call_res.is_empty:
                 return None
-            call_res = call_res.multi[0]
 
-        # Not sure how this can happen, but we should handle it
-        if call_res.is_empty:
-            return None
-
-        # Create a new result object to pass to the middleware. We don't want to
-        # pass the CallResult object because it exposes too many internal
-        # implementation details
-        result = TransformOutputResult(
-            error=call_res.error,
-            output=call_res.output,
-            step=None,
-        )
-        if call_res.step is not None:
-            result.step = TransformOutputStepInfo(
-                id=call_res.step.display_name,
-                op=call_res.step.op,
-                opts=call_res.step.opts,
+            # Create a new result object to pass to the middleware. We don't want to
+            # pass the CallResult object because it exposes too many internal
+            # implementation details
+            result = TransformOutputResult(
+                error=call_res.error,
+                output=call_res.output,
+                step=None,
             )
+            if call_res.step is not None:
+                result.step = TransformOutputStepInfo(
+                    id=call_res.step.display_name,
+                    op=call_res.step.op,
+                    opts=call_res.step.opts,
+                )
 
-        try:
-            # Reverse order because this is an "after" hook.
-            for m in reversed(self._middleware):
-                await transforms.maybe_await(m.transform_output(result))
+            try:
+                # Reverse order because this is an "after" hook.
+                for m in reversed(self._middleware):
+                    await transforms.maybe_await(m.transform_output(result))
 
-            # Update the original call result with the (possibly) mutated fields
-            call_res.error = result.error
-            call_res.output = result.output
+                # Update the original call result with the (possibly) mutated fields
+                call_res.error = result.error
+                call_res.output = result.output
 
-            return None
-        except Exception as err:
-            return err
+                return None
+            except Exception as err:
+                return err
 
     def transform_output_sync(
         self,
         call_res: execution_lib.CallResult,
     ) -> types.MaybeError[None]:
-        # This should only happen when planning parallel steps
-        if call_res.multi is not None:
-            if len(call_res.multi) > 1:
+        with self._timings.mw_transform_output:
+            # This should only happen when planning parallel steps
+            if call_res.multi is not None:
+                if len(call_res.multi) > 1:
+                    return None
+                call_res = call_res.multi[0]
+
+            # Not sure how this can happen, but we should handle it
+            if call_res.is_empty:
                 return None
-            call_res = call_res.multi[0]
 
-        # Not sure how this can happen, but we should handle it
-        if call_res.is_empty:
-            return None
-
-        # Create a new result object to pass to the middleware. We don't want to
-        # pass the CallResult object because it exposes too many internal
-        # implementation details
-        result = TransformOutputResult(
-            error=call_res.error,
-            output=call_res.output,
-            step=None,
-        )
-        if call_res.step is not None:
-            result.step = TransformOutputStepInfo(
-                id=call_res.step.display_name,
-                op=call_res.step.op,
-                opts=call_res.step.opts,
+            # Create a new result object to pass to the middleware. We don't want to
+            # pass the CallResult object because it exposes too many internal
+            # implementation details
+            result = TransformOutputResult(
+                error=call_res.error,
+                output=call_res.output,
+                step=None,
             )
+            if call_res.step is not None:
+                result.step = TransformOutputStepInfo(
+                    id=call_res.step.display_name,
+                    op=call_res.step.op,
+                    opts=call_res.step.opts,
+                )
 
-        try:
-            # Reverse order because this is an "after" hook.
-            for m in reversed(self._middleware):
-                if isinstance(m, Middleware):
-                    return _mismatched_sync
-                m.transform_output(result)
+            try:
+                # Reverse order because this is an "after" hook.
+                for m in reversed(self._middleware):
+                    if isinstance(m, Middleware):
+                        return _mismatched_sync
+                    m.transform_output(result)
 
-            # Update the original call result with the (possibly) mutated fields
-            call_res.error = result.error
-            call_res.output = result.output
+                # Update the original call result with the (possibly) mutated fields
+                call_res.error = result.error
+                call_res.output = result.output
 
-            return None
-        except Exception as err:
-            return err
+                return None
+            except Exception as err:
+                return err

--- a/pkg/inngest/inngest/experimental/mocked/trigger.py
+++ b/pkg/inngest/inngest/experimental/mocked/trigger.py
@@ -10,6 +10,7 @@ from inngest._internal import (
     async_lib,
     execution_lib,
     middleware_lib,
+    net,
     server_lib,
     step_lib,
 )
@@ -45,6 +46,7 @@ def trigger(
     if step_stubs is None:
         step_stubs = {}
 
+    timings = net.ServerTimings()
     stack: list[str] = []
     steps: dict[str, object] = {}
     planned = set[str]()
@@ -75,6 +77,7 @@ def trigger(
         middleware = middleware_lib.MiddlewareManager.from_client(
             client,
             {},
+            timings,
         )
 
         memos = step_lib.StepMemos.from_raw(steps)
@@ -95,6 +98,7 @@ def trigger(
                         middleware,
                         request,
                         step_id,
+                        timings,
                     ),
                     middleware,
                     step_lib.StepIDCounter(),
@@ -129,6 +133,7 @@ def trigger(
                         middleware,
                         request,
                         step_id,
+                        timings,
                     ),
                     middleware,
                     step_lib.StepIDCounter(),

--- a/tests/test_inngest/test_server_timings/test_fast_api.py
+++ b/tests/test_inngest/test_server_timings/test_fast_api.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import typing
+import unittest
+
+import fastapi
+import httpx
+import inngest
+import inngest.fast_api
+import test_core
+import uvicorn
+from inngest._internal import types
+from test_core import base, http_proxy, net
+
+
+class TestStreaming(unittest.IsolatedAsyncioTestCase):
+    def start_proxy(
+        self,
+        client: inngest.Inngest,
+        fns: list[inngest.Function[typing.Any]],
+        streaming: inngest.Streaming,
+    ) -> list[Resp]:
+        sdk_port = net.get_available_port()
+        resps: list[Resp] = []
+
+        def on_request(
+            body: typing.Optional[bytes],
+            headers: dict[str, list[str]],
+            method: str,
+            path: str,
+        ) -> http_proxy.Response:
+            resp_data = Resp()
+            with httpx.stream(
+                method=method,
+                url=f"http://0.0.0.0:{sdk_port}{path}",
+                content=body,
+                headers={k: v[0] for k, v in headers.items()},
+            ) as resp:
+                for chunk in resp.iter_bytes():
+                    resp_data.chunks.append(chunk)
+
+            resp_data.status_code = resp.status_code
+            resp_data.headers = {k: v for k, v in resp.headers.items()}
+            resps.append(resp_data)
+
+            return http_proxy.Response(
+                body=b"".join(resp_data.chunks),
+                headers=dict(resp.headers.items()),
+                status_code=resp.status_code,
+            )
+
+        proxy = http_proxy.Proxy(on_request)
+        proxy.start()
+        self.addCleanup(proxy.stop)
+
+        def start_app() -> None:
+            app = fastapi.FastAPI()
+            inngest.fast_api.serve(
+                app,
+                client,
+                fns,
+                serve_origin=proxy.origin,
+                streaming=streaming,
+            )
+            uvicorn.run(app, host="0.0.0.0", port=sdk_port, log_level="warning")
+
+        app_thread = threading.Thread(daemon=True, target=start_app)
+        app_thread.start()
+        self.addCleanup(app_thread.join, timeout=1)
+        base.register(sdk_port)
+
+        return resps
+
+    async def test_streaming_enabled(self) -> None:
+        """
+        Ensure that we get the correct response when streaming is enabled:
+        - Status code is 201.
+        - Keepalive bytes are sent.
+        - The full streamed body is effectively an HTTP response (status code,
+          headers, body).
+        """
+
+        client = inngest.Inngest(
+            app_id=test_core.random_suffix("app"),
+            is_production=False,
+            middleware=[Middleware],
+        )
+
+        state = test_core.BaseState()
+        event_name = test_core.random_suffix("event")
+
+        @client.create_function(
+            fn_id="fn",
+            trigger=inngest.TriggerEvent(event=event_name),
+        )
+        async def fn(ctx: inngest.Context) -> None:
+            state.run_id = ctx.run_id
+
+            # Sleep long enough for first keepalive byte to send.
+            await asyncio.sleep(0.4)
+
+        resps = self.start_proxy(client, [fn], inngest.Streaming.FORCE)
+
+        await client.send(inngest.Event(name=event_name))
+        await test_core.helper.client.wait_for_run_status(
+            await state.wait_for_run_id(),
+            test_core.helper.RunStatus.COMPLETED,
+        )
+
+        # The final chunk is the wrapped response.
+        wrapped_resp = json.loads(resps[0].chunks[len(resps[0].chunks) - 1])
+        assert types.is_dict(wrapped_resp)
+
+        headers = wrapped_resp["headers"]
+        assert types.is_dict(headers)
+        timings = parse_timings(headers["server-timing"])
+
+        # Really short because we immediately send the streaming response
+        assert timings["comm_handler"] < 100
+
+        assert_approx_timing(timings["function"], 400)
+        assert_approx_timing(timings["mw.transform_input"], 100)
+        assert_approx_timing(timings["mw.transform_output"], 200)
+
+    async def test_streaming_disabled(self) -> None:
+        """
+        Ensure that we get the correct response when streaming is enabled:
+        - Status code is 201.
+        - Keepalive bytes are sent.
+        - The full streamed body is effectively an HTTP response (status code,
+          headers, body).
+        """
+
+        client = inngest.Inngest(
+            app_id=test_core.random_suffix("app"),
+            is_production=False,
+            middleware=[Middleware],
+        )
+
+        state = test_core.BaseState()
+        event_name = test_core.random_suffix("event")
+
+        @client.create_function(
+            fn_id="fn",
+            trigger=inngest.TriggerEvent(event=event_name),
+        )
+        async def fn(ctx: inngest.Context) -> None:
+            state.run_id = ctx.run_id
+
+            # Sleep long enough for first keepalive byte to send.
+            await asyncio.sleep(0.4)
+
+        resps = self.start_proxy(client, [fn], inngest.Streaming.DISABLE)
+
+        await client.send(inngest.Event(name=event_name))
+        await test_core.helper.client.wait_for_run_status(
+            await state.wait_for_run_id(),
+            test_core.helper.RunStatus.COMPLETED,
+        )
+
+        timings = parse_timings(resps[0].headers["server-timing"])
+        assert_approx_timing(timings["comm_handler"], 700)
+        assert_approx_timing(timings["function"], 400)
+        assert_approx_timing(timings["mw.transform_input"], 100)
+        assert_approx_timing(timings["mw.transform_output"], 200)
+
+
+def assert_approx_timing(actual: int, approx_expected: int) -> None:
+    assert actual >= approx_expected
+
+    # Allow some arbitrary margin of error
+    assert actual < approx_expected + 100
+
+
+def parse_timings(timings_value: object) -> dict[str, int]:
+    assert isinstance(timings_value, str)
+    timings: dict[str, int] = {}
+    for timing in timings_value.split(","):
+        name, dur = timing.split(";dur=")
+        timings[name.strip()] = int(dur)
+    return timings
+
+
+class Middleware(inngest.Middleware):
+    async def transform_input(
+        self,
+        ctx: inngest.Context | inngest.ContextSync,
+        function: inngest.Function[typing.Any],
+        steps: inngest.StepMemos,
+    ) -> None:
+        await asyncio.sleep(0.1)
+
+    async def transform_output(
+        self,
+        result: inngest.TransformOutputResult,
+    ) -> None:
+        await asyncio.sleep(0.2)
+
+
+class Resp:
+    def __init__(self) -> None:
+        self.chunks = list[bytes]()
+        self.headers = dict[str, str]()
+        self.status_code = 0

--- a/tests/test_inngest/test_server_timings/test_flask.py
+++ b/tests/test_inngest/test_server_timings/test_flask.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+import typing
+import unittest
+
+import flask
+import httpx
+import inngest
+import inngest.flask
+import test_core
+from test_core import base, http_proxy, net
+
+
+class TestStreaming(unittest.IsolatedAsyncioTestCase):
+    def start_proxy(
+        self,
+        client: inngest.Inngest,
+        fns: list[inngest.Function[typing.Any]],
+    ) -> list[Resp]:
+        sdk_port = net.get_available_port()
+        resps: list[Resp] = []
+
+        def on_request(
+            body: typing.Optional[bytes],
+            headers: dict[str, list[str]],
+            method: str,
+            path: str,
+        ) -> http_proxy.Response:
+            resp_data = Resp()
+            with httpx.stream(
+                method=method,
+                url=f"http://0.0.0.0:{sdk_port}{path}",
+                content=body,
+                headers={k: v[0] for k, v in headers.items()},
+            ) as resp:
+                for chunk in resp.iter_bytes():
+                    resp_data.chunks.append(chunk)
+
+            resp_data.status_code = resp.status_code
+            resp_data.headers = {k: v for k, v in resp.headers.items()}
+            resps.append(resp_data)
+
+            return http_proxy.Response(
+                body=b"".join(resp_data.chunks),
+                headers=dict(resp.headers.items()),
+                status_code=resp.status_code,
+            )
+
+        proxy = http_proxy.Proxy(on_request)
+        proxy.start()
+        self.addCleanup(proxy.stop)
+
+        def start_app() -> None:
+            app = flask.Flask(__name__)
+            inngest.flask.serve(
+                app,
+                client,
+                fns,
+                serve_origin=proxy.origin,
+            )
+            app.run(threaded=True, port=sdk_port)
+
+        app_thread = threading.Thread(daemon=True, target=start_app)
+        app_thread.start()
+        self.addCleanup(app_thread.join, timeout=1)
+        base.register(sdk_port)
+
+        return resps
+
+    async def test_main(self) -> None:
+        client = inngest.Inngest(
+            app_id=test_core.random_suffix("app"),
+            is_production=False,
+            middleware=[Middleware],
+        )
+
+        state = test_core.BaseState()
+        event_name = test_core.random_suffix("event")
+
+        @client.create_function(
+            fn_id="fn",
+            trigger=inngest.TriggerEvent(event=event_name),
+        )
+        async def fn(ctx: inngest.Context) -> None:
+            state.run_id = ctx.run_id
+
+            # Sleep long enough for first keepalive byte to send.
+            await asyncio.sleep(0.4)
+
+        resps = self.start_proxy(client, [fn])
+
+        await client.send(inngest.Event(name=event_name))
+        await test_core.helper.client.wait_for_run_status(
+            await state.wait_for_run_id(),
+            test_core.helper.RunStatus.COMPLETED,
+        )
+
+        timings = parse_timings(resps[0].headers["server-timing"])
+        assert_approx_timing(timings["comm_handler"], 700)
+        assert_approx_timing(timings["function"], 400)
+        assert_approx_timing(timings["mw.transform_input"], 100)
+        assert_approx_timing(timings["mw.transform_output"], 200)
+
+
+def assert_approx_timing(actual: int, approx_expected: int) -> None:
+    assert actual >= approx_expected
+
+    # Allow some arbitrary margin of error
+    assert actual < approx_expected + 100
+
+
+def parse_timings(timings_value: object) -> dict[str, int]:
+    assert isinstance(timings_value, str)
+    timings: dict[str, int] = {}
+    for timing in timings_value.split(","):
+        name, dur = timing.split(";dur=")
+        timings[name.strip()] = int(dur)
+    return timings
+
+
+class Middleware(inngest.Middleware):
+    async def transform_input(
+        self,
+        ctx: inngest.Context | inngest.ContextSync,
+        function: inngest.Function[typing.Any],
+        steps: inngest.StepMemos,
+    ) -> None:
+        await asyncio.sleep(0.1)
+
+    async def transform_output(
+        self,
+        result: inngest.TransformOutputResult,
+    ) -> None:
+        await asyncio.sleep(0.2)
+
+
+class Resp:
+    def __init__(self) -> None:
+        self.chunks = list[bytes]()
+        self.headers = dict[str, str]()
+        self.status_code = 0


### PR DESCRIPTION
Add a `Server-Timing` response header. This helps us understand how long specific things take in the SDK.

An example header value:
```
comm_handler;dur=704, mw.transform_input;dur=101, function;dur=401, mw.transform_output;dur=201
```