### PR TITLE
Add unauthenticated sync opt-out

### DIFF
--- a/pkg/inngest/docs/AUTH.md
+++ b/pkg/inngest/docs/AUTH.md
@@ -23,7 +23,7 @@ When the Inngest server sends an execution request, the SDK validates the reques
 
 GET and POST require a valid signature at the `wrap_handler` level (`require_signature=True`) in cloud mode, returning 401 for unsigned or invalid requests. In dev mode, signature validation is skipped for every HTTP method.
 
-PUT app sync requests use `require_signature=False` by default. This preserves compatibility with unauthenticated out-of-band sync requests.
+PUT app sync requests also use `require_signature=False` by default. This preserves compatibility with unauthenticated out-of-band sync requests. Users can opt out by setting `INNGEST_ENABLE_UNAUTHED_SYNC=false` or passing `enable_unauthed_sync=False` to `serve()`, which makes cloud-mode PUT sync reject unsigned or invalidly signed requests with 401. Dev mode ignores this opt-out because the Dev Server does not send signed requests.
 
 Cloud in-band sync still requires a signed PUT, since the response carries a signed body that the server validates. Dev mode falls back to out-of-band sync because the Dev Server does not sign requests.
 

--- a/pkg/inngest/docs/SYNC.md
+++ b/pkg/inngest/docs/SYNC.md
@@ -18,7 +18,7 @@ The SDK responds directly to the PUT request with all function configs and app m
 2. SDK verifies the request signature (required for in-band sync).
 3. SDK responds with an `InBandSynchronizeResponse`.
 
-In-band sync is always allowed when the request includes the in-band sync header.
+In-band sync is always allowed when the SDK is in cloud mode and the request includes the in-band sync header.
 
 ## Out-of-Band Sync
 
@@ -30,6 +30,8 @@ The SDK makes a separate HTTP POST to the Inngest API's `/fn/register` endpoint.
 2. SDK builds a `SynchronizeRequest` with app metadata and function configs.
 3. SDK POSTs this to `{api_origin}/fn/register`, authenticated with the signing key hash as a Bearer token (see [AUTH.md](AUTH.md)).
 4. SDK forwards the API's response back to the original PUT caller.
+
+Unsigned out-of-band sync PUTs are allowed by default. Users can disable them in cloud mode with `INNGEST_ENABLE_UNAUTHED_SYNC=false` or `serve(enable_unauthed_sync=False)`. Dev mode ignores this opt-out because the Dev Server does not send signed requests.
 
 ## Function Configs
 

--- a/pkg/inngest/inngest/_internal/comm_lib/handler.py
+++ b/pkg/inngest/inngest/_internal/comm_lib/handler.py
@@ -42,6 +42,7 @@ class CommHandler:
         self,
         *,
         client: client_lib.Inngest,
+        enable_unauthed_sync: bool | None,
         framework: server_lib.Framework,
         functions: list[function.Function[typing.Any]],
         streaming: const.Streaming | None,
@@ -52,6 +53,16 @@ class CommHandler:
         self._api_origin = client.api_origin
         self._fns = {fn.get_id(): fn for fn in functions}
         self._framework = framework
+
+        if self._mode == server_lib.ServerKind.DEV_SERVER:
+            self._enable_unauthed_sync = True
+        elif enable_unauthed_sync is None:
+            # TODO(v0.6): Make unauthenticated out-of-band sync PUTs opt-in.
+            self._enable_unauthed_sync = not env_lib.is_false(
+                const.EnvKey.ENABLE_UNAUTHED_SYNC,
+            )
+        else:
+            self._enable_unauthed_sync = enable_unauthed_sync
 
         if streaming is None:
             streaming = env_lib.get_streaming(const.EnvKey.STREAMING)
@@ -435,6 +446,25 @@ class CommHandler:
             == server_lib.SyncKind.IN_BAND.value
         )
 
+    def _get_out_of_band_sync_auth_error(
+        self,
+        request_signing_key: types.MaybeError[str | None],
+    ) -> Exception | None:
+        """
+        Return an auth error when out-of-band sync requires a valid signature.
+        """
+
+        if self._enable_unauthed_sync:
+            return None
+        if isinstance(request_signing_key, str):
+            return None
+        if isinstance(request_signing_key, Exception):
+            return request_signing_key
+
+        return errors.HeaderMissingError(
+            "request must be signed when unauthenticated sync is disabled"
+        )
+
     @wrap_handler(require_signature=False)
     async def put(
         self: CommHandler,
@@ -464,7 +494,17 @@ class CommHandler:
             return syncer.in_band(self, req, request_signing_key)
 
         # Out-of-band sync registers via a separate authenticated SDK-to-API
-        # request, so the incoming PUT may be unsigned.
+        # request, so the incoming PUT may be unsigned unless disabled by
+        # config.
+        out_of_band_auth_error = self._get_out_of_band_sync_auth_error(
+            request_signing_key,
+        )
+        if out_of_band_auth_error is not None:
+            return CommResponse.unauthorized(
+                self._client.logger,
+                out_of_band_auth_error,
+            )
+
         return await syncer.out_of_band(self, req)
 
     @wrap_handler_sync(require_signature=False)
@@ -497,7 +537,17 @@ class CommHandler:
             return syncer.in_band(self, req, request_signing_key)
 
         # Out-of-band sync registers via a separate authenticated SDK-to-API
-        # request, so the incoming PUT may be unsigned.
+        # request, so the incoming PUT may be unsigned unless disabled by
+        # config.
+        out_of_band_auth_error = self._get_out_of_band_sync_auth_error(
+            request_signing_key,
+        )
+        if out_of_band_auth_error is not None:
+            return CommResponse.unauthorized(
+                self._client.logger,
+                out_of_band_auth_error,
+            )
+
         return syncer.out_of_band_sync(self, req)
 
 

--- a/pkg/inngest/inngest/_internal/comm_lib/handler_test.py
+++ b/pkg/inngest/inngest/_internal/comm_lib/handler_test.py
@@ -118,6 +118,7 @@ class TestCommHandlerRequestIDs(unittest.TestCase):
 
         comm_handler = comm_lib.CommHandler(
             client=client,
+            enable_unauthed_sync=None,
             framework=server_lib.Framework.FAST_API,
             functions=[fn],
             streaming=None,
@@ -162,6 +163,7 @@ class TestCommHandlerRequestIDs(unittest.TestCase):
 
         comm_handler = comm_lib.CommHandler(
             client=client,
+            enable_unauthed_sync=None,
             framework=server_lib.Framework.FAST_API,
             functions=[fn],
             streaming=None,

--- a/pkg/inngest/inngest/_internal/const.py
+++ b/pkg/inngest/inngest/_internal/const.py
@@ -23,6 +23,7 @@ class EnvKey(enum.Enum):
 
     EVENT_API_BASE_URL = "INNGEST_EVENT_API_BASE_URL"
     EVENT_KEY = "INNGEST_EVENT_KEY"
+    ENABLE_UNAUTHED_SYNC = "INNGEST_ENABLE_UNAUTHED_SYNC"
     ENV = "INNGEST_ENV"
 
     # The ThreadPoolExecutor max_workers arg. If set to 0, the thread pool will

--- a/pkg/inngest/inngest/connect/_internal/connection.py
+++ b/pkg/inngest/inngest/connect/_internal/connection.py
@@ -166,6 +166,7 @@ class WorkerConnectionImpl(WorkerConnection):
 
             self._comm_handlers[client.app_id] = comm_lib.CommHandler(
                 client=client,
+                enable_unauthed_sync=None,
                 framework=FRAMEWORK,
                 functions=fns,
                 streaming=const.Streaming.DISABLE,  # Probably doesn't make sense for Connect.

--- a/pkg/inngest/inngest/digital_ocean.py
+++ b/pkg/inngest/inngest/digital_ocean.py
@@ -25,6 +25,7 @@ def serve(
     client: client_lib.Inngest,
     functions: list[function.Function[typing.Any]],
     *,
+    enable_unauthed_sync: bool | None = None,
     public_path: str | None = None,
     serve_origin: str | None = None,
     serve_path: str | None = None,
@@ -36,6 +37,7 @@ def serve(
     ----
         client: Inngest client.
         functions: List of functions to serve.
+        enable_unauthed_sync: Controls whether unsigned app sync PUT requests are allowed in cloud mode. Defaults to the INNGEST_ENABLE_UNAUTHED_SYNC env var, or True when unset.
         public_path: Path that the Inngest server sends requests to. This is only necessary if the SDK is behind a proxy that rewrites the path.
         serve_origin: Origin for serving Inngest functions. This is typically only useful during Docker-based development.
         serve_path: Path for serving Inngest functions. This is only useful if you don't want serve Inngest at the /api/inngest path.
@@ -43,6 +45,7 @@ def serve(
 
     handler = comm_lib.CommHandler(
         client=client,
+        enable_unauthed_sync=enable_unauthed_sync,
         framework=FRAMEWORK,
         functions=functions,
         streaming=const.Streaming.DISABLE,  # Not supported yet.

--- a/pkg/inngest/inngest/django.py
+++ b/pkg/inngest/inngest/django.py
@@ -28,6 +28,7 @@ def serve(
     client: client_lib.Inngest,
     functions: list[function.Function[typing.Any]],
     *,
+    enable_unauthed_sync: bool | None = None,
     public_path: str | None = None,
     serve_origin: str | None = None,
     serve_path: str | None = None,
@@ -39,6 +40,7 @@ def serve(
     ----
         client: Inngest client.
         functions: List of functions to serve.
+        enable_unauthed_sync: Controls whether unsigned app sync PUT requests are allowed in cloud mode. Defaults to the INNGEST_ENABLE_UNAUTHED_SYNC env var, or True when unset.
         public_path: Path that the Inngest server sends requests to. This is only necessary if the SDK is behind a proxy that rewrites the path.
         serve_origin: Origin for serving Inngest functions. This is typically only useful during Docker-based development.
         serve_path: Path for serving Inngest functions. This is only useful if you don't want serve Inngest at the /api/inngest path.
@@ -46,6 +48,7 @@ def serve(
 
     handler = comm_lib.CommHandler(
         client=client,
+        enable_unauthed_sync=enable_unauthed_sync,
         framework=FRAMEWORK,
         functions=functions,
         streaming=const.Streaming.DISABLE,  # Not supported yet.

--- a/pkg/inngest/inngest/fast_api.py
+++ b/pkg/inngest/inngest/fast_api.py
@@ -23,6 +23,7 @@ def serve(
     client: client_lib.Inngest,
     functions: list[function.Function[typing.Any]],
     *,
+    enable_unauthed_sync: bool | None = None,
     public_path: str | None = None,
     serve_origin: str | None = None,
     serve_path: str | None = None,
@@ -36,6 +37,7 @@ def serve(
         app: FastAPI app.
         client: Inngest client.
         functions: List of functions to serve.
+        enable_unauthed_sync: Controls whether unsigned app sync PUT requests are allowed in cloud mode. Defaults to the INNGEST_ENABLE_UNAUTHED_SYNC env var, or True when unset.
         public_path: Path that the Inngest server sends requests to. This is only necessary if the SDK is behind a proxy that rewrites the path.
         serve_origin: Origin for serving Inngest functions. This is typically only useful during Docker-based development.
         serve_path: Path for serving Inngest functions. This is only useful if you don't want serve Inngest at the /api/inngest path.
@@ -44,6 +46,7 @@ def serve(
 
     handler = comm_lib.CommHandler(
         client=client,
+        enable_unauthed_sync=enable_unauthed_sync,
         framework=FRAMEWORK,
         functions=functions,
         streaming=streaming,

--- a/pkg/inngest/inngest/flask.py
+++ b/pkg/inngest/inngest/flask.py
@@ -22,6 +22,7 @@ def serve(
     client: client_lib.Inngest,
     functions: list[function.Function[typing.Any]],
     *,
+    enable_unauthed_sync: bool | None = None,
     public_path: str | None = None,
     serve_origin: str | None = None,
     serve_path: str | None = None,
@@ -34,6 +35,7 @@ def serve(
         app: Flask app.
         client: Inngest client.
         functions: List of functions to serve.
+        enable_unauthed_sync: Controls whether unsigned app sync PUT requests are allowed in cloud mode. Defaults to the INNGEST_ENABLE_UNAUTHED_SYNC env var, or True when unset.
         public_path: Path that the Inngest server sends requests to. This is only necessary if the SDK is behind a proxy that rewrites the path.
         serve_origin: Origin for serving Inngest functions. This is typically only useful during Docker-based development.
         serve_path: Path for serving Inngest functions. This is only useful if you don't want serve Inngest at the /api/inngest path.
@@ -41,6 +43,7 @@ def serve(
 
     handler = comm_lib.CommHandler(
         client=client,
+        enable_unauthed_sync=enable_unauthed_sync,
         framework=FRAMEWORK,
         functions=functions,
         streaming=const.Streaming.DISABLE,  # Not supported yet.

--- a/pkg/inngest/inngest/tornado.py
+++ b/pkg/inngest/inngest/tornado.py
@@ -23,6 +23,7 @@ def serve(
     client: client_lib.Inngest,
     functions: list[function.Function[typing.Any]],
     *,
+    enable_unauthed_sync: bool | None = None,
     public_path: str | None = None,
     serve_origin: str | None = None,
     serve_path: str | None = None,
@@ -35,6 +36,7 @@ def serve(
         app: Tornado app.
         client: Inngest client.
         functions: List of functions to serve.
+        enable_unauthed_sync: Controls whether unsigned app sync PUT requests are allowed in cloud mode. Defaults to the INNGEST_ENABLE_UNAUTHED_SYNC env var, or True when unset.
         public_path: Path that the Inngest server sends requests to. This is only necessary if the SDK is behind a proxy that rewrites the path.
         serve_origin: Origin for serving Inngest functions. This is typically only useful during Docker-based development.
         serve_path: Path for serving Inngest functions. This is only useful if you don't want serve Inngest at the /api/inngest path.
@@ -42,6 +44,7 @@ def serve(
 
     handler = comm_lib.CommHandler(
         client=client,
+        enable_unauthed_sync=enable_unauthed_sync,
         framework=FRAMEWORK,
         functions=functions,
         streaming=const.Streaming.DISABLE,  # Not supported yet.

--- a/tests/test_inngest/test_auth/base.py
+++ b/tests/test_inngest/test_auth/base.py
@@ -55,6 +55,8 @@ class TestCase(unittest.TestCase):
         self,
         client: inngest.Inngest,
         fns: list[inngest.Function[typing.Any]],
+        *,
+        enable_unauthed_sync: bool | None = None,
     ) -> None:
         raise NotImplementedError()
 

--- a/tests/test_inngest/test_auth/cases/base.py
+++ b/tests/test_inngest/test_auth/cases/base.py
@@ -41,6 +41,7 @@ def serve_app(
     test_case: TestCase,
     framework: server_lib.Framework,
     *,
+    enable_unauthed_sync: bool | None = None,
     is_production: bool,
     mock_cloud: MockCloud | None = None,
     name: str,
@@ -65,6 +66,7 @@ def serve_app(
     test_case.serve(
         client,
         [fn],
+        enable_unauthed_sync=enable_unauthed_sync,
     )
 
     return ServedApp(fn_id=fn.id)

--- a/tests/test_inngest/test_auth/cases/cloud_invalid_auth.py
+++ b/tests/test_inngest/test_auth/cases/cloud_invalid_auth.py
@@ -25,6 +25,10 @@ def create_cases(framework: server_lib.Framework) -> list[base.Case]:
             name=f"{_TEST_NAME}_put_with_in_band",
             run_test=_put_in_band(framework),
         ),
+        base.Case(
+            name=f"{_TEST_NAME}_put_with_out_of_band_with_disable_option",
+            run_test=_put_out_of_band_disable_option(framework),
+        ),
     ]
 
 
@@ -102,6 +106,28 @@ def _put_in_band(
         )
 
         res = base.run_in_band_put(self, signing_key=base.WRONG_SIGNING_KEY)
+
+        base.assert_unauthorized_response(res)
+
+    return run_test
+
+
+def _put_out_of_band_disable_option(
+    framework: server_lib.Framework,
+) -> typing.Callable[[base.TestCase], None]:
+    def run_test(self: base.TestCase) -> None:
+        base.serve_app(
+            self,
+            framework,
+            enable_unauthed_sync=False,
+            is_production=True,
+            name=f"{_TEST_NAME}-put-out-of-band-disable-option",
+        )
+
+        res = base.run_out_of_band_put(
+            self,
+            signing_key=base.WRONG_SIGNING_KEY,
+        )
 
         base.assert_unauthorized_response(res)
 

--- a/tests/test_inngest/test_auth/cases/cloud_missing_auth.py
+++ b/tests/test_inngest/test_auth/cases/cloud_missing_auth.py
@@ -25,6 +25,10 @@ def create_cases(framework: server_lib.Framework) -> list[base.Case]:
             name=f"{_TEST_NAME}_put_with_out_of_band",
             run_test=_put_out_of_band(framework),
         ),
+        base.Case(
+            name=f"{_TEST_NAME}_put_with_out_of_band_with_disable_option",
+            run_test=_put_out_of_band_disable_option(framework),
+        ),
     ]
 
 
@@ -98,5 +102,24 @@ def _put_out_of_band(
         res = base.run_out_of_band_put(self)
 
         base.assert_out_of_band_sync_succeeded(res, mock_cloud)
+
+    return run_test
+
+
+def _put_out_of_band_disable_option(
+    framework: server_lib.Framework,
+) -> typing.Callable[[base.TestCase], None]:
+    def run_test(self: base.TestCase) -> None:
+        base.serve_app(
+            self,
+            framework,
+            enable_unauthed_sync=False,
+            is_production=True,
+            name=f"{_TEST_NAME}-put-out-of-band-disable-option",
+        )
+
+        res = base.run_out_of_band_put(self)
+
+        base.assert_unauthorized_response(res)
 
     return run_test

--- a/tests/test_inngest/test_auth/cases/dev_missing_auth.py
+++ b/tests/test_inngest/test_auth/cases/dev_missing_auth.py
@@ -32,6 +32,7 @@ def _get(
         base.serve_app(
             self,
             framework,
+            enable_unauthed_sync=False,
             is_production=False,
             name=f"{_TEST_NAME}-get",
         )
@@ -51,6 +52,7 @@ def _post(
         app = base.serve_app(
             self,
             framework,
+            enable_unauthed_sync=False,
             is_production=False,
             name=f"{_TEST_NAME}-post",
         )
@@ -71,6 +73,7 @@ def _put(
         base.serve_app(
             self,
             framework,
+            enable_unauthed_sync=False,
             is_production=False,
             mock_cloud=mock_cloud,
             name=f"{_TEST_NAME}-put",

--- a/tests/test_inngest/test_auth/test_fast_api.py
+++ b/tests/test_inngest/test_auth/test_fast_api.py
@@ -105,11 +105,14 @@ class TestAuth(base.TestCase):
         self,
         client: inngest.Inngest,
         fns: list[inngest.Function[typing.Any]],
+        *,
+        enable_unauthed_sync: bool | None = None,
     ) -> None:
         inngest.fast_api.serve(
             self.app,
             client,
             fns,
+            enable_unauthed_sync=enable_unauthed_sync,
         )
 
 

--- a/tests/test_inngest/test_auth/test_flask.py
+++ b/tests/test_inngest/test_auth/test_flask.py
@@ -100,11 +100,14 @@ class TestAuth(base.TestCase):
         self,
         client: inngest.Inngest,
         fns: list[inngest.Function[typing.Any]],
+        *,
+        enable_unauthed_sync: bool | None = None,
     ) -> None:
         inngest.flask.serve(
             self.app,
             client,
             fns,
+            enable_unauthed_sync=enable_unauthed_sync,
         )
 
 


### PR DESCRIPTION
# Changes

Added `INNGEST_ENABLE_UNAUTHED_SYNC` env var and `enable_unauthed_sync` serve option to let users disable unauthenticated out-of-band sync PUTs.

# Motivation

Unauthenticated app sync remains allowed by default for compatibility, but users can now opt-out.

# Context

Despite their name, unauthenticated app syncs are not insecure. The SDK does not send app configuration back to the unauthenticated caller; it sends an outgoing authenticated request to Inngest Cloud.

That said, requiring auth on the incoming sync request adds defense in depth. In-band syncs already require auth because they return app configuration directly in the response.