### PR TITLE
fix(connect): reset init_handshake_complete in close_ws

### DIFF
--- a/pkg/inngest/inngest/connect/_internal/close_ws_regression_test.py
+++ b/pkg/inngest/inngest/connect/_internal/close_ws_regression_test.py
@@ -1,0 +1,35 @@
+"""Regression tests for inngest-py#380: close_ws() must reset
+init_handshake_complete so a reconnecting heartbeat can't race the new
+connection's init handshake (gateway closes with
+connect_worker_hello_invalid_msg)."""
+
+from inngest.connect._internal.models import ConnectionState, State
+from inngest.connect._internal.value_watcher import ValueWatcher
+
+
+def _make_state(conn_state: ConnectionState) -> State:
+    return State(
+        conn_id=ValueWatcher(None),
+        conn_init=ValueWatcher(None),
+        conn_state=ValueWatcher(conn_state),
+        exclude_gateways=ValueWatcher([]),
+        extend_lease_interval=ValueWatcher(None),
+        fatal_error=ValueWatcher(None),
+        init_handshake_complete=ValueWatcher(True),
+        pending_request_count=ValueWatcher(0),
+        ws=ValueWatcher(None),
+    )
+
+
+def test_close_ws_resets_init_handshake_complete_on_reconnect() -> None:
+    state = _make_state(ConnectionState.ACTIVE)
+    assert state.init_handshake_complete.value is True
+    state.close_ws()
+    assert state.conn_state.value is ConnectionState.RECONNECTING
+    assert state.init_handshake_complete.value is False
+
+
+def test_close_ws_resets_init_handshake_complete_on_close() -> None:
+    state = _make_state(ConnectionState.CLOSED)
+    state.close_ws()
+    assert state.init_handshake_complete.value is False

--- a/pkg/inngest/inngest/connect/_internal/models.py
+++ b/pkg/inngest/inngest/connect/_internal/models.py
@@ -53,6 +53,12 @@ class State:
         self.conn_init.value = None
         self.ws.value = None
 
+        # The handshake is tied to the socket's lifetime: once the socket is
+        # gone, "handshake complete" is stale. Reset it so heartbeat sends wait
+        # for the new connection's handshake instead of racing it (which the
+        # gateway rejects with connect_worker_hello_invalid_msg).
+        self.init_handshake_complete.value = False
+
 
 class ConnectionState(enum.Enum):
     """


### PR DESCRIPTION
Fixes #380

## Problem

On reconnect, the heartbeat can race the new connection's init handshake: `close_ws()` tears down the socket but never resets `init_handshake_complete`, so the heartbeat handler keeps treating the connection as fully established while the gateway expects a fresh worker hello. Heartbeats sent in that window get the socket closed with 1008 `connect_worker_hello_invalid_msg`.

## Fix

One-line state reset in `close_ws()`: `init_handshake_complete` goes back to `False`, so heartbeats wait for the new connection's handshake instead of racing it. The handshake is tied to the socket's lifetime; once the socket is gone the flag is stale.

## Verification

- New regression tests cover the close->reconnect and close->closed paths (both fail without the fix - verified red).
- Existing connect suite green: `pytest pkg/inngest/inngest/connect/` - 36 passed.

> Built by breken, your AI support engineer - breken.ai - this one's on us.
