### PR TITLE
feat: add throttle scope config support

### DIFF
--- a/pkg/inngest/inngest/_internal/server_lib/registration.py
+++ b/pkg/inngest/inngest/_internal/server_lib/registration.py
@@ -156,6 +156,7 @@ class Throttle(_BaseConfig):
     limit: int
     period: int | datetime.timedelta
     burst: int | None = 1
+    scope: typing.Literal["account", "env", "fn"] | None = None
 
     @pydantic.field_serializer("period")
     def serialize_period(
@@ -168,6 +169,16 @@ class Throttle(_BaseConfig):
         if isinstance(out, Exception):
             raise out
         return out
+
+    @pydantic.model_serializer(mode="wrap")
+    def serialize_model(
+        self,
+        handler: pydantic.SerializerFunctionWrapHandler,
+    ) -> dict[str, object]:
+        data = typing.cast(dict[str, object], handler(self))
+        if self.scope is None:
+            data.pop("scope", None)
+        return data
 
 
 class Timeouts(_BaseConfig):

--- a/pkg/inngest/inngest/_internal/server_lib/registration_test.py
+++ b/pkg/inngest/inngest/_internal/server_lib/registration_test.py
@@ -69,6 +69,7 @@ def test_serialization() -> None:
             key="foo",
             limit=1,
             period=datetime.timedelta(seconds=60),
+            scope="account",
         ),
         timeouts=Timeouts(
             start=datetime.timedelta(minutes=5),
@@ -139,6 +140,7 @@ def test_serialization() -> None:
             "limit": 1,
             "burst": 1,
             "period": "1m",
+            "scope": "account",
         },
         "timeouts": {
             "start": "5m",
@@ -155,6 +157,23 @@ def test_serialization() -> None:
                 "expression": "foo",
             },
         ],
+    }
+
+
+def test_throttle_serialization_omits_scope_when_unset() -> None:
+    data = Throttle(
+        key="foo",
+        limit=1,
+        period=datetime.timedelta(seconds=60),
+    ).to_dict()
+    if isinstance(data, Exception):
+        raise data
+
+    assert data == {
+        "key": "foo",
+        "limit": 1,
+        "burst": 1,
+        "period": "1m",
     }
 
 


### PR DESCRIPTION
Summary
- Adds Python SDK support for configuring shared throttle scopes when registering functions.

Changes
- Adds optional `scope` support to `inngest.Throttle` with `fn`, `env`, and `account` values.
- Omits `scope` from serialized throttle payloads when unset to preserve existing function-scoped behavior.
- Adds registration serialization coverage for scoped throttles and existing unscoped throttles.

Tests
- `uv run pytest pkg/inngest/inngest/_internal/server_lib/registration_test.py -q`
- `cd pkg/inngest && make lint && make type-check && make utest`

Related Issues
- Server/runtime PR: https://github.com/inngest/inngest/pull/4407
- TypeScript SDK PR: https://github.com/inngest/inngest-js/pull/1576
- Go SDK PR: https://github.com/inngest/inngestgo/pull/237
- Feature request: https://github.com/inngest/inngest/issues/3701
