### PR TITLE
fix: invalid connect handshake w/concurrency config

### DIFF
--- a/pkg/inngest/inngest/connect/_internal/init_handshake_handler.py
+++ b/pkg/inngest/inngest/connect/_internal/init_handshake_handler.py
@@ -171,7 +171,9 @@ def _create_sync_message(
     apps: list[connect_pb2.AppConfiguration] = []
     for app_id, functions in apps_configs.items():
         try:
-            functions_bytes = pydantic_core.to_json(functions)
+            functions_bytes = pydantic_core.to_json(
+                functions, exclude_none=True
+            )
         except Exception as err:
             return err
 


### PR DESCRIPTION
Fix a bug in which null values were included for optional fields when serializing a function configuration