### PR TITLE
Remove `"authentication_succeeded": false` in introspection response

### DIFF
--- a/pkg/inngest/inngest/_internal/comm_lib/handler.py
+++ b/pkg/inngest/inngest/_internal/comm_lib/handler.py
@@ -531,12 +531,7 @@ def _build_inspection_response(
             signing_key_hash=signing_key_hash,
         )
 
-    authentication_succeeded: typing.Literal[False | None] = None
-    if isinstance(request_signing_key, Exception):
-        authentication_succeeded = False
-
     return server_lib.UnauthenticatedInspection(
-        authentication_succeeded=authentication_succeeded,
         function_count=len(handler._fns),
         has_event_key=handler._client.event_key is not None,
         has_signing_key=handler._signing_key is not None,

--- a/pkg/inngest/inngest/_internal/server_lib/inspection.py
+++ b/pkg/inngest/inngest/_internal/server_lib/inspection.py
@@ -14,7 +14,6 @@ class Capabilities(types.BaseModel):
 class UnauthenticatedInspection(types.BaseModel):
     schema_version: str = "2024-05-24"
 
-    authentication_succeeded: typing.Literal[False] | None
     function_count: int
     has_event_key: bool
     has_signing_key: bool

--- a/pkg/test_core/test_core/base.py
+++ b/pkg/test_core/test_core/base.py
@@ -157,7 +157,6 @@ class BaseTestIntrospection(BaseTest):
 
     def setUp(self) -> None:
         self.expected_unauthed_body = {
-            "authentication_succeeded": None,
             "function_count": 1,
             "has_event_key": True,
             "has_signing_key": True,

--- a/tests/test_inngest/test_introspection/test_digital_ocean.py
+++ b/tests/test_inngest/test_introspection/test_digital_ocean.py
@@ -32,10 +32,7 @@ class TestIntrospection(base.BaseTestIntrospection):
         )
         res = app_client.get(digital_ocean_simulator.FULL_PATH)
         assert res.status_code == 200
-        assert res.json == {
-            **self.expected_unauthed_body,
-            "authentication_succeeded": False,
-        }
+        assert res.json == self.expected_unauthed_body
         assert res.headers.get(server_lib.HeaderKey.SIGNATURE.value) is None
 
     def test_cloud_mode_with_signature(self) -> None:

--- a/tests/test_inngest/test_introspection/test_fast_api.py
+++ b/tests/test_inngest/test_introspection/test_fast_api.py
@@ -36,10 +36,7 @@ class TestIntrospection(base.BaseTestIntrospection):
         )
         res = fast_api_client.get("/api/inngest")
         assert res.status_code == 200
-        assert res.json() == {
-            **self.expected_unauthed_body,
-            "authentication_succeeded": False,
-        }
+        assert res.json() == self.expected_unauthed_body
         assert res.headers.get(server_lib.HeaderKey.SIGNATURE.value) is None
 
     def test_cloud_mode_with_signature(self) -> None:

--- a/tests/test_inngest/test_introspection/test_flask.py
+++ b/tests/test_inngest/test_introspection/test_flask.py
@@ -36,10 +36,7 @@ class TestIntrospection(base.BaseTestIntrospection):
         )
         res = flask_client.get("/api/inngest")
         assert res.status_code == 200
-        assert res.json == {
-            **self.expected_unauthed_body,
-            "authentication_succeeded": False,
-        }
+        assert res.json == self.expected_unauthed_body
         assert res.headers.get(server_lib.HeaderKey.SIGNATURE.value) is None
 
     def test_cloud_mode_with_signature(self) -> None:


### PR DESCRIPTION
Responding with `"authentication_succeeded": false` doesn't necessarily mean there's a problem, but many users inferred that it did.

The SDK responds with `"authentication_succeeded": false` when responding to an unsigned GET request. It just means that auth wasn't performed, but users thought it mean auth failed