### PR TITLE
Bump to v0.5.19

### DIFF
--- a/pkg/inngest/pyproject.toml
+++ b/pkg/inngest/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "inngest"
-version = "0.5.19a348"
+version = "0.5.19"
 authors = [{ name = "Inngest Inc.", email = "hello@inngest.com" }]
 description = "Python SDK for Inngest"
 readme = "README.md"

--- a/tests/test_inngest/test_connect/test_long_function_run.py
+++ b/tests/test_inngest/test_connect/test_long_function_run.py
@@ -40,4 +40,5 @@ class TestLongFunctionRun(BaseTest):
         await test_core.helper.client.wait_for_run_status(
             await state.wait_for_run_id(),
             test_core.helper.RunStatus.COMPLETED,
+            timeout=30,
         )

--- a/uv.lock
+++ b/uv.lock
@@ -568,7 +568,7 @@ wheels = [
 
 [[package]]
 name = "inngest"
-version = "0.5.19a348"
+version = "0.5.19"
 source = { editable = "pkg/inngest" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Breaking changes
- Remove INNGEST_ALLOW_IN_BAND_SYNC env var.
- Minimize details in response after auth failure.

# Features
- Add unauthenticated sync opt-out.
- Add request and job IDs to function ctx.
- Add optional jitter field to TriggerCron.

# Fixes
- Fix PydanticSerializer memory leak.
- Fix reconnect during graceful shutdown (Connect).