### PR TITLE
Use pipe operator everywhere

### DIFF
--- a/pkg/inngest/inngest/_internal/async_lib.py
+++ b/pkg/inngest/inngest/_internal/async_lib.py
@@ -1,8 +1,7 @@
 import asyncio
-import typing
 
 
-def get_event_loop() -> typing.Optional[asyncio.AbstractEventLoop]:
+def get_event_loop() -> asyncio.AbstractEventLoop | None:
     try:
         loop = asyncio.get_event_loop()
     except RuntimeError:

--- a/pkg/inngest/inngest/_internal/client_lib/client.py
+++ b/pkg/inngest/inngest/_internal/client_lib/client.py
@@ -46,7 +46,7 @@ class Inngest:
         return self._api_origin
 
     @property
-    def env(self) -> typing.Optional[str]:
+    def env(self) -> str | None:
         return self._env
 
     @property
@@ -54,33 +54,31 @@ class Inngest:
         return self._event_api_origin
 
     @property
-    def event_key(self) -> typing.Optional[str]:
+    def event_key(self) -> str | None:
         return self._event_key
 
     @property
-    def signing_key(self) -> typing.Optional[str]:
+    def signing_key(self) -> str | None:
         return self._signing_key
 
     @property
-    def signing_key_fallback(self) -> typing.Optional[str]:
+    def signing_key_fallback(self) -> str | None:
         return self._signing_key_fallback
 
     def __init__(
         self,
         *,
-        api_base_url: typing.Optional[str] = None,
+        api_base_url: str | None = None,
         app_id: str,
-        env: typing.Optional[str] = None,
-        event_api_base_url: typing.Optional[str] = None,
-        event_key: typing.Optional[str] = None,
-        is_production: typing.Optional[bool] = None,
-        logger: typing.Optional[types.Logger] = None,
-        middleware: typing.Optional[
-            list[middleware_lib.UninitializedMiddleware]
-        ] = None,
+        env: str | None = None,
+        event_api_base_url: str | None = None,
+        event_key: str | None = None,
+        is_production: bool | None = None,
+        logger: types.Logger | None = None,
+        middleware: list[middleware_lib.UninitializedMiddleware] | None = None,
         request_timeout: int | datetime.timedelta | None = None,
         serializer: serializer_lib.Serializer | None = None,
-        signing_key: typing.Optional[str] = None,
+        signing_key: str | None = None,
     ) -> None:
         """
         Args:
@@ -208,39 +206,31 @@ class Inngest:
     def create_function(
         self,
         *,
-        batch_events: typing.Optional[server_lib.Batch] = None,
-        cancel: typing.Optional[list[server_lib.Cancel]] = None,
-        concurrency: typing.Optional[list[server_lib.Concurrency]] = None,
-        debounce: typing.Optional[server_lib.Debounce] = None,
+        batch_events: server_lib.Batch | None = None,
+        cancel: list[server_lib.Cancel] | None = None,
+        concurrency: list[server_lib.Concurrency] | None = None,
+        debounce: server_lib.Debounce | None = None,
         fn_id: str,
-        idempotency: typing.Optional[str] = None,
-        middleware: typing.Optional[
-            list[middleware_lib.UninitializedMiddleware]
-        ] = None,
-        name: typing.Optional[str] = None,
-        on_failure: typing.Union[
-            execution_lib.FunctionHandlerAsync[typing.Any],
-            execution_lib.FunctionHandlerSync[typing.Any],
-            None,
-        ] = None,
+        idempotency: str | None = None,
+        middleware: list[middleware_lib.UninitializedMiddleware] | None = None,
+        name: str | None = None,
+        on_failure: execution_lib.FunctionHandlerAsync[typing.Any]
+        | execution_lib.FunctionHandlerSync[typing.Any]
+        | None = None,
         output_type: object = types.EmptySentinel,
-        priority: typing.Optional[server_lib.Priority] = None,
-        rate_limit: typing.Optional[server_lib.RateLimit] = None,
-        retries: typing.Optional[int] = None,
-        throttle: typing.Optional[server_lib.Throttle] = None,
-        timeouts: typing.Optional[server_lib.Timeouts] = None,
-        singleton: typing.Optional[server_lib.Singleton] = None,
-        trigger: typing.Union[
-            server_lib.TriggerCron,
-            server_lib.TriggerEvent,
-            list[typing.Union[server_lib.TriggerCron, server_lib.TriggerEvent]],
-        ],
+        priority: server_lib.Priority | None = None,
+        rate_limit: server_lib.RateLimit | None = None,
+        retries: int | None = None,
+        throttle: server_lib.Throttle | None = None,
+        timeouts: server_lib.Timeouts | None = None,
+        singleton: server_lib.Singleton | None = None,
+        trigger: server_lib.TriggerCron
+        | server_lib.TriggerEvent
+        | list[server_lib.TriggerCron | server_lib.TriggerEvent],
     ) -> typing.Callable[
         [
-            typing.Union[
-                execution_lib.FunctionHandlerAsync[types.T],
-                execution_lib.FunctionHandlerSync[types.T],
-            ]
+            execution_lib.FunctionHandlerAsync[types.T]
+            | execution_lib.FunctionHandlerSync[types.T]
         ],
         function.Function[types.T],
     ]:
@@ -271,12 +261,11 @@ class Inngest:
         fully_qualified_fn_id = f"{self.app_id}-{fn_id}"
 
         def decorator(
-            func: typing.Union[
-                execution_lib.FunctionHandlerAsync[types.T],
-                execution_lib.FunctionHandlerSync[types.T],
-            ],
+            func: execution_lib.FunctionHandlerAsync[types.T]
+            | execution_lib.FunctionHandlerSync[types.T],
         ) -> function.Function[types.T]:
             triggers = trigger if isinstance(trigger, list) else [trigger]
+
             return function.Function(
                 function.FunctionOpts(
                     batch_events=batch_events,
@@ -395,7 +384,7 @@ class Inngest:
 
     async def send(
         self,
-        events: typing.Union[server_lib.Event, list[server_lib.Event]],
+        events: server_lib.Event | list[server_lib.Event],
         *,
         skip_middleware: bool = False,
     ) -> list[str]:
@@ -464,7 +453,7 @@ class Inngest:
 
     def send_sync(
         self,
-        events: typing.Union[server_lib.Event, list[server_lib.Event]],
+        events: server_lib.Event | list[server_lib.Event],
         *,
         skip_middleware: bool = False,
     ) -> list[str]:
@@ -562,7 +551,7 @@ class Inngest:
 
 def _get_mode(
     logger: types.Logger,
-    is_production: typing.Optional[bool],
+    is_production: bool | None,
 ) -> server_lib.ServerKind:
     if is_production is not None:
         if is_production:

--- a/pkg/inngest/inngest/_internal/client_lib/models.py
+++ b/pkg/inngest/inngest/_internal/client_lib/models.py
@@ -1,10 +1,8 @@
-import typing
-
 import pydantic
 
 from inngest._internal import types
 
 
 class SendEventsResult(types.BaseModel):
-    error: typing.Optional[str] = None
+    error: str | None = None
     ids: list[str] = pydantic.Field(default_factory=list)

--- a/pkg/inngest/inngest/_internal/client_lib/utils.py
+++ b/pkg/inngest/inngest/_internal/client_lib/utils.py
@@ -1,10 +1,8 @@
-import typing
-
 from inngest._internal import const, env_lib, net, server_lib, types
 
 
 def get_api_origin(
-    constructor_param: typing.Optional[str],
+    constructor_param: str | None,
     mode: server_lib.ServerKind,
 ) -> types.MaybeError[str]:
     """
@@ -31,7 +29,7 @@ def get_api_origin(
 
 
 def get_event_api_origin(
-    constructor_param: typing.Optional[str],
+    constructor_param: str | None,
     mode: server_lib.ServerKind,
 ) -> types.MaybeError[str]:
     """

--- a/pkg/inngest/inngest/_internal/comm_lib/models.py
+++ b/pkg/inngest/inngest/_internal/comm_lib/models.py
@@ -17,17 +17,17 @@ from inngest._internal import (
 
 class CommRequest(types.BaseModel):
     body: bytes
-    headers: typing.Union[dict[str, str], dict[str, str]]
+    headers: dict[str, str]
 
     # Is this a Connect request? (As opposed to our HTTP execution model)
     is_connect: bool = False
 
-    public_path: typing.Optional[str]
-    query_params: typing.Union[dict[str, str], dict[str, list[str]]]
+    public_path: str | None
+    query_params: dict[str, str] | dict[str, list[str]]
     raw_request: object
     request_url: str
-    serve_origin: typing.Optional[str]
-    serve_path: typing.Optional[str]
+    serve_origin: str | None
+    serve_path: str | None
 
 
 class CommResponse:
@@ -35,10 +35,9 @@ class CommResponse:
         self,
         *,
         body: object = None,
-        headers: typing.Optional[dict[str, str]] = None,
-        stream: typing.Optional[
-            typing.Callable[[], typing.AsyncGenerator[bytes, None]]
-        ] = None,
+        headers: dict[str, str] | None = None,
+        stream: typing.Callable[[], typing.AsyncGenerator[bytes, None]]
+        | None = None,
         status_code: int = http.HTTPStatus.OK.value,
     ) -> None:
         self.headers = headers or {}
@@ -54,7 +53,7 @@ class CommResponse:
         return False
 
     @property
-    def request_version(self) -> typing.Optional[int]:
+    def request_version(self) -> int | None:
         value = self.headers.get(server_lib.HeaderKey.REQUEST_VERSION.value)
         if value is None:
             return None
@@ -64,11 +63,11 @@ class CommResponse:
             return None
 
     @property
-    def retry_after(self) -> typing.Optional[str]:
+    def retry_after(self) -> str | None:
         return self.headers.get(server_lib.HeaderKey.RETRY_AFTER.value)
 
     @property
-    def sdk_version(self) -> typing.Optional[str]:
+    def sdk_version(self) -> str | None:
         return self.headers.get(server_lib.HeaderKey.SDK.value)
 
     @classmethod
@@ -76,9 +75,9 @@ class CommResponse:
         cls,
         logger: types.Logger,
         call_res_task: asyncio.Task[execution_lib.CallResult],
-        env: typing.Optional[str],
+        env: str | None,
         framework: server_lib.Framework,
-        server_kind: typing.Optional[server_lib.ServerKind],
+        server_kind: server_lib.ServerKind | None,
     ) -> CommResponse:
         """
         Create a streaming response. Sends keepalive bytes until the response is
@@ -133,9 +132,9 @@ class CommResponse:
         cls,
         logger: types.Logger,
         call_res: execution_lib.CallResult,
-        env: typing.Optional[str],
+        env: str | None,
         framework: server_lib.Framework,
-        server_kind: typing.Optional[server_lib.ServerKind],
+        server_kind: server_lib.ServerKind | None,
     ) -> CommResponse:
         headers = {
             server_lib.HeaderKey.SERVER_TIMING.value: "handler",
@@ -192,7 +191,7 @@ class CommResponse:
         err: Exception,
         status: http.HTTPStatus = http.HTTPStatus.INTERNAL_SERVER_ERROR,
     ) -> CommResponse:
-        code: typing.Optional[str] = None
+        code: str | None = None
         if isinstance(err, errors.Error):
             code = err.code.value
         else:
@@ -339,7 +338,7 @@ class ErrorData(types.BaseModel):
     code: server_lib.ErrorCode
     message: str
     name: str
-    stack: typing.Optional[str]
+    stack: str | None
 
     @classmethod
     def from_error(cls, err: Exception) -> ErrorData:

--- a/pkg/inngest/inngest/_internal/comm_lib/utils.py
+++ b/pkg/inngest/inngest/_internal/comm_lib/utils.py
@@ -12,15 +12,15 @@ if typing.TYPE_CHECKING:
 
 
 class _QueryParams(types.BaseModel):
-    fn_id: typing.Optional[str]
-    probe: typing.Optional[server_lib.Probe]
-    step_id: typing.Optional[str]
-    sync_id: typing.Optional[str]
+    fn_id: str | None
+    probe: server_lib.Probe | None
+    step_id: str | None
+    sync_id: str | None
 
 
 def parse_query_params(
-    query_params: typing.Union[dict[str, str], dict[str, list[str]]],
-) -> typing.Union[_QueryParams, Exception]:
+    query_params: dict[str, str] | dict[str, list[str]],
+) -> _QueryParams | Exception:
     normalized: dict[str, str] = {}
     for k, v in query_params.items():
         if isinstance(v, list):
@@ -28,7 +28,7 @@ def parse_query_params(
         else:
             normalized[k] = v
 
-    probe: typing.Optional[server_lib.Probe] = None
+    probe: server_lib.Probe | None = None
     probe_str = normalized.get(server_lib.QueryParamKey.PROBE.value)
     if probe_str:
         try:
@@ -49,8 +49,8 @@ def parse_query_params(
 
 
 _MethodHandler = typing.Callable[
-    [typing.Any, CommRequest, types.MaybeError[typing.Optional[str]]],
-    typing.Awaitable[typing.Union[CommResponse, Exception]],
+    [typing.Any, CommRequest, types.MaybeError[str | None]],
+    typing.Awaitable[CommResponse | Exception],
 ]
 
 
@@ -128,8 +128,8 @@ def wrap_handler(
 
 
 _MethodHandlerSync = typing.Callable[
-    [typing.Any, CommRequest, types.MaybeError[typing.Optional[str]]],
-    typing.Union[CommResponse, Exception],
+    [typing.Any, CommRequest, types.MaybeError[str | None]],
+    CommResponse | Exception,
 ]
 
 

--- a/pkg/inngest/inngest/_internal/config_lib.py
+++ b/pkg/inngest/inngest/_internal/config_lib.py
@@ -1,10 +1,9 @@
 import os
-import typing
 
 from inngest._internal import const
 
 
-def get_serve_origin(code_value: typing.Optional[str]) -> typing.Optional[str]:
+def get_serve_origin(code_value: str | None) -> str | None:
     if code_value is not None:
         return code_value
 
@@ -15,7 +14,7 @@ def get_serve_origin(code_value: typing.Optional[str]) -> typing.Optional[str]:
     return None
 
 
-def get_serve_path(code_value: typing.Optional[str]) -> typing.Optional[str]:
+def get_serve_path(code_value: str | None) -> str | None:
     if code_value is not None:
         return code_value
 

--- a/pkg/inngest/inngest/_internal/env_lib.py
+++ b/pkg/inngest/inngest/_internal/env_lib.py
@@ -1,10 +1,9 @@
 import os
-import typing
 
 from . import const, net, server_lib
 
 
-def get_environment_name() -> typing.Optional[str]:
+def get_environment_name() -> str | None:
     """
     Get the Inngest environment name from env vars. Checks our env var and cloud
     platform (e.g. Vercel) specific env vars
@@ -21,7 +20,7 @@ def get_environment_name() -> typing.Optional[str]:
 def get_url(
     env_var: const.EnvKey,
     mode: server_lib.ServerKind,
-) -> typing.Optional[str]:
+) -> str | None:
     """
     Get a URL from an env var. Returns None if the env var is not set or if its value is not a valid URL
     """
@@ -68,7 +67,7 @@ def is_truthy(env_var: const.EnvKey) -> bool:
     return True
 
 
-def get_int(env_var: const.EnvKey) -> typing.Optional[int]:
+def get_int(env_var: const.EnvKey) -> int | None:
     """
     Get an int from an env var. Returns None if the env var is not set or if its
     value is not an int.
@@ -83,7 +82,7 @@ def get_int(env_var: const.EnvKey) -> typing.Optional[int]:
         return None
 
 
-def get_streaming(env_var: const.EnvKey) -> typing.Optional[const.Streaming]:
+def get_streaming(env_var: const.EnvKey) -> const.Streaming | None:
     val = os.getenv(env_var.value)
     if val is None:
         return None

--- a/pkg/inngest/inngest/_internal/errors.py
+++ b/pkg/inngest/inngest/_internal/errors.py
@@ -35,7 +35,7 @@ class Error(Exception):
         return type(self).__name__
 
     @property
-    def stack(self) -> typing.Optional[str]:
+    def stack(self) -> str | None:
         if self.include_stack is False:
             return None
 
@@ -153,7 +153,7 @@ class NonRetriableError(Error):
 
     def __init__(
         self,
-        message: typing.Optional[str] = None,
+        message: str | None = None,
         quiet: bool = False,
     ) -> None:
         super().__init__(message)
@@ -165,8 +165,8 @@ class RetryAfterError(Error):
 
     def __init__(
         self,
-        message: typing.Optional[str],
-        retry_after: typing.Union[int, datetime.timedelta, datetime.datetime],
+        message: str | None,
+        retry_after: int | datetime.timedelta | datetime.datetime,
         quiet: bool = False,
     ) -> None:
         """
@@ -236,7 +236,7 @@ class StepError(Error):
         return self._name
 
     @property
-    def stack(self) -> typing.Optional[str]:
+    def stack(self) -> str | None:
         """
         Returns the userland error stack trace
         """
@@ -247,7 +247,7 @@ class StepError(Error):
         self,
         message: str,
         name: str,
-        stack: typing.Optional[str],
+        stack: str | None,
     ) -> None:
         """
         Args:

--- a/pkg/inngest/inngest/_internal/execution_lib/models.py
+++ b/pkg/inngest/inngest/_internal/execution_lib/models.py
@@ -10,18 +10,18 @@ from inngest._internal import errors, server_lib, step_lib, types
 
 @dataclasses.dataclass
 class CallResult:
-    error: typing.Optional[Exception] = None
+    error: Exception | None = None
 
     # Multiple results from a single call (only used for steps). This will only
     # be longer than 1 for parallel steps. Otherwise, it will be 1 long for
     # sequential steps
-    multi: typing.Optional[list[CallResult]] = None
+    multi: list[CallResult] | None = None
 
     # Need a sentinel value to differentiate between None and unset
     output: object = types.empty_sentinel
 
     # Step metadata (e.g. user-specified ID)
-    step: typing.Optional[step_lib.StepInfo] = None
+    step: step_lib.StepInfo | None = None
 
     @property
     def is_empty(self) -> bool:
@@ -91,14 +91,14 @@ _in_step = contextvars.ContextVar("in_step", default=False)
 
 
 class ReportedStep:
-    _in_step_token: typing.Optional[contextvars.Token[bool]] = None
+    _in_step_token: contextvars.Token[bool] | None = None
 
     def __init__(
         self,
         step_signal: asyncio.Future[ReportedStep],
         step_info: step_lib.StepInfo,
     ) -> None:
-        self.error: typing.Optional[errors.StepError] = None
+        self.error: errors.StepError | None = None
         self.info = step_info
         self.output: object = types.empty_sentinel
         self.skip = False
@@ -142,10 +142,10 @@ class ReportedStep:
 
 
 class ReportedStepSync:
-    _in_step_token: typing.Optional[contextvars.Token[bool]] = None
+    _in_step_token: contextvars.Token[bool] | None = None
 
     def __init__(self, step_info: step_lib.StepInfo) -> None:
-        self.error: typing.Optional[errors.StepError] = None
+        self.error: errors.StepError | None = None
         self.info = step_info
         self.output: object = types.empty_sentinel
         self.skip = False

--- a/pkg/inngest/inngest/_internal/execution_lib/utils.py
+++ b/pkg/inngest/inngest/_internal/execution_lib/utils.py
@@ -1,6 +1,5 @@
 import asyncio
 import inspect
-import typing
 
 import typing_extensions
 
@@ -8,19 +7,15 @@ from .. import execution_lib, types
 
 
 def is_function_handler_async(
-    value: typing.Union[
-        execution_lib.FunctionHandlerAsync[types.T],
-        execution_lib.FunctionHandlerSync[types.T],
-    ],
+    value: execution_lib.FunctionHandlerAsync[types.T]
+    | execution_lib.FunctionHandlerSync[types.T],
 ) -> typing_extensions.TypeGuard[execution_lib.FunctionHandlerAsync[types.T]]:
     return inspect.iscoroutinefunction(value)
 
 
 def is_function_handler_sync(
-    value: typing.Union[
-        execution_lib.FunctionHandlerAsync[types.T],
-        execution_lib.FunctionHandlerSync[types.T],
-    ],
+    value: execution_lib.FunctionHandlerAsync[types.T]
+    | execution_lib.FunctionHandlerSync[types.T],
 ) -> typing_extensions.TypeGuard[execution_lib.FunctionHandlerSync[types.T]]:
     return not inspect.iscoroutinefunction(value)
 

--- a/pkg/inngest/inngest/_internal/execution_lib/v0.py
+++ b/pkg/inngest/inngest/_internal/execution_lib/v0.py
@@ -29,7 +29,7 @@ class ExecutionV0(BaseExecution):
         memos: step_lib.StepMemos,
         middleware: middleware_lib.MiddlewareManager,
         request: server_lib.ServerRequest,
-        target_hashed_id: typing.Optional[str],
+        target_hashed_id: str | None,
     ) -> None:
         self._memos = memos
         self._middleware = middleware
@@ -176,7 +176,7 @@ class ExecutionV0Sync(BaseExecutionSync):
         memos: step_lib.StepMemos,
         middleware: middleware_lib.MiddlewareManager,
         request: server_lib.ServerRequest,
-        target_hashed_id: typing.Optional[str],
+        target_hashed_id: str | None,
     ) -> None:
         self._memos = memos
         self._middleware = middleware

--- a/pkg/inngest/inngest/_internal/function.py
+++ b/pkg/inngest/inngest/_internal/function.py
@@ -23,37 +23,37 @@ class _Config:
     main: server_lib.FunctionConfig
 
     # The internal on_failure function
-    on_failure: typing.Optional[server_lib.FunctionConfig]
+    on_failure: server_lib.FunctionConfig | None
 
 
 class FunctionOpts(types.BaseModel):
     model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
 
-    batch_events: typing.Optional[server_lib.Batch]
-    cancel: typing.Optional[list[server_lib.Cancel]]
-    concurrency: typing.Optional[list[server_lib.Concurrency]]
-    debounce: typing.Optional[server_lib.Debounce]
+    batch_events: server_lib.Batch | None
+    cancel: list[server_lib.Cancel] | None
+    concurrency: list[server_lib.Concurrency] | None
+    debounce: server_lib.Debounce | None
 
     # Unique within an environment
     fully_qualified_id: str
 
-    idempotency: typing.Optional[str]
+    idempotency: str | None
 
     # Unique within an app
     local_id: str
 
     name: str
-    on_failure: typing.Union[
-        execution_lib.FunctionHandlerAsync[typing.Any],
-        execution_lib.FunctionHandlerSync[typing.Any],
-        None,
-    ]
-    priority: typing.Optional[server_lib.Priority]
-    rate_limit: typing.Optional[server_lib.RateLimit]
-    retries: typing.Optional[int]
-    throttle: typing.Optional[server_lib.Throttle]
-    timeouts: typing.Optional[server_lib.Timeouts]
-    singleton: typing.Optional[server_lib.Singleton]
+    on_failure: (
+        execution_lib.FunctionHandlerAsync[typing.Any]
+        | execution_lib.FunctionHandlerSync[typing.Any]
+        | None
+    )
+    priority: server_lib.Priority | None
+    rate_limit: server_lib.RateLimit | None
+    retries: int | None
+    throttle: server_lib.Throttle | None
+    timeouts: server_lib.Timeouts | None
+    singleton: server_lib.Singleton | None
 
     def convert_validation_error(
         self,
@@ -63,15 +63,13 @@ class FunctionOpts(types.BaseModel):
 
 
 class Function(typing.Generic[types.T]):
-    _handler: typing.Union[
-        execution_lib.FunctionHandlerAsync[types.T],
-        execution_lib.FunctionHandlerSync[types.T],
-    ]
-    _on_failure_fn_id: typing.Optional[str] = None
+    _handler: (
+        execution_lib.FunctionHandlerAsync[types.T]
+        | execution_lib.FunctionHandlerSync[types.T]
+    )
+    _on_failure_fn_id: str | None = None
     _opts: FunctionOpts
-    _triggers: list[
-        typing.Union[server_lib.TriggerCron, server_lib.TriggerEvent]
-    ]
+    _triggers: list[server_lib.TriggerCron | server_lib.TriggerEvent]
 
     @property
     def id(self) -> str:
@@ -83,7 +81,7 @@ class Function(typing.Generic[types.T]):
         return inspect.iscoroutinefunction(self._handler)
 
     @property
-    def is_on_failure_handler_async(self) -> typing.Optional[bool]:
+    def is_on_failure_handler_async(self) -> bool | None:
         """
         Whether the on_failure handler is async. Returns None if there isn't an
         on_failure handler.
@@ -101,25 +99,19 @@ class Function(typing.Generic[types.T]):
         return self._opts.name
 
     @property
-    def on_failure_fn_id(self) -> typing.Optional[str]:
+    def on_failure_fn_id(self) -> str | None:
         return self._on_failure_fn_id
 
     def __init__(
         self,
         opts: FunctionOpts,
-        trigger: typing.Union[
-            server_lib.TriggerCron,
-            server_lib.TriggerEvent,
-            list[typing.Union[server_lib.TriggerCron, server_lib.TriggerEvent]],
-        ],
-        handler: typing.Union[
-            execution_lib.FunctionHandlerAsync[types.T],
-            execution_lib.FunctionHandlerSync[types.T],
-        ],
+        trigger: server_lib.TriggerCron
+        | server_lib.TriggerEvent
+        | list[server_lib.TriggerCron | server_lib.TriggerEvent],
+        handler: execution_lib.FunctionHandlerAsync[types.T]
+        | execution_lib.FunctionHandlerSync[types.T],
         output_type: object = types.EmptySentinel,
-        middleware: typing.Optional[
-            list[middleware_lib.UninitializedMiddleware]
-        ] = None,
+        middleware: list[middleware_lib.UninitializedMiddleware] | None = None,
     ) -> None:
         self._handler = handler
         self._middleware = middleware or []
@@ -313,8 +305,8 @@ class Function(typing.Generic[types.T]):
 
             on_failure = server_lib.FunctionConfig(
                 batch_events=None,
-                cancel=None,
-                concurrency=None,
+                cancel=[],
+                concurrency=[],
                 debounce=None,
                 id=self.on_failure_fn_id,
                 idempotency=None,

--- a/pkg/inngest/inngest/_internal/middleware_lib/middleware.py
+++ b/pkg/inngest/inngest/_internal/middleware_lib/middleware.py
@@ -67,7 +67,7 @@ class Middleware:
 
     async def transform_input(
         self,
-        ctx: typing.Union[execution_lib.Context, execution_lib.ContextSync],
+        ctx: execution_lib.Context | execution_lib.ContextSync,
         function: function.Function[typing.Any],
         steps: step_lib.StepMemos,
     ) -> None:
@@ -140,7 +140,7 @@ class MiddlewareSync:
 
     def transform_input(
         self,
-        ctx: typing.Union[execution_lib.Context, execution_lib.ContextSync],
+        ctx: execution_lib.Context | execution_lib.ContextSync,
         function: function.Function[typing.Any],
         steps: step_lib.StepMemos,
     ) -> None:
@@ -161,7 +161,7 @@ class MiddlewareSync:
 
 UninitializedMiddleware = typing.Callable[
     # Used a "client_lib.Inngest" string to avoid a circular import
-    ["client_lib.Inngest", object], typing.Union[Middleware, MiddlewareSync]
+    ["client_lib.Inngest", object], Middleware | MiddlewareSync
 ]
 
 
@@ -169,12 +169,12 @@ UninitializedMiddleware = typing.Callable[
 class TransformOutputResult:
     # Mutations to these fields within middleware will be kept after running
     # middleware
-    error: typing.Optional[Exception]
+    error: Exception | None
     output: object
 
     # Mutations to these fields within middleware will be discarded after
     # running middleware
-    step: typing.Optional[TransformOutputStepInfo]
+    step: TransformOutputStepInfo | None
 
     def has_output(self) -> bool:
         return self.output is not types.empty_sentinel
@@ -184,4 +184,4 @@ class TransformOutputResult:
 class TransformOutputStepInfo:
     id: str
     op: server_lib.Opcode
-    opts: typing.Optional[dict[str, object]]
+    opts: dict[str, object] | None

--- a/pkg/inngest/inngest/_internal/net.py
+++ b/pkg/inngest/inngest/_internal/net.py
@@ -6,7 +6,6 @@ import hmac
 import http
 import threading
 import time
-import typing
 import urllib.parse
 
 import httpx
@@ -34,10 +33,10 @@ class AuthenticatedHTTPClient:
     def __init__(
         self,
         *,
-        env: typing.Optional[str],
+        env: str | None,
         request_timeout: int | datetime.timedelta | None = None,
-        signing_key: typing.Optional[str],
-        signing_key_fallback: typing.Optional[str],
+        signing_key: str | None,
+        signing_key_fallback: str | None,
     ):
         self._http_client = ThreadAwareAsyncHTTPClient().initialize()
         self._http_client_sync = httpx.Client()
@@ -253,7 +252,7 @@ class ThreadAwareAsyncHTTPClient(httpx.AsyncClient):
     async method in a different thread will raise an exception
     """
 
-    _creation_thread_id: typing.Optional[int] = None
+    _creation_thread_id: int | None = None
 
     def is_same_thread(self) -> bool:
         if self._creation_thread_id is None:
@@ -269,9 +268,9 @@ class ThreadAwareAsyncHTTPClient(httpx.AsyncClient):
 
 def create_headers(
     *,
-    env: typing.Optional[str],
-    framework: typing.Optional[server_lib.Framework],
-    server_kind: typing.Optional[server_lib.ServerKind],
+    env: str | None,
+    framework: server_lib.Framework | None,
+    server_kind: server_lib.ServerKind | None,
 ) -> dict[str, str]:
     """
     Create standard headers that should exist on every possible outgoing
@@ -299,10 +298,10 @@ def create_headers(
 
 def create_serve_url(
     *,
-    public_path: typing.Optional[str],
+    public_path: str | None,
     request_url: str,
-    serve_origin: typing.Optional[str],
-    serve_path: typing.Optional[str],
+    serve_origin: str | None,
+    serve_path: str | None,
 ) -> str:
     """
     Create the serve URL, which is the URL that the Executor will use to reach
@@ -355,8 +354,8 @@ async def fetch_with_auth_fallback(
     client_sync: httpx.Client,
     request: httpx.Request,
     *,
-    signing_key: typing.Optional[str],
-    signing_key_fallback: typing.Optional[str],
+    signing_key: str | None,
+    signing_key_fallback: str | None,
 ) -> types.MaybeError[httpx.Response]:
     """
     Send an HTTP request with the given signing key. If the response is a 401 or
@@ -401,8 +400,8 @@ def fetch_with_auth_fallback_sync(
     client: httpx.Client,
     request: httpx.Request,
     *,
-    signing_key: typing.Optional[str],
-    signing_key_fallback: typing.Optional[str],
+    signing_key: str | None,
+    signing_key_fallback: str | None,
 ) -> types.MaybeError[httpx.Response]:
     """
     Send an HTTP request with the given signing key. If the response is a 401 or
@@ -435,7 +434,7 @@ def fetch_with_auth_fallback_sync(
 
 
 def normalize_headers(
-    headers: typing.Union[dict[str, str], dict[str, list[str]]],
+    headers: dict[str, str] | dict[str, list[str]],
 ) -> dict[str, str]:
     """
     Ensure that known headers are in the correct casing.
@@ -503,7 +502,7 @@ async def fetch_with_thready_safety(
 def sign_request(
     body: bytes,
     signing_key: str,
-    unix_ms: typing.Optional[int] = None,
+    unix_ms: int | None = None,
 ) -> types.MaybeError[str]:
     """
     Sign an HTTP request in the same way an Inngest server would. This is only
@@ -532,7 +531,7 @@ def sign_request(
 def sign_response(
     body: bytes,
     signing_key: str,
-    unix_ms: typing.Optional[int] = None,
+    unix_ms: int | None = None,
 ) -> types.MaybeError[str]:
     """
     Sign an HTTP response.
@@ -558,8 +557,8 @@ def _validate_sig(
     body: bytes,
     headers: dict[str, str],
     mode: server_lib.ServerKind,
-    signing_key: typing.Optional[str],
-) -> types.MaybeError[typing.Optional[str]]:
+    signing_key: str | None,
+) -> types.MaybeError[str | None]:
     if mode == server_lib.ServerKind.DEV_SERVER:
         return None
 
@@ -607,9 +606,9 @@ def validate_request_sig(
     body: bytes,
     headers: dict[str, str],
     mode: server_lib.ServerKind,
-    signing_key: typing.Optional[str],
-    signing_key_fallback: typing.Optional[str],
-) -> types.MaybeError[typing.Optional[str]]:
+    signing_key: str | None,
+    signing_key_fallback: str | None,
+) -> types.MaybeError[str | None]:
     """
     Validate the request signature. Falls back to the fallback signing key if
     signature validation fails with the primary signing key.
@@ -653,7 +652,7 @@ def validate_response_sig(
     headers: dict[str, str],
     mode: server_lib.ServerKind,
     signing_key: str,
-) -> types.MaybeError[typing.Optional[str]]:
+) -> types.MaybeError[str | None]:
     """
     Validate an HTTP response signature in the same way an Inngest server would.
     This is only needed for tests that mimic Inngest server behavior.

--- a/pkg/inngest/inngest/_internal/server_lib/event.py
+++ b/pkg/inngest/inngest/_internal/server_lib/event.py
@@ -17,7 +17,7 @@ class Event(types.BaseModel):
     @classmethod
     def _ensure_dict(
         cls,
-        v: typing.Optional[typing.Mapping[str, types.JSON]],
+        v: typing.Mapping[str, types.JSON] | None,
     ) -> typing.Mapping[str, types.JSON]:
         """
         Necessary because sometimes event data is sent as null, but we want

--- a/pkg/inngest/inngest/_internal/server_lib/execution_request.py
+++ b/pkg/inngest/inngest/_internal/server_lib/execution_request.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import typing
-
 from inngest._internal import types
 
 from .event import Event
@@ -10,7 +8,7 @@ from .event import Event
 class ServerRequest(types.BaseModel):
     ctx: ServerRequestCtx
     event: Event
-    events: typing.Optional[list[Event]] = None
+    events: list[Event] | None = None
     steps: dict[str, object]
     use_api: bool
 
@@ -24,4 +22,4 @@ class ServerRequestCtx(types.BaseModel):
 
 
 class ServerRequestCtxStack(types.BaseModel):
-    stack: typing.Optional[list[str]] = None
+    stack: list[str] | None = None

--- a/pkg/inngest/inngest/_internal/server_lib/inspection.py
+++ b/pkg/inngest/inngest/_internal/server_lib/inspection.py
@@ -14,7 +14,7 @@ class Capabilities(types.BaseModel):
 class UnauthenticatedInspection(types.BaseModel):
     schema_version: str = "2024-05-24"
 
-    authentication_succeeded: typing.Optional[typing.Literal[False]]
+    authentication_succeeded: typing.Literal[False] | None
     function_count: int
     has_event_key: bool
     has_signing_key: bool
@@ -29,9 +29,9 @@ class AuthenticatedInspection(types.BaseModel):
     app_id: str
     authentication_succeeded: typing.Literal[True] = True
     capabilities: Capabilities = Capabilities()
-    env: typing.Optional[str]
+    env: str | None
     event_api_origin: str
-    event_key_hash: typing.Optional[str]
+    event_key_hash: str | None
     framework: str
     function_count: int
     has_event_key: bool
@@ -40,7 +40,7 @@ class AuthenticatedInspection(types.BaseModel):
     mode: ServerKind
     sdk_language: str = const.LANGUAGE
     sdk_version: str = const.VERSION
-    serve_origin: typing.Optional[str]
-    serve_path: typing.Optional[str]
-    signing_key_fallback_hash: typing.Optional[str]
-    signing_key_hash: typing.Optional[str]
+    serve_origin: str | None
+    serve_path: str | None
+    signing_key_fallback_hash: str | None
+    signing_key_hash: str | None

--- a/pkg/inngest/inngest/_internal/server_lib/registration.py
+++ b/pkg/inngest/inngest/_internal/server_lib/registration.py
@@ -21,17 +21,15 @@ class _BaseConfig(types.BaseModel):
 
 class Batch(_BaseConfig):
     max_size: int = pydantic.Field(..., serialization_alias="maxSize")
-    timeout: typing.Union[int, datetime.timedelta, None] = None
-    key: typing.Optional[str] = None
-    if_exp: typing.Optional[str] = pydantic.Field(
-        default=None, serialization_alias="if"
-    )
+    timeout: int | datetime.timedelta | None = None
+    key: str | None = None
+    if_exp: str | None = pydantic.Field(default=None, serialization_alias="if")
 
     @pydantic.field_serializer("timeout")
     def serialize_timeout(
         self,
-        value: typing.Union[int, datetime.timedelta, None],
-    ) -> typing.Optional[str]:
+        value: int | datetime.timedelta | None,
+    ) -> str | None:
         if value is None:
             return None
         out = transforms.to_duration_str(value)
@@ -42,16 +40,14 @@ class Batch(_BaseConfig):
 
 class Cancel(_BaseConfig):
     event: str
-    if_exp: typing.Optional[str] = pydantic.Field(
-        default=None, serialization_alias="if"
-    )
-    timeout: typing.Union[int, datetime.timedelta, None] = None
+    if_exp: str | None = pydantic.Field(default=None, serialization_alias="if")
+    timeout: int | datetime.timedelta | None = None
 
     @pydantic.field_serializer("timeout")
     def serialize_timeout(
         self,
-        value: typing.Union[int, datetime.timedelta, None],
-    ) -> typing.Optional[str]:
+        value: int | datetime.timedelta | None,
+    ) -> str | None:
         if value is None:
             return None
         out = transforms.to_duration_str(value)
@@ -61,20 +57,20 @@ class Cancel(_BaseConfig):
 
 
 class Concurrency(_BaseConfig):
-    key: typing.Optional[str] = None
+    key: str | None = None
     limit: int
-    scope: typing.Optional[typing.Literal["account", "env", "fn"]] = None
+    scope: typing.Literal["account", "env", "fn"] | None = None
 
 
 class Debounce(_BaseConfig):
-    key: typing.Optional[str] = None
-    period: typing.Union[int, datetime.timedelta]
+    key: str | None = None
+    period: int | datetime.timedelta
 
     @pydantic.field_serializer("period")
     def serialize_period(
         self,
-        value: typing.Union[int, datetime.timedelta, None],
-    ) -> typing.Optional[str]:
+        value: int | datetime.timedelta | None,
+    ) -> str | None:
         if value is None:
             return None
         out = transforms.to_duration_str(value)
@@ -84,24 +80,24 @@ class Debounce(_BaseConfig):
 
 
 class FunctionConfig(_BaseConfig):
-    batch_events: typing.Optional[Batch] = pydantic.Field(
+    batch_events: Batch | None = pydantic.Field(
         ..., serialization_alias="batchEvents"
     )
-    cancel: typing.Optional[list[Cancel]]
-    concurrency: typing.Optional[list[Concurrency]]
-    debounce: typing.Optional[Debounce]
+    cancel: list[Cancel] | None
+    concurrency: list[Concurrency] | None
+    debounce: Debounce | None
     id: str
-    idempotency: typing.Optional[str]
-    name: typing.Optional[str]
-    priority: typing.Optional[Priority]
-    rate_limit: typing.Optional[RateLimit] = pydantic.Field(
+    idempotency: str | None
+    name: str | None
+    priority: Priority | None
+    rate_limit: RateLimit | None = pydantic.Field(
         ..., serialization_alias="rateLimit"
     )
     steps: dict[str, Step]
-    throttle: typing.Optional[Throttle]
-    timeouts: typing.Optional[Timeouts]
-    singleton: typing.Optional[Singleton]
-    triggers: list[typing.Union[TriggerCron, TriggerEvent]]
+    throttle: Throttle | None
+    timeouts: Timeouts | None
+    singleton: Singleton | None
+    triggers: list[TriggerCron | TriggerEvent]
 
 
 class Priority(_BaseConfig):
@@ -109,15 +105,15 @@ class Priority(_BaseConfig):
 
 
 class RateLimit(_BaseConfig):
-    key: typing.Optional[str] = None
+    key: str | None = None
     limit: int
-    period: typing.Union[int, datetime.timedelta]
+    period: int | datetime.timedelta
 
     @pydantic.field_serializer("period")
     def serialize_period(
         self,
-        value: typing.Union[int, datetime.timedelta, None],
-    ) -> typing.Optional[str]:
+        value: int | datetime.timedelta | None,
+    ) -> str | None:
         if value is None:
             return None
         out = transforms.to_duration_str(value)
@@ -138,21 +134,21 @@ class Runtime(_BaseConfig):
 class Step(_BaseConfig):
     id: str
     name: str
-    retries: typing.Optional[Retries] = None
+    retries: Retries | None = None
     runtime: Runtime
 
 
 class Throttle(_BaseConfig):
-    key: typing.Optional[str] = None
+    key: str | None = None
     limit: int
-    period: typing.Union[int, datetime.timedelta]
-    burst: typing.Optional[int] = 1
+    period: int | datetime.timedelta
+    burst: int | None = 1
 
     @pydantic.field_serializer("period")
     def serialize_period(
         self,
-        value: typing.Union[int, datetime.timedelta, None],
-    ) -> typing.Optional[str]:
+        value: int | datetime.timedelta | None,
+    ) -> str | None:
         if value is None:
             return None
         out = transforms.to_duration_str(value)
@@ -162,14 +158,14 @@ class Throttle(_BaseConfig):
 
 
 class Timeouts(_BaseConfig):
-    start: typing.Union[int, datetime.timedelta, None] = None
-    finish: typing.Union[int, datetime.timedelta, None] = None
+    start: int | datetime.timedelta | None = None
+    finish: int | datetime.timedelta | None = None
 
     @pydantic.field_serializer("start")
     def serialize_start(
         self,
-        value: typing.Union[int, datetime.timedelta, None],
-    ) -> typing.Optional[str]:
+        value: int | datetime.timedelta | None,
+    ) -> str | None:
         if value is None:
             return None
         out = transforms.to_duration_str(value)
@@ -180,8 +176,8 @@ class Timeouts(_BaseConfig):
     @pydantic.field_serializer("finish")
     def serialize_finish(
         self,
-        value: typing.Union[int, datetime.timedelta, None],
-    ) -> typing.Optional[str]:
+        value: int | datetime.timedelta | None,
+    ) -> str | None:
         if value is None:
             return None
         out = transforms.to_duration_str(value)
@@ -191,7 +187,7 @@ class Timeouts(_BaseConfig):
 
 
 class Singleton(_BaseConfig):
-    key: typing.Optional[str] = None
+    key: str | None = None
     mode: typing.Literal["skip", "cancel"]
 
 
@@ -201,7 +197,7 @@ class TriggerCron(_BaseConfig):
 
 class TriggerEvent(_BaseConfig):
     event: str
-    expression: typing.Optional[str] = None
+    expression: str | None = None
 
 
 class SynchronizeRequest(types.BaseModel):
@@ -221,11 +217,11 @@ class InBandSynchronizeRequest(types.BaseModel):
 
 class InBandSynchronizeResponse(types.BaseModel):
     app_id: str
-    env: typing.Optional[str]
+    env: str | None
     framework: Framework
     functions: list[FunctionConfig]
     inspection: AuthenticatedInspection
-    platform: typing.Optional[str]
+    platform: str | None
     sdk_author: str = const.AUTHOR
     sdk_language: str = const.LANGUAGE
     sdk_version: str = const.VERSION

--- a/pkg/inngest/inngest/_internal/step_lib/base.py
+++ b/pkg/inngest/inngest/_internal/step_lib/base.py
@@ -18,7 +18,7 @@ from inngest._internal import (
 class MemoizedError(types.BaseModel):
     message: str
     name: str
-    stack: typing.Optional[str] = None
+    stack: str | None = None
 
     @classmethod
     def from_error(cls, err: Exception) -> MemoizedError:
@@ -35,7 +35,7 @@ class Output(types.BaseModel):
     model_config = pydantic.ConfigDict(extra="forbid")
 
     data: object = None
-    error: typing.Optional[MemoizedError] = None
+    error: MemoizedError | None = None
 
 
 class StepMemos:
@@ -51,7 +51,7 @@ class StepMemos:
     def values(self) -> typing.Iterator[Output]:
         return iter(self._memos.values())
 
-    def pop(self, hashed_id: str) -> typing.Union[Output, types.EmptySentinel]:
+    def pop(self, hashed_id: str) -> Output | types.EmptySentinel:
         if hashed_id in self._memos:
             memo = self._memos[hashed_id]
 
@@ -86,7 +86,7 @@ class StepBase:
         client: client_lib.Inngest,
         middleware: middleware_lib.MiddlewareManager,
         step_id_counter: StepIDCounter,
-        target_hashed_id: typing.Optional[str],
+        target_hashed_id: str | None,
     ) -> None:
         self._client = client
         self._middleware = middleware
@@ -158,7 +158,7 @@ class ResponseInterrupt(BaseException):
 
     def __init__(
         self,
-        responses: typing.Union[StepResponse, list[StepResponse]],
+        responses: StepResponse | list[StepResponse],
     ) -> None:
         if not isinstance(responses, list):
             responses = [responses]
@@ -187,16 +187,16 @@ class NestedStepInterrupt(BaseException):
 class InvokeOpts(types.BaseModel):
     function_id: str
     payload: InvokeOptsPayload
-    timeout: typing.Optional[str]
+    timeout: str | None
 
 
 class InvokeOptsPayload(types.BaseModel):
     data: object
-    v: typing.Optional[str]
+    v: str | None
 
 
 class WaitForEventOpts(types.BaseModel):
-    if_exp: typing.Optional[str] = pydantic.Field(..., serialization_alias="if")
+    if_exp: str | None = pydantic.Field(..., serialization_alias="if")
     timeout: str
 
 
@@ -214,10 +214,10 @@ class StepInfo(types.BaseModel):
     id: str
 
     # Deprecated
-    name: typing.Optional[str] = None
+    name: str | None = None
 
     op: server_lib.Opcode
-    opts: typing.Optional[dict[str, object]] = None
+    opts: dict[str, object] | None = None
 
     def set_parallel_mode(self, parallel_mode: server_lib.ParallelMode) -> None:
         if parallel_mode != server_lib.ParallelMode.RACE:

--- a/pkg/inngest/inngest/_internal/step_lib/step_async.py
+++ b/pkg/inngest/inngest/_internal/step_lib/step_async.py
@@ -30,7 +30,7 @@ class Step(base.StepBase):
         exe: execution_lib.BaseExecution,
         middleware: middleware_lib.MiddlewareManager,
         step_id_counter: base.StepIDCounter,
-        target_hashed_id: typing.Optional[str],
+        target_hashed_id: str | None,
     ) -> None:
         super().__init__(
             client,
@@ -47,9 +47,9 @@ class Step(base.StepBase):
         step_id: str,
         *,
         function: function.Function[types.T],
-        data: typing.Optional[typing.Mapping[str, object]] = None,
-        timeout: typing.Union[int, datetime.timedelta, None] = None,
-        v: typing.Optional[str] = None,
+        data: typing.Mapping[str, object] | None = None,
+        timeout: int | datetime.timedelta | None = None,
+        v: str | None = None,
     ) -> types.T:
         """
         Invoke an Inngest function with data. Returns the result of the returned
@@ -85,11 +85,11 @@ class Step(base.StepBase):
         self,
         step_id: str,
         *,
-        app_id: typing.Optional[str] = None,
+        app_id: str | None = None,
         function_id: str,
-        data: typing.Optional[typing.Mapping[str, object]] = None,
-        timeout: typing.Union[int, datetime.timedelta, None] = None,
-        v: typing.Optional[str] = None,
+        data: typing.Mapping[str, object] | None = None,
+        timeout: int | datetime.timedelta | None = None,
+        v: str | None = None,
     ) -> object:
         """
         Invoke an Inngest function with data. Returns the result of the returned
@@ -243,7 +243,7 @@ class Step(base.StepBase):
     async def send_event(
         self,
         step_id: str,
-        events: typing.Union[server_lib.Event, list[server_lib.Event]],
+        events: server_lib.Event | list[server_lib.Event],
     ) -> list[str]:
         """
         Send an event or list of events.
@@ -265,7 +265,7 @@ class Step(base.StepBase):
                 raise middleware_err
 
             # Need to initialize `result` because of the `finally` block.
-            result: typing.Optional[client_models.SendEventsResult] = None
+            result: client_models.SendEventsResult | None = None
 
             try:
                 result = client_models.SendEventsResult(
@@ -308,7 +308,7 @@ class Step(base.StepBase):
     async def sleep(
         self,
         step_id: str,
-        duration: typing.Union[int, datetime.timedelta],
+        duration: int | datetime.timedelta,
     ) -> None:
         """
         Sleep for a duration.
@@ -365,9 +365,9 @@ class Step(base.StepBase):
         step_id: str,
         *,
         event: str,
-        if_exp: typing.Optional[str] = None,
-        timeout: typing.Union[int, datetime.timedelta],
-    ) -> typing.Optional[server_lib.Event]:
+        if_exp: str | None = None,
+        timeout: int | datetime.timedelta,
+    ) -> server_lib.Event | None:
         """
         Wait for an event to be sent.
 

--- a/pkg/inngest/inngest/_internal/step_lib/step_sync.py
+++ b/pkg/inngest/inngest/_internal/step_lib/step_sync.py
@@ -28,7 +28,7 @@ class StepSync(base.StepBase):
         exe: execution_lib.BaseExecutionSync,
         middleware: middleware_lib.MiddlewareManager,
         step_id_counter: base.StepIDCounter,
-        target_hashed_id: typing.Optional[str],
+        target_hashed_id: str | None,
     ) -> None:
         super().__init__(
             client,
@@ -45,9 +45,9 @@ class StepSync(base.StepBase):
         step_id: str,
         *,
         function: function.Function[types.T],
-        data: typing.Optional[typing.Mapping[str, object]] = None,
-        timeout: typing.Union[int, datetime.timedelta, None] = None,
-        v: typing.Optional[str] = None,
+        data: typing.Mapping[str, object] | None = None,
+        timeout: int | datetime.timedelta | None = None,
+        v: str | None = None,
     ) -> types.T:
         """
         Invoke an Inngest function with data. Returns the result of the returned
@@ -83,11 +83,11 @@ class StepSync(base.StepBase):
         self,
         step_id: str,
         *,
-        app_id: typing.Optional[str] = None,
+        app_id: str | None = None,
         function_id: str,
-        data: typing.Optional[typing.Mapping[str, object]] = None,
-        timeout: typing.Union[int, datetime.timedelta, None] = None,
-        v: typing.Optional[str] = None,
+        data: typing.Mapping[str, object] | None = None,
+        timeout: int | datetime.timedelta | None = None,
+        v: str | None = None,
     ) -> object:
         """
         Invoke an Inngest function with data. Returns the result of the returned
@@ -233,7 +233,7 @@ class StepSync(base.StepBase):
     def send_event(
         self,
         step_id: str,
-        events: typing.Union[server_lib.Event, list[server_lib.Event]],
+        events: server_lib.Event | list[server_lib.Event],
     ) -> list[str]:
         """
         Send an event or list of events.
@@ -255,7 +255,7 @@ class StepSync(base.StepBase):
                 raise middleware_err
 
             # Need to initialize `result` because of the `finally` block.
-            result: typing.Optional[client_models.SendEventsResult] = None
+            result: client_models.SendEventsResult | None = None
 
             try:
                 result = client_models.SendEventsResult(
@@ -296,7 +296,7 @@ class StepSync(base.StepBase):
     def sleep(
         self,
         step_id: str,
-        duration: typing.Union[int, datetime.timedelta],
+        duration: int | datetime.timedelta,
     ) -> None:
         """
         Sleep for a duration.
@@ -353,9 +353,9 @@ class StepSync(base.StepBase):
         step_id: str,
         *,
         event: str,
-        if_exp: typing.Optional[str] = None,
-        timeout: typing.Union[int, datetime.timedelta],
-    ) -> typing.Optional[server_lib.Event]:
+        if_exp: str | None = None,
+        timeout: int | datetime.timedelta,
+    ) -> server_lib.Event | None:
         """
         Wait for an event to be sent.
 

--- a/pkg/inngest/inngest/_internal/transforms.py
+++ b/pkg/inngest/inngest/_internal/transforms.py
@@ -96,7 +96,7 @@ class _Duration:
 
 
 def to_duration_str(
-    ms: typing.Union[int, datetime.timedelta],
+    ms: int | datetime.timedelta,
 ) -> types.MaybeError[str]:
     if isinstance(ms, datetime.timedelta):
         ms = int(ms.total_seconds() * 1000)
@@ -119,8 +119,8 @@ def to_duration_str(
 
 
 def to_maybe_duration_str(
-    ms: typing.Union[int, datetime.timedelta, None],
-) -> typing.Union[types.MaybeError[str], None]:
+    ms: int | datetime.timedelta | None,
+) -> types.MaybeError[str | None]:
     if ms is None:
         return None
     return to_duration_str(ms)
@@ -148,7 +148,7 @@ def get_major_version(version: str) -> types.MaybeError[int]:
 
 def get_server_kind(
     headers: dict[str, str],
-) -> typing.Union[server_lib.ServerKind, None, Exception]:
+) -> server_lib.ServerKind | None | Exception:
     value = headers.get(server_lib.HeaderKey.SERVER_KIND.value, None)
     if value is None:
         return None
@@ -160,7 +160,7 @@ def get_server_kind(
 
 
 async def maybe_await(
-    value: typing.Union[types.T, typing.Awaitable[types.T]],
+    value: types.T | typing.Awaitable[types.T],
 ) -> types.T:
     if inspect.isawaitable(value):
         return await value  # type: ignore

--- a/pkg/inngest/inngest/_internal/types.py
+++ b/pkg/inngest/inngest/_internal/types.py
@@ -8,7 +8,7 @@ import typing_extensions
 
 if typing.TYPE_CHECKING:
     # https://github.com/python/typeshed/issues/7855
-    Logger = typing.Union[logging.Logger, logging.LoggerAdapter[logging.Logger]]
+    Logger = logging.Logger | logging.LoggerAdapter[logging.Logger]
 else:
     Logger = object
 
@@ -29,15 +29,13 @@ empty_sentinel = EmptySentinel()
 # 2. Mypy errors with "possible cyclic definition"
 JSON = typing_extensions.TypeAliasType(
     "JSON",
-    typing.Union[
-        bool,
-        int,
-        float,
-        str,
-        typing.Mapping[str, object],
-        typing.Sequence[object],
-        None,
-    ],
+    bool
+    | int
+    | float
+    | str
+    | typing.Mapping[str, object]
+    | typing.Sequence[object]
+    | None,
 )
 
 
@@ -68,7 +66,7 @@ class BaseModel(pydantic.BaseModel):
     def from_raw(
         cls: type[BaseModelT],
         raw: object,
-    ) -> typing.Union[BaseModelT, Exception]:
+    ) -> BaseModelT | Exception:
         try:
             if isinstance(raw, (str, bytes)):
                 raw = cls.model_validate_json(raw)
@@ -86,7 +84,7 @@ class BaseModel(pydantic.BaseModel):
 
 BaseModelT = typing.TypeVar("BaseModelT", bound=BaseModel)
 
-MaybeError: typing_extensions.TypeAlias = typing.Union[T, Exception]
+MaybeError: typing_extensions.TypeAlias = T | Exception
 
 
 def is_dict(v: object) -> typing.TypeGuard[dict[object, object]]:

--- a/pkg/inngest/inngest/connect/_internal/base_handler.py
+++ b/pkg/inngest/inngest/connect/_internal/base_handler.py
@@ -1,5 +1,4 @@
 import asyncio
-import typing
 
 from inngest._internal import types
 
@@ -7,7 +6,7 @@ from . import connect_pb2
 
 
 class _BaseHandler:
-    _closed_event: typing.Optional[asyncio.Event] = None
+    _closed_event: asyncio.Event | None = None
 
     @property
     def closed_event(self) -> asyncio.Event:

--- a/pkg/inngest/inngest/connect/_internal/conn_init_starter.py
+++ b/pkg/inngest/inngest/connect/_internal/conn_init_starter.py
@@ -21,9 +21,9 @@ class _ConnInitHandler(_BaseHandler):
     Starts the connection by sending the "start request" to the REST API.
     """
 
-    _closed_event: typing.Optional[asyncio.Event] = None
-    _initial_request_task: typing.Optional[asyncio.Task[None]] = None
-    _reconnect_watcher_task: typing.Optional[asyncio.Task[None]] = None
+    _closed_event: asyncio.Event | None = None
+    _initial_request_task: asyncio.Task[None] | None = None
+    _reconnect_watcher_task: asyncio.Task[None] | None = None
 
     @property
     def closed_event(self) -> asyncio.Event:
@@ -35,13 +35,13 @@ class _ConnInitHandler(_BaseHandler):
         self,
         *,
         api_origin: str,
-        env: typing.Optional[str],
+        env: str | None,
         http_client: net.ThreadAwareAsyncHTTPClient,
         http_client_sync: httpx.Client,
         logger: types.Logger,
-        rewrite_gateway_endpoint: typing.Optional[typing.Callable[[str], str]],
-        signing_key: typing.Optional[str],
-        signing_key_fallback: typing.Optional[str],
+        rewrite_gateway_endpoint: typing.Callable[[str], str] | None,
+        signing_key: str | None,
+        signing_key_fallback: str | None,
         state: _State,
     ):
         self._api_origin = api_origin
@@ -87,7 +87,7 @@ class _ConnInitHandler(_BaseHandler):
                 pass
 
     async def _send_start_request(self) -> None:
-        err: typing.Optional[Exception] = None
+        err: Exception | None = None
 
         while self.closed_event.is_set() is False:
             if err is not None:

--- a/pkg/inngest/inngest/connect/_internal/connect.py
+++ b/pkg/inngest/inngest/connect/_internal/connect.py
@@ -11,11 +11,9 @@ from .connection import WorkerConnection, _WebSocketWorkerConnection
 def connect(
     apps: list[tuple[inngest.Inngest, list[inngest.Function[typing.Any]]]],
     *,
-    instance_id: typing.Optional[str] = None,
-    rewrite_gateway_endpoint: typing.Optional[
-        typing.Callable[[str], str]
-    ] = None,
-    shutdown_signals: typing.Optional[list[signal.Signals]] = None,
+    instance_id: str | None = None,
+    rewrite_gateway_endpoint: typing.Callable[[str], str] | None = None,
+    shutdown_signals: list[signal.Signals] | None = None,
 ) -> WorkerConnection:
     """
     Create a persistent connection to an Inngest server.

--- a/pkg/inngest/inngest/connect/_internal/connection.py
+++ b/pkg/inngest/inngest/connect/_internal/connection.py
@@ -76,22 +76,18 @@ class WorkerConnection(typing.Protocol):
 
 
 class _WebSocketWorkerConnection(WorkerConnection):
-    _consumers_closed_task: typing.Optional[asyncio.Task[None]] = None
-    _event_loop_keep_alive_task: typing.Optional[asyncio.Task[None]] = None
+    _consumers_closed_task: asyncio.Task[None] | None = None
+    _event_loop_keep_alive_task: asyncio.Task[None] | None = None
 
-    _message_handler_task: typing.Optional[
-        asyncio.Task[types.MaybeError[None]]
-    ] = None
+    _message_handler_task: asyncio.Task[types.MaybeError[None]] | None = None
 
     def __init__(
         self,
         apps: list[tuple[inngest.Inngest, list[inngest.Function[typing.Any]]]],
         *,
-        instance_id: typing.Optional[str] = None,
-        rewrite_gateway_endpoint: typing.Optional[
-            typing.Callable[[str], str]
-        ] = None,
-        shutdown_signals: typing.Optional[list[signal.Signals]] = None,
+        instance_id: str | None = None,
+        rewrite_gateway_endpoint: typing.Callable[[str], str] | None = None,
+        shutdown_signals: list[signal.Signals] | None = None,
     ) -> None:
         # Used to ensure that no messages are being handled when we fully close.
         self._handling_message_count = _ValueWatcher(0)
@@ -429,11 +425,7 @@ async def _wait_for_gateway_endpoint(
         # Need to cast because Mypy doesn't understand the type (it thinks it's
         # `object`).
         r = typing.cast(
-            typing.Union[
-                ConnectionState,
-                tuple[connect_pb2.AuthData, str],
-                Exception,
-            ],
+            ConnectionState | tuple[connect_pb2.AuthData, str] | Exception,
             t.result(),
         )
 

--- a/pkg/inngest/inngest/connect/_internal/drain_handler.py
+++ b/pkg/inngest/inngest/connect/_internal/drain_handler.py
@@ -1,5 +1,4 @@
 import asyncio
-import typing
 
 from inngest._internal import types
 
@@ -9,7 +8,7 @@ from .models import _State
 
 
 class _DrainHandler(_BaseHandler):
-    _closed_event: typing.Optional[asyncio.Event] = None
+    _closed_event: asyncio.Event | None = None
 
     def __init__(
         self,

--- a/pkg/inngest/inngest/connect/_internal/execution_handler.py
+++ b/pkg/inngest/inngest/connect/_internal/execution_handler.py
@@ -1,5 +1,4 @@
 import asyncio
-import typing
 import urllib.parse
 
 import httpx
@@ -20,8 +19,8 @@ class _ExecutionHandler(_BaseHandler):
     Handles incoming execution requests from the Gateway.
     """
 
-    _leaser_extender_task: typing.Optional[asyncio.Task[None]] = None
-    _unacked_msg_flush_poller_task: typing.Optional[asyncio.Task[None]] = None
+    _leaser_extender_task: asyncio.Task[None] | None = None
+    _unacked_msg_flush_poller_task: asyncio.Task[None] | None = None
 
     def __init__(
         self,
@@ -30,8 +29,8 @@ class _ExecutionHandler(_BaseHandler):
         http_client: net.ThreadAwareAsyncHTTPClient,
         http_client_sync: httpx.Client,
         logger: types.Logger,
-        signing_key: typing.Optional[str],
-        signing_key_fallback: typing.Optional[str],
+        signing_key: str | None,
+        signing_key_fallback: str | None,
         state: _State,
     ) -> None:
         self._api_origin = api_origin

--- a/pkg/inngest/inngest/connect/_internal/heartbeat_handler.py
+++ b/pkg/inngest/inngest/connect/_internal/heartbeat_handler.py
@@ -1,5 +1,4 @@
 import asyncio
-import typing
 
 from inngest._internal import types
 
@@ -15,7 +14,7 @@ class _HeartbeatHandler(_BaseHandler):
     messages.
     """
 
-    _heartbeat_sender_task: typing.Optional[asyncio.Task[None]] = None
+    _heartbeat_sender_task: asyncio.Task[None] | None = None
 
     def __init__(
         self,

--- a/pkg/inngest/inngest/connect/_internal/init_handshake_handler.py
+++ b/pkg/inngest/inngest/connect/_internal/init_handshake_handler.py
@@ -2,7 +2,6 @@ import asyncio
 import dataclasses
 import platform
 import re
-import typing
 
 import psutil
 import pydantic_core
@@ -15,16 +14,16 @@ from .models import ConnectionState, _State
 
 
 class _InitHandshakeHandler(_BaseHandler):
-    _closed_event: typing.Optional[asyncio.Event] = None
-    _send_data_task: typing.Optional[asyncio.Task[None]] = None
-    _reconnect_task: typing.Optional[asyncio.Task[None]] = None
+    _closed_event: asyncio.Event | None = None
+    _send_data_task: asyncio.Task[None] | None = None
+    _reconnect_task: asyncio.Task[None] | None = None
 
     def __init__(
         self,
         logger: types.Logger,
         state: _State,
         app_configs: dict[str, list[server_lib.FunctionConfig]],
-        env: typing.Optional[str],
+        env: str | None,
         instance_id: str,
     ) -> None:
         self._app_configs = app_configs
@@ -166,7 +165,7 @@ def _create_sync_message(
     apps_configs: dict[str, list[server_lib.FunctionConfig]],
     auth_data: connect_pb2.AuthData,
     connection_id: str,
-    env: typing.Optional[str],
+    env: str | None,
     instance_id: str,
 ) -> types.MaybeError[connect_pb2.ConnectMessage]:
     apps: list[connect_pb2.AppConfiguration] = []

--- a/pkg/inngest/inngest/connect/_internal/models.py
+++ b/pkg/inngest/inngest/connect/_internal/models.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import dataclasses
 import enum
-import typing
 
 import websockets
 
@@ -12,16 +11,16 @@ from .value_watcher import _ValueWatcher
 
 @dataclasses.dataclass
 class _State:
-    conn_id: typing.Optional[str]
-    conn_init: _ValueWatcher[typing.Optional[tuple[connect_pb2.AuthData, str]]]
+    conn_id: str | None
+    conn_init: _ValueWatcher[tuple[connect_pb2.AuthData, str] | None]
     conn_state: _ValueWatcher[ConnectionState]
     exclude_gateways: list[str]
-    extend_lease_interval: _ValueWatcher[typing.Optional[int]]
+    extend_lease_interval: _ValueWatcher[int | None]
 
     # Error that should make Connect close and raise an exception.
-    fatal_error: _ValueWatcher[typing.Optional[Exception]]
+    fatal_error: _ValueWatcher[Exception | None]
 
-    ws: _ValueWatcher[typing.Optional[websockets.ClientConnection]]
+    ws: _ValueWatcher[websockets.ClientConnection | None]
 
 
 class ConnectionState(enum.Enum):

--- a/pkg/inngest/inngest/connect/_internal/value_watcher.py
+++ b/pkg/inngest/inngest/connect/_internal/value_watcher.py
@@ -18,7 +18,7 @@ class _ValueWatcher(typing.Generic[T]):
         self,
         initial_value: T,
         *,
-        on_change: typing.Optional[typing.Callable[[T, T], None]] = None,
+        on_change: typing.Callable[[T, T], None] | None = None,
     ) -> None:
         """
         Args:
@@ -106,7 +106,7 @@ class _ValueWatcher(typing.Generic[T]):
         raise Exception("unreachable")
 
     async def wait_for_not_none(
-        self: _ValueWatcher[typing.Optional[S]],
+        self: _ValueWatcher[S | None],
         *,
         immediate: bool = True,
     ) -> S:
@@ -180,8 +180,8 @@ class _WatchContextManager(typing.Generic[T]):
 
     def __exit__(
         self,
-        exc_type: typing.Optional[type[BaseException]],
-        exc_value: typing.Optional[BaseException],
+        exc_type: type[BaseException | None],
+        exc_value: BaseException | None,
         traceback: object,
     ) -> None:
         self._on_exit()

--- a/pkg/inngest/inngest/digital_ocean.py
+++ b/pkg/inngest/inngest/digital_ocean.py
@@ -25,9 +25,9 @@ def serve(
     client: client_lib.Inngest,
     functions: list[function.Function[typing.Any]],
     *,
-    public_path: typing.Optional[str] = None,
-    serve_origin: typing.Optional[str] = None,
-    serve_path: typing.Optional[str] = None,
+    public_path: str | None = None,
+    serve_origin: str | None = None,
+    serve_path: str | None = None,
 ) -> typing.Callable[[dict[str, object], _Context], _Response]:
     """
     Serve Inngest functions in a DigitalOcean Function.
@@ -166,14 +166,14 @@ def serve(
 
 
 def _get_first(
-    items: typing.Optional[list[types.T]],
-) -> typing.Optional[types.T]:
+    items: list[types.T] | None,
+) -> types.T | None:
     if items is None or len(items) == 0:
         return None
     return items[0]
 
 
-def _to_body_bytes(body: typing.Optional[str]) -> bytes:
+def _to_body_bytes(body: str | None) -> bytes:
     if body is None:
         return b""
     return body.encode("utf-8")
@@ -190,11 +190,11 @@ def _to_response(
 
 
 class _EventHTTP(types.BaseModel):
-    body: typing.Optional[str] = None
-    headers: typing.Optional[dict[str, str]] = None
-    method: typing.Optional[str] = None
-    path: typing.Optional[str] = None
-    queryString: typing.Optional[str] = None  # noqa: N815
+    body: str | None = None
+    headers: dict[str, str] | None = None
+    method: str | None = None
+    path: str | None = None
+    queryString: str | None = None  # noqa: N815
 
 
 class _Context(typing.Protocol):

--- a/pkg/inngest/inngest/django.py
+++ b/pkg/inngest/inngest/django.py
@@ -28,9 +28,9 @@ def serve(
     client: client_lib.Inngest,
     functions: list[function.Function[typing.Any]],
     *,
-    public_path: typing.Optional[str] = None,
-    serve_origin: typing.Optional[str] = None,
-    serve_path: typing.Optional[str] = None,
+    public_path: str | None = None,
+    serve_origin: str | None = None,
+    serve_path: str | None = None,
 ) -> django.urls.URLPattern:
     """
     Serve Inngest functions in a Django app.
@@ -78,9 +78,9 @@ def _create_handler_sync(
     client: client_lib.Inngest,
     handler: comm_lib.CommHandler,
     *,
-    public_path: typing.Optional[str],
-    serve_origin: typing.Optional[str],
-    serve_path: typing.Optional[str],
+    public_path: str | None,
+    serve_origin: str | None,
+    serve_path: str | None,
 ) -> django.urls.URLPattern:
     def inngest_api(
         request: django.http.HttpRequest,
@@ -131,9 +131,9 @@ def _create_handler_async(
     client: client_lib.Inngest,
     handler: comm_lib.CommHandler,
     *,
-    public_path: typing.Optional[str],
-    serve_origin: typing.Optional[str],
-    serve_path: typing.Optional[str],
+    public_path: str | None,
+    serve_origin: str | None,
+    serve_path: str | None,
 ) -> django.urls.URLPattern:
     major_version = transforms.get_major_version(django.get_version())
     if isinstance(major_version, Exception):

--- a/pkg/inngest/inngest/experimental/dev_server/command_runner.py
+++ b/pkg/inngest/inngest/experimental/dev_server/command_runner.py
@@ -15,16 +15,16 @@ class _CommandRunner:
         self,
         command: str,
         *,
-        log_path: typing.Optional[pathlib.Path] = None,
+        log_path: pathlib.Path | None = None,
     ):
         self._command = command
         self._log_path = log_path
-        self._process: typing.Optional[subprocess.Popen[str]] = None
+        self._process: subprocess.Popen[str] | None = None
         self._stdout_queue: queue.Queue[str] = queue.Queue()
         self._stderr_queue: queue.Queue[str] = queue.Queue()
         self._stop_printing_flag = False
-        self._stdout_thread: typing.Optional[threading.Thread] = None
-        self._stderr_thread: typing.Optional[threading.Thread] = None
+        self._stdout_thread: threading.Thread | None = None
+        self._stderr_thread: threading.Thread | None = None
         self._running = False
 
     def run(self) -> None:

--- a/pkg/inngest/inngest/experimental/dev_server/dev_server.py
+++ b/pkg/inngest/inngest/experimental/dev_server/dev_server.py
@@ -5,7 +5,6 @@ import pathlib
 import subprocess
 import threading
 import time
-import typing
 
 import httpx
 
@@ -26,7 +25,7 @@ class _Server:
             port = 8288
         self.port = port
 
-        log_path: typing.Optional[pathlib.Path] = None
+        log_path: pathlib.Path | None = None
         if os.getenv("DEV_SERVER_LOGS") == "1":
             artifacts_dir = pathlib.Path("artifacts").absolute()
             print(f"Using artifacts directory: {artifacts_dir}")
@@ -42,9 +41,9 @@ class _Server:
         )
 
         self._enabled = os.getenv("DEV_SERVER_ENABLED") != "0"
-        self._output_thread: typing.Optional[threading.Thread] = None
+        self._output_thread: threading.Thread | None = None
 
-        self._process: typing.Optional[subprocess.Popen[str]] = None
+        self._process: subprocess.Popen[str] | None = None
         self._ready_event = threading.Event()
         self._stop_event = threading.Event()
 

--- a/pkg/inngest/inngest/experimental/mocked/client.py
+++ b/pkg/inngest/inngest/experimental/mocked/client.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import typing
-
 import inngest
 from inngest._internal import server_lib
 
@@ -13,7 +11,7 @@ class Inngest(inngest.Inngest):
 
     async def send(
         self,
-        events: typing.Union[server_lib.Event, list[server_lib.Event]],
+        events: server_lib.Event | list[server_lib.Event],
         *,
         skip_middleware: bool = False,
     ) -> list[str]:
@@ -28,7 +26,7 @@ class Inngest(inngest.Inngest):
 
     def send_sync(
         self,
-        events: typing.Union[server_lib.Event, list[server_lib.Event]],
+        events: server_lib.Event | list[server_lib.Event],
         *,
         skip_middleware: bool = False,
     ) -> list[str]:

--- a/pkg/inngest/inngest/experimental/mocked/trigger.py
+++ b/pkg/inngest/inngest/experimental/mocked/trigger.py
@@ -21,10 +21,10 @@ from .errors import UnstubbedStepError
 
 def trigger(
     fn: inngest.Function[typing.Any],
-    event: typing.Union[inngest.Event, list[inngest.Event]],
+    event: inngest.Event | list[inngest.Event],
     client: Inngest,
     *,
-    step_stubs: typing.Optional[dict[str, object]] = None,
+    step_stubs: dict[str, object] | None = None,
 ) -> _Result:
     """
     Trigger a function.
@@ -55,7 +55,7 @@ def trigger(
         max_attempt = fn._opts.retries
 
     while True:
-        step_id: typing.Optional[str] = None
+        step_id: str | None = None
         if len(planned) > 0:
             step_id = planned.pop()
 
@@ -202,6 +202,6 @@ def trigger(
 
 @dataclasses.dataclass
 class _Result:
-    error: typing.Optional[Exception]
+    error: Exception | None
     output: object
     status: Status

--- a/pkg/inngest/inngest/experimental/remote_state_middleware/middleware.py
+++ b/pkg/inngest/inngest/experimental/remote_state_middleware/middleware.py
@@ -46,7 +46,7 @@ class RemoteStateMiddleware(inngest.MiddlewareSync):
     output is stored within your infrastructure rather than Inngest's.
     """
 
-    _run_id: typing.Optional[str] = None
+    _run_id: str | None = None
 
     def __init__(
         self,

--- a/pkg/inngest/inngest/fast_api.py
+++ b/pkg/inngest/inngest/fast_api.py
@@ -23,9 +23,9 @@ def serve(
     client: client_lib.Inngest,
     functions: list[function.Function[typing.Any]],
     *,
-    public_path: typing.Optional[str] = None,
-    serve_origin: typing.Optional[str] = None,
-    serve_path: typing.Optional[str] = None,
+    public_path: str | None = None,
+    serve_origin: str | None = None,
+    serve_path: str | None = None,
     streaming: const.Streaming | None = None,
 ) -> None:
     """

--- a/pkg/inngest/inngest/flask.py
+++ b/pkg/inngest/inngest/flask.py
@@ -22,9 +22,9 @@ def serve(
     client: client_lib.Inngest,
     functions: list[function.Function[typing.Any]],
     *,
-    public_path: typing.Optional[str] = None,
-    serve_origin: typing.Optional[str] = None,
-    serve_path: typing.Optional[str] = None,
+    public_path: str | None = None,
+    serve_origin: str | None = None,
+    serve_path: str | None = None,
 ) -> None:
     """
     Serve Inngest functions in a Flask app.
@@ -75,15 +75,15 @@ def _create_handler_async(
     client: client_lib.Inngest,
     handler: comm_lib.CommHandler,
     *,
-    public_path: typing.Optional[str],
-    serve_origin: typing.Optional[str],
-    serve_path: typing.Optional[str],
+    public_path: str | None,
+    serve_origin: str | None,
+    serve_path: str | None,
 ) -> None:
     @app.route(
         config_lib.get_serve_path(serve_path) or const.DEFAULT_SERVE_PATH,
         methods=["GET", "POST", "PUT"],
     )
-    async def inngest_api() -> typing.Union[flask.Response, str]:
+    async def inngest_api() -> flask.Response | str:
         comm_req = comm_lib.CommRequest(
             body=_get_body_bytes(),
             headers=dict(flask.request.headers.items()),
@@ -122,15 +122,15 @@ def _create_handler_sync(
     client: client_lib.Inngest,
     handler: comm_lib.CommHandler,
     *,
-    public_path: typing.Optional[str],
-    serve_origin: typing.Optional[str],
-    serve_path: typing.Optional[str],
+    public_path: str | None,
+    serve_origin: str | None,
+    serve_path: str | None,
 ) -> None:
     @app.route(
         config_lib.get_serve_path(serve_path) or const.DEFAULT_SERVE_PATH,
         methods=["GET", "POST", "PUT"],
     )
-    def inngest_api() -> typing.Union[flask.Response, str]:
+    def inngest_api() -> flask.Response | str:
         comm_req = comm_lib.CommRequest(
             body=_get_body_bytes(),
             headers=dict(flask.request.headers.items()),

--- a/pkg/inngest/inngest/tornado.py
+++ b/pkg/inngest/inngest/tornado.py
@@ -23,9 +23,9 @@ def serve(
     client: client_lib.Inngest,
     functions: list[function.Function[typing.Any]],
     *,
-    public_path: typing.Optional[str] = None,
-    serve_origin: typing.Optional[str] = None,
-    serve_path: typing.Optional[str] = None,
+    public_path: str | None = None,
+    serve_origin: str | None = None,
+    serve_path: str | None = None,
 ) -> None:
     """
     Serve Inngest functions in a Tornado app.
@@ -48,9 +48,7 @@ def serve(
     )
 
     class InngestHandler(tornado.web.RequestHandler):
-        def data_received(
-            self, chunk: bytes
-        ) -> typing.Optional[typing.Awaitable[None]]:
+        def data_received(self, chunk: bytes) -> typing.Awaitable[None] | None:
             return None
 
         def get(self) -> None:

--- a/pkg/inngest_encryption/inngest_encryption/main.py
+++ b/pkg/inngest_encryption/inngest_encryption/main.py
@@ -27,7 +27,7 @@ _strategy_identifier: typing.Final = "inngest/libsodium"
 _default_event_encryption_field: typing.Final = "encrypted"
 
 
-def _ensure_key_bytes(secret_key: typing.Union[bytes, str]) -> bytes:
+def _ensure_key_bytes(secret_key: bytes | str) -> bytes:
     if isinstance(secret_key, str):
         return nacl.hash.generichash(
             secret_key.encode("utf-8"),
@@ -47,13 +47,11 @@ class EncryptionMiddleware(inngest.MiddlewareSync):
         self,
         client: inngest.Inngest,
         raw_request: object,
-        secret_key: typing.Union[bytes, str],
+        secret_key: bytes | str,
         *,
         decrypt_only: bool = False,
         event_encryption_field: str = _default_event_encryption_field,
-        fallback_decryption_keys: typing.Optional[
-            list[typing.Union[bytes, str]]
-        ] = None,
+        fallback_decryption_keys: list[bytes | str] | None = None,
     ) -> None:
         """
         Args:
@@ -87,13 +85,11 @@ class EncryptionMiddleware(inngest.MiddlewareSync):
     @classmethod
     def factory(
         cls,
-        secret_key: typing.Union[bytes, str],
+        secret_key: bytes | str,
         *,
         decrypt_only: bool = False,
         event_encryption_field: str = _default_event_encryption_field,
-        fallback_decryption_keys: typing.Optional[
-            list[typing.Union[bytes, str]]
-        ] = None,
+        fallback_decryption_keys: list[bytes | str] | None = None,
     ) -> typing.Callable[[inngest.Inngest, object], EncryptionMiddleware]:
         """
         Create an encryption middleware factory that can be passed to an Inngest
@@ -122,7 +118,7 @@ class EncryptionMiddleware(inngest.MiddlewareSync):
 
         return _factory
 
-    def _encrypt(self, data: object) -> dict[str, typing.Union[bool, str]]:
+    def _encrypt(self, data: object) -> dict[str, bool | str]:
         if isinstance(data, dict) and data.get(_encryption_marker) is True:
             # Already encrypted
             self.client.logger.warning(

--- a/pkg/test_core/test_core/base.py
+++ b/pkg/test_core/test_core/base.py
@@ -15,7 +15,7 @@ from . import http_proxy, net
 
 
 class BaseState:
-    run_id: typing.Optional[str] = None
+    run_id: str | None = None
 
     async def wait_for_run_id(
         self,
@@ -31,9 +31,8 @@ class BaseState:
 
 
 async def wait_for(
-    assertion: typing.Union[
-        typing.Callable[[], None], typing.Callable[[], typing.Awaitable[None]]
-    ],
+    assertion: typing.Callable[[], None]
+    | typing.Callable[[], typing.Awaitable[None]],
     *,
     timeout: datetime.timedelta = datetime.timedelta(seconds=5),
 ) -> None:
@@ -83,7 +82,7 @@ class _FrameworkTestCase(typing.Protocol):
     def on_proxy_request(
         self,
         *,
-        body: typing.Optional[bytes],
+        body: bytes | None,
         headers: dict[str, list[str]],
         method: str,
         path: str,
@@ -105,7 +104,7 @@ def create_test_name(file: str) -> str:
 
 def register(
     app_port: int,
-    path: typing.Optional[str] = "/api/inngest",
+    path: str | None = "/api/inngest",
 ) -> None:
     start = time.time()
     while time.time() < start + 5:

--- a/pkg/test_core/test_core/gql.py
+++ b/pkg/test_core/test_core/gql.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import typing
-
 import httpx
 import pydantic
 
@@ -10,7 +8,7 @@ class Client:
     def __init__(self, endpoint: str):
         self._endpoint = endpoint
 
-    async def query(self, query: Query) -> typing.Union[Response, Error]:
+    async def query(self, query: Query) -> Response | Error:
         async with httpx.AsyncClient() as client:
             http_res = await client.post(
                 self._endpoint,
@@ -41,7 +39,7 @@ class Query:
     def __init__(
         self,
         query: str,
-        variables: typing.Optional[dict[str, object]] = None,
+        variables: dict[str, object] | None = None,
     ):
         self._query = query
         self._variables = variables
@@ -55,9 +53,9 @@ class Query:
 
 class Response(pydantic.BaseModel):
     data: dict[str, object]
-    errors: typing.Optional[list[dict[str, object]]] = None
+    errors: list[dict[str, object]] | None = None
 
 
 class Error(pydantic.BaseModel):
-    response: typing.Optional[Response] = None
+    response: Response | None = None
     message: str

--- a/pkg/test_core/test_core/helper.py
+++ b/pkg/test_core/test_core/helper.py
@@ -4,7 +4,6 @@ import asyncio
 import enum
 import json
 import time
-import typing
 
 import inngest
 import pydantic
@@ -179,7 +178,7 @@ class _Client:
         """
 
         start = time.time()
-        actual_status: typing.Optional[str] = None
+        actual_status: str | None = None
         while True:
             res = await self._gql.query(gql.Query(query, {"run_id": run_id}))
             if isinstance(res, gql.Response):
@@ -222,7 +221,7 @@ class _Client:
 class _Run(types.BaseModel):
     event: inngest.Event
     id: str
-    output: typing.Optional[str]
+    output: str | None
     status: RunStatus
 
 

--- a/pkg/test_core/test_core/http_proxy.py
+++ b/pkg/test_core/test_core/http_proxy.py
@@ -15,7 +15,7 @@ from . import net
 
 class Proxy:
     _port: int
-    _thread: typing.Optional[threading.Thread] = None
+    _thread: threading.Thread | None = None
 
     @property
     def host(self) -> str:
@@ -143,7 +143,7 @@ class Proxy:
 
 @dataclasses.dataclass
 class Response:
-    body: typing.Optional[bytes]
+    body: bytes | None
     headers: dict[str, str]
     status_code: int
 
@@ -152,7 +152,7 @@ class OnRequest(typing.Protocol):
     def __call__(
         self,
         *,
-        body: typing.Optional[bytes],
+        body: bytes | None,
         headers: dict[str, list[str]],
         method: str,
         path: str,
@@ -162,7 +162,7 @@ class OnRequest(typing.Protocol):
 def on_proxy_fast_api_request(
     client: fastapi.testclient.TestClient,
     *,
-    body: typing.Optional[bytes],
+    body: bytes | None,
     headers: dict[str, list[str]],
     method: str,
     path: str,
@@ -197,7 +197,7 @@ def on_proxy_fast_api_request(
 def on_proxy_flask_request(
     client: flask.testing.FlaskClient,
     *,
-    body: typing.Optional[bytes],
+    body: bytes | None,
     headers: dict[str, list[str]],
     method: str,
     path: str,

--- a/pkg/test_core/test_core/ws_proxy.py
+++ b/pkg/test_core/test_core/ws_proxy.py
@@ -1,5 +1,4 @@
 import asyncio
-import typing
 import uuid
 
 import websockets
@@ -19,7 +18,7 @@ class WebSocketProxy:
         self._conns: dict[str, tuple[_Connection, _Connection]] = {}
         self._port = get_available_port()
         self._server_uri = server_uri
-        self._server: typing.Optional[websockets.Server] = None
+        self._server: websockets.Server | None = None
         self._tasks = set[asyncio.Task[None]]()
         self.forwarded_messages: list[bytes] = []
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,9 +2,11 @@ exclude = [
     ".venv",
     "pkg/inngest/inngest/connect/_internal/connect_pb2.py",
     "pkg/inngest/inngest/connect/_internal/connect_pb2.pyi",
+    "smoke_tests",
 ]
 
 line-length = 80
+target-version = "py310"
 
 [lint.extend-per-file-ignores]
 "**/*_test.py" = ['C901', 'D', 'N', 'S', 'T20']
@@ -40,9 +42,7 @@ extend-ignore = [
     'D415',
     'RUF022',
     'S112',
-
-    # Delete when we use "|" for unions.
-    'UP007',
+    'UP038',  # isinstance with tuple (has performance implications)
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/tests/test_inngest/test_client/test_client_middleware.py
+++ b/tests/test_inngest/test_client/test_client_middleware.py
@@ -81,7 +81,7 @@ class TestClientMiddleware(unittest.IsolatedAsyncioTestCase):
 
         def on_request(
             *,
-            body: typing.Optional[bytes],
+            body: bytes | None,
             headers: dict[str, list[str]],
             method: str,
             path: str,
@@ -173,7 +173,7 @@ class TestClientMiddleware(unittest.IsolatedAsyncioTestCase):
 
         def on_request(
             *,
-            body: typing.Optional[bytes],
+            body: bytes | None,
             headers: dict[str, list[str]],
             method: str,
             path: str,

--- a/tests/test_inngest/test_client/test_send.py
+++ b/tests/test_inngest/test_client/test_send.py
@@ -32,7 +32,7 @@ class TestSend(unittest.IsolatedAsyncioTestCase):
 
         def on_request(
             *,
-            body: typing.Optional[bytes],
+            body: bytes | None,
             headers: dict[str, list[str]],
             method: str,
             path: str,
@@ -221,7 +221,7 @@ class TestSend(unittest.IsolatedAsyncioTestCase):
 
                 # Create a proxy that returns a 400
                 def on_request(
-                    body: typing.Optional[bytes],
+                    body: bytes | None,
                     headers: dict[str, list[str]],
                     method: str,
                     path: str,
@@ -272,7 +272,7 @@ def create_first_request_500_handler() -> tuple[
     proxy_request_count = 0
 
     def on_request(
-        body: typing.Optional[bytes],
+        body: bytes | None,
         headers: dict[str, list[str]],
         method: str,
         path: str,
@@ -317,7 +317,7 @@ def create_first_request_timeout_handler() -> tuple[
     proxy_request_count = 0
 
     def on_request(
-        body: typing.Optional[bytes],
+        body: bytes | None,
         headers: dict[str, list[str]],
         method: str,
         path: str,

--- a/tests/test_inngest/test_connect/base.py
+++ b/tests/test_inngest/test_connect/base.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import dataclasses
-import typing
 import unittest
 
 import httpx
@@ -27,7 +26,7 @@ class _Proxies:
 
 @dataclasses.dataclass
 class _Request:
-    body: typing.Optional[bytes]
+    body: bytes | None
     headers: dict[str, list[str]]
     method: str
     path: str
@@ -46,7 +45,7 @@ class BaseTest(unittest.IsolatedAsyncioTestCase):
 
         def http_proxy_handler(
             *,
-            body: typing.Optional[bytes],
+            body: bytes | None,
             headers: dict[str, list[str]],
             method: str,
             path: str,

--- a/tests/test_inngest/test_connect/test_close.py
+++ b/tests/test_inngest/test_connect/test_close.py
@@ -1,6 +1,5 @@
 import asyncio
 import json
-import typing
 
 import inngest
 import test_core
@@ -80,7 +79,7 @@ class TestWaitForExecutionRequest(BaseTest):
 
         def on_request(
             *,
-            body: typing.Optional[bytes],
+            body: bytes | None,
             headers: dict[str, list[str]],
             method: str,
             path: str,

--- a/tests/test_inngest/test_connect/test_init_handshake.py
+++ b/tests/test_inngest/test_connect/test_init_handshake.py
@@ -1,7 +1,6 @@
 import asyncio
 import dataclasses
 import os
-import typing
 
 import httpx
 import inngest
@@ -27,7 +26,7 @@ class TestAPIRequestHeaders(BaseTest):
 
         def mock_api_handler(
             *,
-            body: typing.Optional[bytes],
+            body: bytes | None,
             headers: dict[str, list[str]],
             method: str,
             path: str,
@@ -76,14 +75,14 @@ class TestAPIRequestHeaders(BaseTest):
 
         @dataclasses.dataclass
         class State:
-            attempt_1_auth_header: typing.Optional[str] = None
-            attempt_2_auth_header: typing.Optional[str] = None
+            attempt_1_auth_header: str | None = None
+            attempt_2_auth_header: str | None = None
 
         state = State()
 
         def mock_api_handler(
             *,
-            body: typing.Optional[bytes],
+            body: bytes | None,
             headers: dict[str, list[str]],
             method: str,
             path: str,
@@ -172,7 +171,7 @@ class TestAPIRequestHeaders(BaseTest):
 
         def mock_api_handler(
             *,
-            body: typing.Optional[bytes],
+            body: bytes | None,
             headers: dict[str, list[str]],
             method: str,
             path: str,
@@ -223,7 +222,7 @@ class TestAPIRequestHeaders(BaseTest):
 
         def mock_api_handler(
             *,
-            body: typing.Optional[bytes],
+            body: bytes | None,
             headers: dict[str, list[str]],
             method: str,
             path: str,

--- a/tests/test_inngest/test_connect/test_signals.py
+++ b/tests/test_inngest/test_connect/test_signals.py
@@ -4,7 +4,6 @@ import multiprocessing.connection
 import signal
 import subprocess
 import time
-import typing
 
 import httpx
 import inngest
@@ -142,7 +141,7 @@ def _start_app(
     app_id: str,
     event_name: str,
     listener_port: int,
-    signals: typing.Optional[list[signal.Signals]] = None,
+    signals: list[signal.Signals] | None = None,
 ) -> subprocess.Popen[bytes]:
     signals_str = "None"
     if signals is not None:

--- a/tests/test_inngest/test_experimental/test_remote_state_middleware/cases/base.py
+++ b/tests/test_inngest/test_experimental/test_remote_state_middleware/cases/base.py
@@ -20,9 +20,7 @@ class TestClass(typing.Protocol):
 
 @dataclasses.dataclass
 class Case:
-    fn: typing.Union[
-        inngest.Function[typing.Any], list[inngest.Function[typing.Any]]
-    ]
+    fn: inngest.Function[typing.Any] | list[inngest.Function[typing.Any]]
     name: str
     run_test: typing.Callable[[TestClass], typing.Awaitable[None]]
 
@@ -51,7 +49,7 @@ class Encryptor:
             secret_key, encoder=nacl.encoding.HexEncoder
         )
 
-    def encrypt(self, data: object) -> dict[str, typing.Union[bool, str]]:
+    def encrypt(self, data: object) -> dict[str, bool | str]:
         """
         Encrypt data the way middleware would.
         """

--- a/tests/test_inngest/test_experimental/test_remote_state_middleware/test_flask.py
+++ b/tests/test_inngest/test_experimental/test_remote_state_middleware/test_flask.py
@@ -60,7 +60,7 @@ class TestRemoteStateMiddleware(unittest.IsolatedAsyncioTestCase):
     def on_proxy_request(
         cls,
         *,
-        body: typing.Optional[bytes],
+        body: bytes | None,
         headers: dict[str, list[str]],
         method: str,
         path: str,

--- a/tests/test_inngest/test_function/cases/base.py
+++ b/tests/test_inngest/test_function/cases/base.py
@@ -25,9 +25,7 @@ class TestClass(typing.Protocol):
 
 @dataclasses.dataclass
 class Case:
-    fn: typing.Union[
-        inngest.Function[typing.Any], list[inngest.Function[typing.Any]]
-    ]
+    fn: inngest.Function[typing.Any] | list[inngest.Function[typing.Any]]
     name: str
     run_test: typing.Callable[[TestClass], typing.Awaitable[None]]
 

--- a/tests/test_inngest/test_function/cases/batch_that_needs_api.py
+++ b/tests/test_inngest/test_function/cases/batch_that_needs_api.py
@@ -8,7 +8,6 @@ API when use_api is true.
 """
 
 import datetime
-import typing
 
 import inngest
 import test_core.helper
@@ -18,7 +17,7 @@ from . import base
 
 
 class _State(base.BaseState):
-    events: typing.Optional[list[inngest.Event]] = None
+    events: list[inngest.Event] | None = None
 
 
 def create(

--- a/tests/test_inngest/test_function/cases/event_payload.py
+++ b/tests/test_inngest/test_function/cases/event_payload.py
@@ -1,5 +1,3 @@
-import typing
-
 import inngest
 import test_core.helper
 from inngest._internal import server_lib
@@ -8,7 +6,7 @@ from . import base
 
 
 class _State(base.BaseState):
-    event: typing.Optional[inngest.Event] = None
+    event: inngest.Event | None = None
 
 
 def create(

--- a/tests/test_inngest/test_function/cases/function_args.py
+++ b/tests/test_inngest/test_function/cases/function_args.py
@@ -1,5 +1,3 @@
-import typing
-
 import inngest
 import test_core.helper
 from inngest._internal import server_lib
@@ -8,10 +6,10 @@ from . import base
 
 
 class _State(base.BaseState):
-    attempt: typing.Optional[int] = None
-    event: typing.Optional[inngest.Event] = None
-    events: typing.Optional[list[inngest.Event]] = None
-    step: typing.Union[inngest.Step, inngest.StepSync, None] = None
+    attempt: int | None = None
+    event: inngest.Event | None = None
+    events: list[inngest.Event] | None = None
+    step: inngest.Step | inngest.StepSync | None = None
 
 
 def create(

--- a/tests/test_inngest/test_function/cases/invoke_failure.py
+++ b/tests/test_inngest/test_function/cases/invoke_failure.py
@@ -3,7 +3,6 @@ When an invoked function fails, `step.invoke` raises a NonRetriableError.
 """
 
 import json
-import typing
 
 import inngest
 import test_core.helper
@@ -13,7 +12,7 @@ from . import base
 
 
 class _State(base.BaseState):
-    raised_error: typing.Optional[inngest.StepError] = None
+    raised_error: inngest.StepError | None = None
 
 
 class MyException(Exception):

--- a/tests/test_inngest/test_function/cases/invoke_timeout.py
+++ b/tests/test_inngest/test_function/cases/invoke_timeout.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import typing
 
 import inngest
 import test_core.helper
@@ -10,7 +9,7 @@ from . import base
 
 
 class _State(base.BaseState):
-    raised_err: typing.Optional[Exception] = None
+    raised_err: Exception | None = None
 
 
 def create(

--- a/tests/test_inngest/test_function/cases/middleware_order.py
+++ b/tests/test_inngest/test_function/cases/middleware_order.py
@@ -155,7 +155,7 @@ class _MwSyncBase(inngest.MiddlewareSync):
 
     def transform_input(
         self,
-        ctx: typing.Union[inngest.Context, inngest.ContextSync],
+        ctx: inngest.Context | inngest.ContextSync,
         function: inngest.Function[typing.Any],
         steps: inngest.StepMemos,
     ) -> None:
@@ -192,7 +192,7 @@ class _MwAsyncBase(inngest.Middleware):
 
     async def transform_input(
         self,
-        ctx: typing.Union[inngest.Context, inngest.ContextSync],
+        ctx: inngest.Context | inngest.ContextSync,
         function: inngest.Function[typing.Any],
         steps: inngest.StepMemos,
     ) -> None:

--- a/tests/test_inngest/test_function/cases/on_failure.py
+++ b/tests/test_inngest/test_function/cases/on_failure.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import typing
 import unittest.mock
 
 import inngest
@@ -11,11 +10,11 @@ from . import base
 
 
 class _State(base.BaseState):
-    attempt: typing.Optional[int] = None
-    event: typing.Optional[inngest.Event] = None
-    events: typing.Optional[list[inngest.Event]] = None
-    on_failure_run_id: typing.Optional[str] = None
-    step: typing.Union[inngest.Step, inngest.StepSync, None] = None
+    attempt: int | None = None
+    event: inngest.Event | None = None
+    events: list[inngest.Event] | None = None
+    on_failure_run_id: str | None = None
+    step: inngest.Step | inngest.StepSync | None = None
 
     async def wait_for_on_failure_run_id(self) -> str:
         def assertion() -> None:

--- a/tests/test_inngest/test_function/cases/retry_after_error.py
+++ b/tests/test_inngest/test_function/cases/retry_after_error.py
@@ -1,5 +1,4 @@
 import datetime
-import typing
 
 import inngest
 import test_core.helper
@@ -9,12 +8,12 @@ from . import base
 
 
 class _State(base.BaseState):
-    fn_level_raise_1_time: typing.Optional[datetime.datetime] = None
-    fn_level_retry_1_time: typing.Optional[datetime.datetime] = None
-    fn_level_raise_2_time: typing.Optional[datetime.datetime] = None
-    fn_level_retry_2_time: typing.Optional[datetime.datetime] = None
-    step_level_raise_time: typing.Optional[datetime.datetime] = None
-    step_level_retry_time: typing.Optional[datetime.datetime] = None
+    fn_level_raise_1_time: datetime.datetime | None = None
+    fn_level_retry_1_time: datetime.datetime | None = None
+    fn_level_raise_2_time: datetime.datetime | None = None
+    fn_level_retry_2_time: datetime.datetime | None = None
+    step_level_raise_time: datetime.datetime | None = None
+    step_level_retry_time: datetime.datetime | None = None
 
 
 def create(

--- a/tests/test_inngest/test_function/cases/sleep.py
+++ b/tests/test_inngest/test_function/cases/sleep.py
@@ -1,5 +1,4 @@
 import datetime
-import typing
 
 import inngest
 import test_core.helper
@@ -9,8 +8,8 @@ from . import base
 
 
 class _State(base.BaseState):
-    after_sleep: typing.Optional[datetime.datetime] = None
-    before_sleep: typing.Optional[datetime.datetime] = None
+    after_sleep: datetime.datetime | None = None
+    before_sleep: datetime.datetime | None = None
 
     def is_done(self) -> bool:
         return self.after_sleep is not None and self.before_sleep is not None

--- a/tests/test_inngest/test_function/cases/sleep_until.py
+++ b/tests/test_inngest/test_function/cases/sleep_until.py
@@ -1,5 +1,4 @@
 import datetime
-import typing
 
 import inngest
 import test_core.helper
@@ -9,8 +8,8 @@ from . import base
 
 
 class _State(base.BaseState):
-    after_sleep: typing.Optional[datetime.datetime] = None
-    before_sleep: typing.Optional[datetime.datetime] = None
+    after_sleep: datetime.datetime | None = None
+    before_sleep: datetime.datetime | None = None
 
     def is_done(self) -> bool:
         return self.after_sleep is not None and self.before_sleep is not None

--- a/tests/test_inngest/test_function/cases/unserializable_step_output.py
+++ b/tests/test_inngest/test_function/cases/unserializable_step_output.py
@@ -1,5 +1,4 @@
 import json
-import typing
 
 import inngest
 import test_core.helper
@@ -9,7 +8,7 @@ from . import base
 
 
 class _State(base.BaseState):
-    error: typing.Optional[BaseException] = None
+    error: BaseException | None = None
 
 
 def create(

--- a/tests/test_inngest/test_function/cases/wait_for_event_fulfill.py
+++ b/tests/test_inngest/test_function/cases/wait_for_event_fulfill.py
@@ -1,6 +1,5 @@
 import asyncio
 import datetime
-import typing
 
 import inngest
 import test_core.helper
@@ -10,7 +9,7 @@ from . import base
 
 
 class _State(base.BaseState):
-    result: typing.Optional[inngest.Event] = None
+    result: inngest.Event | None = None
 
 
 def create(

--- a/tests/test_inngest/test_function/cases/wait_for_event_timeout_if_exp_not_match.py
+++ b/tests/test_inngest/test_function/cases/wait_for_event_timeout_if_exp_not_match.py
@@ -4,7 +4,6 @@ Wait for event times out if its expression isn't matched
 
 import asyncio
 import datetime
-import typing
 
 import inngest
 import test_core.helper
@@ -14,7 +13,7 @@ from . import base
 
 
 class _State(base.BaseState):
-    result: typing.Union[inngest.Event, None, str] = "not_set"
+    result: inngest.Event | None | str = "not_set"
 
 
 def create(

--- a/tests/test_inngest/test_function/cases/wait_for_event_timeout_name_not_match.py
+++ b/tests/test_inngest/test_function/cases/wait_for_event_timeout_name_not_match.py
@@ -3,7 +3,6 @@ Wait for event times out if the specified event name isn't received
 """
 
 import datetime
-import typing
 
 import inngest
 import test_core.helper
@@ -13,7 +12,7 @@ from . import base
 
 
 class _State(base.BaseState):
-    result: typing.Union[inngest.Event, None, str] = "not_set"
+    result: inngest.Event | None | str = "not_set"
 
 
 def create(

--- a/tests/test_inngest/test_function/test_digital_ocean.py
+++ b/tests/test_inngest/test_function/test_digital_ocean.py
@@ -67,7 +67,7 @@ class TestFunctions(unittest.IsolatedAsyncioTestCase):
     def on_proxy_request(
         cls,
         *,
-        body: typing.Optional[bytes],
+        body: bytes | None,
         headers: dict[str, list[str]],
         method: str,
         path: str,

--- a/tests/test_inngest/test_function/test_django.py
+++ b/tests/test_inngest/test_function/test_django.py
@@ -80,7 +80,7 @@ class TestFunctions(unittest.IsolatedAsyncioTestCase):
     def on_proxy_request(
         cls,
         *,
-        body: typing.Optional[bytes],
+        body: bytes | None,
         headers: dict[str, list[str]],
         method: str,
         path: str,

--- a/tests/test_inngest/test_introspection/test_fast_api.py
+++ b/tests/test_inngest/test_introspection/test_fast_api.py
@@ -1,4 +1,3 @@
-import typing
 import unittest
 
 import fastapi
@@ -16,7 +15,7 @@ class TestIntrospection(base.BaseTestIntrospection):
         self,
         client: inngest.Inngest,
         *,
-        serve_path: typing.Optional[str] = None,
+        serve_path: str | None = None,
     ) -> fastapi.testclient.TestClient:
         app = fastapi.FastAPI()
         inngest.fast_api.serve(

--- a/tests/test_inngest/test_introspection/test_flask.py
+++ b/tests/test_inngest/test_introspection/test_flask.py
@@ -1,4 +1,3 @@
-import typing
 import unittest
 
 import flask
@@ -16,7 +15,7 @@ class TestIntrospection(base.BaseTestIntrospection):
         self,
         client: inngest.Inngest,
         *,
-        serve_path: typing.Optional[str] = None,
+        serve_path: str | None = None,
     ) -> flask.testing.FlaskClient:
         app = flask.Flask(__name__)
         inngest.flask.serve(

--- a/tests/test_inngest/test_registration/base.py
+++ b/tests/test_inngest/test_registration/base.py
@@ -19,8 +19,8 @@ class TestCase(unittest.TestCase):
     def put(
         self,
         *,
-        body: typing.Union[dict[str, object], bytes],
-        headers: typing.Optional[dict[str, str]] = None,
+        body: dict[str, object] | bytes,
+        headers: dict[str, str] | None = None,
     ) -> RegistrationResponse:
         raise NotImplementedError()
 

--- a/tests/test_inngest/test_registration/cases/disallow_in_band.py
+++ b/tests/test_inngest/test_registration/cases/disallow_in_band.py
@@ -1,7 +1,6 @@
 import dataclasses
 import json
 import os
-import typing
 
 import inngest
 from inngest._internal import const, net, server_lib
@@ -27,7 +26,7 @@ def create(framework: server_lib.Framework) -> base.Case:
 
         @dataclasses.dataclass
         class State:
-            body: typing.Optional[bytes]
+            body: bytes | None
             headers: dict[str, list[str]]
 
         state = State(
@@ -37,7 +36,7 @@ def create(framework: server_lib.Framework) -> base.Case:
 
         def on_request(
             *,
-            body: typing.Optional[bytes],
+            body: bytes | None,
             headers: dict[str, list[str]],
             method: str,
             path: str,

--- a/tests/test_inngest/test_registration/cases/missing_sync_kind_header.py
+++ b/tests/test_inngest/test_registration/cases/missing_sync_kind_header.py
@@ -1,6 +1,5 @@
 import dataclasses
 import json
-import typing
 
 import inngest
 from inngest._internal import const, server_lib
@@ -19,7 +18,7 @@ def create(framework: server_lib.Framework) -> base.Case:
 
         @dataclasses.dataclass
         class State:
-            body: typing.Optional[bytes]
+            body: bytes | None
             headers: dict[str, list[str]]
 
         state = State(
@@ -29,7 +28,7 @@ def create(framework: server_lib.Framework) -> base.Case:
 
         def on_request(
             *,
-            body: typing.Optional[bytes],
+            body: bytes | None,
             headers: dict[str, list[str]],
             method: str,
             path: str,

--- a/tests/test_inngest/test_registration/test_fast_api.py
+++ b/tests/test_inngest/test_registration/test_fast_api.py
@@ -22,8 +22,8 @@ class TestRegistration(base.TestCase):
     def put(
         self,
         *,
-        body: typing.Union[dict[str, object], bytes],
-        headers: typing.Optional[dict[str, str]] = None,
+        body: dict[str, object] | bytes,
+        headers: dict[str, str] | None = None,
     ) -> base.RegistrationResponse:
         if isinstance(body, bytes):
             body = json.loads(body)

--- a/tests/test_inngest/test_registration/test_flask.py
+++ b/tests/test_inngest/test_registration/test_flask.py
@@ -20,8 +20,8 @@ class TestRegistration(base.TestCase):
     def put(
         self,
         *,
-        body: typing.Union[dict[str, object], bytes],
-        headers: typing.Optional[dict[str, str]] = None,
+        body: dict[str, object] | bytes,
+        headers: dict[str, str] | None = None,
     ) -> base.RegistrationResponse:
         if headers is None:
             headers = {}

--- a/tests/test_inngest/test_serialization/test_flask.py
+++ b/tests/test_inngest/test_serialization/test_flask.py
@@ -28,7 +28,7 @@ class _TestBase(unittest.IsolatedAsyncioTestCase):
 
         def on_proxy_request(
             *,
-            body: typing.Optional[bytes],
+            body: bytes | None,
             headers: dict[str, list[str]],
             method: str,
             path: str,

--- a/tests/test_inngest/test_serve/test_streaming.py
+++ b/tests/test_inngest/test_serve/test_streaming.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import threading
-import typing
 import unittest
 
 import fastapi
@@ -31,7 +30,7 @@ class TestStreaming(unittest.IsolatedAsyncioTestCase):
         res_chunks = list[bytes]()
 
         def on_request(
-            body: typing.Optional[bytes],
+            body: bytes | None,
             headers: dict[str, list[str]],
             method: str,
             path: str,
@@ -139,7 +138,7 @@ class TestStreaming(unittest.IsolatedAsyncioTestCase):
         res_chunks = list[bytes]()
 
         def on_request(
-            body: typing.Optional[bytes],
+            body: bytes | None,
             headers: dict[str, list[str]],
             method: str,
             path: str,

--- a/tests/test_inngest_encryption/cases/base.py
+++ b/tests/test_inngest_encryption/cases/base.py
@@ -20,9 +20,7 @@ class TestClass(typing.Protocol):
 
 @dataclasses.dataclass
 class Case:
-    fn: typing.Union[
-        inngest.Function[typing.Any], list[inngest.Function[typing.Any]]
-    ]
+    fn: inngest.Function[typing.Any] | list[inngest.Function[typing.Any]]
     name: str
     run_test: typing.Callable[[TestClass], typing.Awaitable[None]]
 
@@ -51,7 +49,7 @@ class Encryptor:
             secret_key, encoder=nacl.encoding.HexEncoder
         )
 
-    def encrypt(self, data: object) -> dict[str, typing.Union[bool, str]]:
+    def encrypt(self, data: object) -> dict[str, bool | str]:
         """
         Encrypt data the way middleware would.
         """

--- a/tests/test_inngest_encryption/cases/invoke.py
+++ b/tests/test_inngest_encryption/cases/invoke.py
@@ -26,8 +26,8 @@ enc = base.Encryptor(
 
 
 class _State(base.BaseState):
-    child_run_id: typing.Optional[str] = None
-    child_event: typing.Optional[inngest.Event] = None
+    child_run_id: str | None = None
+    child_event: inngest.Event | None = None
 
     async def wait_for_child_run_id(self) -> str:
         def assertion() -> None:

--- a/tests/test_inngest_encryption/cases/invoke_custom_encryption_field.py
+++ b/tests/test_inngest_encryption/cases/invoke_custom_encryption_field.py
@@ -26,8 +26,8 @@ enc = base.Encryptor(
 
 
 class _State(base.BaseState):
-    child_run_id: typing.Optional[str] = None
-    child_event: typing.Optional[inngest.Event] = None
+    child_run_id: str | None = None
+    child_event: inngest.Event | None = None
 
     async def wait_for_child_run_id(self) -> str:
         def assertion() -> None:

--- a/tests/test_inngest_encryption/cases/send_event.py
+++ b/tests/test_inngest_encryption/cases/send_event.py
@@ -26,8 +26,8 @@ enc = base.Encryptor(
 
 
 class _State(base.BaseState):
-    child_run_id: typing.Optional[str] = None
-    child_event: typing.Optional[inngest.Event] = None
+    child_run_id: str | None = None
+    child_event: inngest.Event | None = None
 
     async def wait_for_child_run_id(self) -> str:
         def assertion() -> None:

--- a/tests/test_inngest_encryption/cases/send_event_custom_encryption_field.py
+++ b/tests/test_inngest_encryption/cases/send_event_custom_encryption_field.py
@@ -26,8 +26,8 @@ enc = base.Encryptor(
 
 
 class _State(base.BaseState):
-    child_run_id: typing.Optional[str] = None
-    child_event: typing.Optional[inngest.Event] = None
+    child_run_id: str | None = None
+    child_event: inngest.Event | None = None
 
     async def wait_for_child_run_id(self) -> str:
         def assertion() -> None:

--- a/tests/test_inngest_encryption/test_flask.py
+++ b/tests/test_inngest_encryption/test_flask.py
@@ -60,7 +60,7 @@ class TestEncryptionMiddleware(unittest.IsolatedAsyncioTestCase):
     def on_proxy_request(
         cls,
         *,
-        body: typing.Optional[bytes],
+        body: bytes | None,
         headers: dict[str, list[str]],
         method: str,
         path: str,


### PR DESCRIPTION
Replace all `typing.Optional` and `typing.Union` usage with the pipe operator (`|`). This is purely for static checking and will not change runtime logic