### PR TITLE
Add optional jitter field to TriggerCron

### DIFF
--- a/pkg/inngest/inngest/_internal/server_lib/registration.py
+++ b/pkg/inngest/inngest/_internal/server_lib/registration.py
@@ -206,6 +206,7 @@ class Singleton(_BaseConfig):
 
 class TriggerCron(_BaseConfig):
     cron: str
+    jitter: str | None = None
 
 
 class TriggerEvent(_BaseConfig):

--- a/pkg/inngest/inngest/_internal/server_lib/registration_test.py
+++ b/pkg/inngest/inngest/_internal/server_lib/registration_test.py
@@ -149,10 +149,26 @@ def test_serialization() -> None:
             "mode": "skip",
         },
         "triggers": [
-            {"cron": "foo"},
+            {"cron": "foo", "jitter": None},
             {
                 "event": "foo",
                 "expression": "foo",
             },
         ],
     }
+
+
+def test_cron_trigger_with_jitter() -> None:
+    trigger = TriggerCron(cron="*/5 * * * *", jitter="30s")
+    data = trigger.to_dict()
+    if isinstance(data, Exception):
+        raise data
+    assert data == {"cron": "*/5 * * * *", "jitter": "30s"}
+
+
+def test_cron_trigger_without_jitter() -> None:
+    trigger = TriggerCron(cron="*/5 * * * *")
+    data = trigger.to_dict()
+    if isinstance(data, Exception):
+        raise data
+    assert data == {"cron": "*/5 * * * *", "jitter": None}


### PR DESCRIPTION
Allows cron triggers to specify a jitter duration that delays execution by a random amount after the cron boundary.

Tested by registering a cron function with TriggerCron(cron="* * * * *", jitter="30s") against a local dev server. Verified the cron event payload contains both scheduledAt and fireAt with fireAt offset from scheduledAt by the jitter amount. Also ran unit tests confirming serialization with and without jitter. 